### PR TITLE
docs: add email migration, ci/cd, and github pages deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,6 +13,10 @@ name: CD
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+      - '*.md'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,67 @@
+# =============================================================================
+# Documentation Deployment Pipeline
+# =============================================================================
+# Builds Docusaurus site and deploys to GitHub Pages.
+# Triggers on pushes to main that modify docs/ or on manual dispatch.
+
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Docusaurus
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./docs
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: './docs/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs/build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/docs/architecture/overview.md
+++ b/docs/docs/architecture/overview.md
@@ -51,7 +51,7 @@ The RAG Platform follows a modular, layered architecture designed for scalabilit
 │  │ Analytics       │  │  Notification   │  │   Real-Time Services    │ │
 │  │   Service       │  │    Service      │  │                         │ │
 │  │                 │  │                 │  │ - Socket.io Service     │ │
-│  │ - Query Metrics │  │ - Email (SMTP)  │  │ - Presence Tracking     │ │
+│  │ - Query Metrics │  │ - Email (Resend)│  │ - Presence Tracking     │ │
 │  │ - Cost Tracking │  │ - In-App Alerts │  │ - Live Analytics        │ │
 │  │ - RAGAS Eval    │  │ - Token Expiry  │  │ - Activity Feed         │ │
 │  │ - LangSmith     │  │                 │  │ - Real-Time Events      │ │
@@ -287,7 +287,7 @@ rag/
 │   │   ├── notionTransformer.js # Notion → Markdown
 │   │   ├── notionTokenMonitor.js # Token health checks
 │   │   ├── socketService.js   # Socket.io real-time
-│   │   ├── emailService.js    # SMTP email sending
+│   │   ├── emailService.js    # Resend email sending
 │   │   ├── notificationService.js
 │   │   ├── deadLetterQueue.js # Failed job handling
 │   │   ├── tenantIsolation.js # Multi-tenant security

--- a/docs/docs/backend/overview.md
+++ b/docs/docs/backend/overview.md
@@ -70,7 +70,9 @@ backend/
 │   ├── rag/            # RAG sub-modules
 │   ├── memory/         # Conversation memory
 │   ├── context/        # Context management
-│   └── metrics/        # Observability
+│   ├── metrics/        # Observability
+│   ├── emailService.js # Resend email sending
+│   └── notificationService.js # Dual-channel notifications
 ├── utils/              # Utilities
 │   ├── core/           # Core utilities
 │   ├── rag/            # RAG utilities

--- a/docs/docs/deployment/ci-cd.md
+++ b/docs/docs/deployment/ci-cd.md
@@ -1,0 +1,242 @@
+---
+sidebar_position: 4
+---
+
+# CI/CD Pipeline
+
+The project uses GitHub Actions for continuous integration and continuous deployment.
+
+## Overview
+
+```
+Push/PR to main/dev/staging
+         │
+         ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                     CI Workflow (ci.yml)                         │
+│                                                                 │
+│  ┌──────────────┐  ┌──────────────┐  ┌───────────────────────┐ │
+│  │ Backend Tests │  │Frontend Tests│  │ RAGAS Service Tests   │ │
+│  │  (Node.js)   │  │  (Next.js)   │  │     (Python)          │ │
+│  │ + Lint        │  │ + Lint       │  │ + Lint                │ │
+│  │ + MongoDB     │  │ + Vitest     │  │ + Pytest              │ │
+│  │ + Redis       │  │              │  │                       │ │
+│  └──────────────┘  └──────────────┘  └───────────────────────┘ │
+│  ┌──────────────┐  ┌──────────────────────────────────────────┐ │
+│  │   Security   │  │          Docker Build Check              │ │
+│  │    Audit     │  │  backend / frontend / ragas-service      │ │
+│  └──────────────┘  └──────────────────────────────────────────┘ │
+│                           │                                     │
+│                    CI Success Gate                               │
+└─────────────────────────────────────────────────────────────────┘
+                            │
+                   (only push to main)
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                     CD Workflow (cd.yml)                         │
+│                                                                 │
+│  1. Run CI ──► 2. Build & Push  ──► 3. Deploy via SSH           │
+│                  to GHCR               to DigitalOcean          │
+│                                                                 │
+│                                    4. Health Check               │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## CI Workflow
+
+**File:** `.github/workflows/ci.yml`
+
+**Triggers:**
+- Push to `main`, `dev`, or `staging`
+- Pull requests targeting `main`, `dev`, or `staging`
+- Called by the CD workflow (`workflow_call`)
+
+### Jobs
+
+| Job | Description | Services |
+|-----|-------------|----------|
+| `backend-test` | Lint + run Vitest tests | MongoDB 7.0, Redis 7 |
+| `frontend-test` | Lint + run Vitest tests | None |
+| `backend-security` | `npm audit --audit-level=high` | None |
+| `ragas-test` | Flake8 lint + Pytest | None |
+| `docker-build` | Build Docker images (no push) for backend, frontend, ragas-service | None |
+| `ci-success` | Gate job — fails if `backend-test` or `frontend-test` failed | None |
+
+### Backend Test Environment
+
+The CI job spins up MongoDB and Redis as service containers and sets test-specific environment variables:
+
+```yaml
+env:
+  NODE_ENV: test
+  MONGODB_URI: mongodb://localhost:27017/test_db
+  REDIS_URL: redis://localhost:6378
+  JWT_ACCESS_SECRET: <test-secret>
+  JWT_REFRESH_SECRET: <test-secret>
+  ENCRYPTION_KEY: <test-key>
+```
+
+## CD Workflow
+
+**File:** `.github/workflows/cd.yml`
+
+**Triggers:**
+- Push to `main` only
+- Manual dispatch (`workflow_dispatch`)
+
+### Steps
+
+1. **Run CI** — calls the CI workflow as a reusable workflow
+2. **Build & Push** — builds Docker images for `backend`, `frontend`, and `ragas-service`, then pushes to GHCR
+3. **Deploy via SSH** — connects to the production droplet and runs the deployment script
+4. **Health Check** — verifies backend (`/health`) and frontend are responding
+
+### Docker Images
+
+Images are pushed to GitHub Container Registry (GHCR):
+
+```
+ghcr.io/andreliar/retrieva/backend
+ghcr.io/andreliar/retrieva/frontend
+ghcr.io/andreliar/retrieva/ragas-service
+```
+
+**Tagging strategy:**
+- `latest` — always points to the most recent `main` build
+- `<git-sha>` — short SHA of the commit for pinning and rollback
+
+## GitHub Secrets
+
+The CD workflow requires these repository secrets:
+
+| Secret | Description |
+|--------|-------------|
+| `DEPLOY_HOST` | Production droplet IP address |
+| `DEPLOY_SSH_KEY` | Private SSH key for the `deploy` user on the droplet |
+| `GHCR_PAT` | GitHub PAT with `read:packages` scope (used by the server to pull images) |
+
+:::note
+`GITHUB_TOKEN` is automatically available and used to push images to GHCR during the build step. `GHCR_PAT` is a separate token used on the production server to pull private images.
+:::
+
+## Secrets Management
+
+Production secrets are encrypted at rest using **SOPS** with **age** encryption.
+
+### Encrypted Files
+
+| File | Contents |
+|------|----------|
+| `backend/.env.production.enc` | Main backend secrets (DB URIs, API keys, JWT secrets, etc.) |
+| `backend/.env.resend.production.enc` | Email service secrets (`RESEND_API_KEY`, `RESEND_FROM_EMAIL`) |
+| `ragas-service/.env.production.enc` | RAGAS service secrets |
+
+### Decryption During Deployment
+
+The CD workflow decrypts secrets on the production server using an age key stored at `~/.age/key.txt`:
+
+```bash
+# Decrypt main backend secrets
+SOPS_AGE_KEY_FILE=~/.age/key.txt sops --decrypt \
+  --input-type dotenv --output-type dotenv \
+  backend/.env.production.enc > backend/.env
+
+# Append email secrets
+SOPS_AGE_KEY_FILE=~/.age/key.txt sops --decrypt \
+  --input-type dotenv --output-type dotenv \
+  backend/.env.resend.production.enc >> backend/.env
+```
+
+### Encrypting / Updating Secrets
+
+To update a secret:
+
+```bash
+# Edit in place (opens $EDITOR)
+SOPS_AGE_KEY_FILE=~/.age/key.txt sops \
+  --input-type dotenv --output-type dotenv \
+  backend/.env.production.enc
+
+# Or encrypt a new plaintext file
+sops --encrypt --age <age-public-key> \
+  --input-type dotenv --output-type dotenv \
+  backend/.env.plaintext > backend/.env.production.enc
+```
+
+:::warning
+Never commit plaintext `.env` files. Only `.enc` (encrypted) files belong in the repository.
+:::
+
+## Production Deployment Architecture
+
+```
+                     Internet
+                        │
+                   ┌────▼────┐
+                   │  Nginx  │  (TLS termination, reverse proxy)
+                   └────┬────┘
+                        │
+          ┌─────────────┼─────────────┐
+          │             │             │
+     ┌────▼────┐  ┌─────▼────┐  ┌────▼────────┐
+     │Frontend │  │ Backend  │  │RAGAS Service │
+     │ :3000   │  │  :3007   │  │   :8001      │
+     └─────────┘  └────┬─────┘  └──────────────┘
+                       │
+          ┌────────────┼────────────┐
+          │            │            │
+     ┌────▼────┐ ┌─────▼───┐ ┌─────▼───┐
+     │MongoDB  │ │  Redis  │ │ Qdrant  │
+     │ :27017  │ │  :6379  │ │  :6333  │
+     └─────────┘ └─────────┘ └─────────┘
+```
+
+All services run on a single **DigitalOcean droplet** via `docker-compose.production.yml`.
+
+### Nginx Reverse Proxy
+
+Nginx handles TLS termination and routing. Configuration: `nginx/rag.conf`
+
+| Path | Upstream | Notes |
+|------|----------|-------|
+| `/api/*` | `backend:3007` | 120s read/send timeout for RAG queries |
+| `/socket.io/*` | `backend:3007` | WebSocket upgrade headers |
+| `/health` | `backend:3007` | Health check endpoint |
+| `/*` | `frontend:3000` | Catch-all for Next.js pages |
+
+**TLS** is managed by **Certbot** (Let's Encrypt) with automatic renewal. Certificates are stored at `/etc/letsencrypt/live/devandre.sbs/`.
+
+## Health Check
+
+After deployment, the CD workflow waits 15 seconds then verifies:
+
+```bash
+curl -sf http://localhost:3007/health   # Backend API
+curl -sf http://localhost:3000           # Frontend
+```
+
+The backend `/health` endpoint returns service status including database connectivity and email configuration state.
+
+## Rollback
+
+To roll back to a previous version:
+
+```bash
+# SSH into the production server
+ssh deploy@<DEPLOY_HOST>
+cd /opt/rag
+
+# Find the previous image SHA
+docker images ghcr.io/andreliar/retrieva/backend --format "{{.Tag}}"
+
+# Update docker-compose.production.yml to pin the previous SHA
+# Or pull a specific tag:
+docker pull ghcr.io/andreliar/retrieva/backend:<previous-sha>
+docker pull ghcr.io/andreliar/retrieva/frontend:<previous-sha>
+
+# Restart with the pinned images
+docker compose -f docker-compose.production.yml up -d
+```
+
+Alternatively, revert the commit on `main` and let CD redeploy automatically.

--- a/docs/docs/deployment/email-service.md
+++ b/docs/docs/deployment/email-service.md
@@ -1,0 +1,188 @@
+---
+sidebar_position: 5
+---
+
+# Email Service
+
+The platform sends transactional emails using the **Resend HTTP API**. This page covers setup, DNS configuration, and troubleshooting.
+
+## Why Resend (not SMTP)
+
+DigitalOcean blocks outbound traffic on SMTP ports (25, 465, 587) for all droplets. This means traditional SMTP libraries like Nodemailer cannot deliver email from production.
+
+**Resend** solves this by providing an HTTP API over port 443 (HTTPS), which is never blocked. The migration from Nodemailer to Resend was done for this reason.
+
+## Setup
+
+### 1. Create a Resend Account
+
+1. Sign up at [resend.com](https://resend.com)
+2. Navigate to **API Keys** and create a new key
+3. Copy the key — it starts with `re_`
+
+### 2. Configure Environment Variables
+
+```bash
+# Required for email to work
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Optional (have defaults)
+SMTP_FROM_NAME=RAG Platform
+RESEND_FROM_EMAIL=noreply@yourdomain.com
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RESEND_API_KEY` | - | Resend API key (required) |
+| `SMTP_FROM_NAME` | `RAG Platform` | Display name in the "From" field |
+| `RESEND_FROM_EMAIL` | `noreply@devandre.sbs` | Sender email (must match a verified Resend domain) |
+
+:::note
+If `RESEND_API_KEY` is not set, the service gracefully degrades — emails are skipped with a warning log. This means email is optional for local development.
+:::
+
+## Domain Verification
+
+To send from your own domain (instead of Resend's shared domain), you must verify it with DNS records.
+
+### Required DNS Records
+
+After adding your domain in the Resend dashboard, you'll be given records to create. For the `devandre.sbs` domain, these are:
+
+| Type | Name | Value | Purpose |
+|------|------|-------|---------|
+| TXT | `resend._domainkey.devandre.sbs` | `p=MIGfMA0GCSq...` | DKIM signature (record 1) |
+| TXT | `resend2._domainkey.devandre.sbs` | `p=MIGfMA0GCSq...` | DKIM signature (record 2) |
+| TXT | `resend3._domainkey.devandre.sbs` | `p=MIGfMA0GCSq...` | DKIM signature (record 3) |
+| MX | `send.devandre.sbs` | `feedback-smtp.us-east-1.amazonses.com` | SPF return path |
+| TXT | `send.devandre.sbs` | `v=spf1 include:amazonses.com ~all` | SPF authorization |
+| TXT | `_dmarc.devandre.sbs` | `v=DMARC1; p=none;` | DMARC policy |
+
+### DNS Management
+
+Even if your domain is registered at a different registrar (e.g., Namecheap), DNS can be managed at **DigitalOcean** by pointing the domain's nameservers to:
+
+```
+ns1.digitalocean.com
+ns2.digitalocean.com
+ns3.digitalocean.com
+```
+
+Then add the DNS records in the DigitalOcean control panel under **Networking > Domains**.
+
+:::warning
+DNS propagation can take up to 48 hours. Resend will show the domain as "Pending" until all records are verified.
+:::
+
+## Email Templates
+
+The email service sends 4 types of branded HTML emails:
+
+| Method | Trigger | Template |
+|--------|---------|----------|
+| `sendEmailVerification` | User registration | Verification link (24h expiry) |
+| `sendPasswordResetEmail` | Forgot password | Reset link (1h expiry) |
+| `sendWelcomeEmail` | Account created | Onboarding steps + dashboard link |
+| `sendWorkspaceInvitation` | Member invited | Workspace details + join link |
+
+All templates use inline CSS for email client compatibility and share a consistent branded header with gradient styling.
+
+## Integration Points
+
+The email service is called from these locations in the codebase:
+
+| Caller | Email Sent |
+|--------|------------|
+| `controllers/authController.js` | Verification email on registration, password reset email |
+| `controllers/workspaceMemberController.js` | Workspace invitation email |
+| `services/notificationService.js` | Notification emails (sync failures, system alerts) |
+
+### Notification Service Integration
+
+The `notificationService` uses `emailService.sendEmail()` as a secondary delivery channel. When a notification is created:
+
+1. It's always persisted in MongoDB
+2. If the user is online, it's delivered via WebSocket
+3. If the user has email enabled for that notification type **and** the priority is not LOW, an email is also sent
+
+## Production Secrets
+
+Email secrets are stored in a separate SOPS-encrypted file:
+
+```
+backend/.env.resend.production.enc
+```
+
+During deployment, the CD workflow decrypts and appends it to the main `.env`:
+
+```bash
+SOPS_AGE_KEY_FILE=~/.age/key.txt sops --decrypt \
+  --input-type dotenv --output-type dotenv \
+  backend/.env.resend.production.enc >> backend/.env
+```
+
+See [CI/CD Pipeline](./ci-cd.md) for the full secrets management flow.
+
+## Health Check
+
+The backend health endpoint at `GET /api/v1/health` includes email service status:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "status": "up",
+    "email": {
+      "configured": true
+    }
+  }
+}
+```
+
+`email.configured` will be `false` if `RESEND_API_KEY` is not set.
+
+## Troubleshooting
+
+### Domain Not Verified
+
+**Symptom:** Resend dashboard shows domain as "Pending".
+
+**Fix:**
+1. Double-check all 6 DNS records are created in DigitalOcean
+2. Use `dig` to verify records have propagated:
+   ```bash
+   dig TXT resend._domainkey.devandre.sbs
+   dig MX send.devandre.sbs
+   dig TXT _dmarc.devandre.sbs
+   ```
+3. Wait up to 48 hours for full propagation
+4. Click "Verify" again in the Resend dashboard
+
+### Emails Not Sending (503 Error)
+
+**Symptom:** Logs show `Email not sent - Resend client not configured`.
+
+**Fix:** Ensure `RESEND_API_KEY` is set in the environment. Check that the encrypted secrets file was properly decrypted during deployment:
+
+```bash
+# On the production server
+grep RESEND_API_KEY /opt/rag/backend/.env
+```
+
+### Emails Sent But Not Received
+
+**Symptom:** Resend API returns success but recipient never gets the email.
+
+**Fix:**
+1. Check the Resend dashboard **Logs** tab for delivery status
+2. Verify the sender domain is fully verified (not "Pending")
+3. Check the recipient's spam folder
+4. Ensure `RESEND_FROM_EMAIL` matches the verified domain
+
+### Testing Email Locally
+
+To test email sending in local development:
+
+1. Set `RESEND_API_KEY` in your `.env` (use a test API key from Resend)
+2. Send a test request that triggers email (e.g., password reset)
+3. Check backend logs for `Email sent successfully` with a `messageId`

--- a/docs/docs/deployment/environment-variables.md
+++ b/docs/docs/deployment/environment-variables.md
@@ -197,6 +197,18 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 | `FRONTEND_URL` | Frontend URL for OAuth redirects |
 | `ALLOWED_ORIGINS` | Comma-separated allowed origins |
 
+### Email Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RESEND_API_KEY` | - | Resend API key for sending emails |
+| `SMTP_FROM_NAME` | `RAG Platform` | Display name in the "From" field |
+| `RESEND_FROM_EMAIL` | `noreply@devandre.sbs` | Sender email address (must match a verified Resend domain) |
+
+:::note
+The email service uses the **Resend HTTP API** over HTTPS (port 443). No SMTP ports (25, 465, 587) are needed — this is important because DigitalOcean blocks outbound SMTP traffic.
+:::
+
 ### Logging
 
 | Variable | Default | Description |
@@ -245,6 +257,11 @@ ENCRYPTION_KEY=
 NOTION_CLIENT_ID=
 NOTION_CLIENT_SECRET=
 NOTION_REDIRECT_URI=http://localhost:3007/api/v1/notion/callback
+
+# Email (optional for local dev - emails will be skipped if not set)
+RESEND_API_KEY=
+SMTP_FROM_NAME=RAG Platform
+RESEND_FROM_EMAIL=noreply@yourdomain.com
 
 # Frontend
 FRONTEND_URL=http://localhost:3000

--- a/docs/docs/deployment/production-checklist.md
+++ b/docs/docs/deployment/production-checklist.md
@@ -24,6 +24,8 @@ Essential tasks before deploying to production.
 
 - [ ] **Azure OpenAI key secured** - Never commit to version control
 
+- [ ] **Resend API key secured** - Store in encrypted `.env.resend.production.enc`
+
 - [ ] **Environment files excluded** - `.env` in `.gitignore`
 
 ### Authentication
@@ -93,6 +95,13 @@ Essential tasks before deploying to production.
 - [ ] **Timeouts configured** - LLM and streaming timeouts
 - [ ] **Guardrails enabled** - Hallucination blocking active
 - [ ] **Fallback messages** - User-friendly error messages
+
+### Email Service
+
+- [ ] **Resend API key configured** - `RESEND_API_KEY` set in production env
+- [ ] **Domain verified in Resend** - DKIM, SPF, and DMARC DNS records configured for sender domain
+- [ ] **From email set** - `RESEND_FROM_EMAIL` matches a verified Resend domain
+- [ ] **Email flows tested** - Password reset, email verification, workspace invitation, welcome emails all sending correctly
 
 ### Sync & Workers
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -100,6 +100,11 @@ FRONTEND_URL=http://localhost:3000
 NOTION_CLIENT_ID=your-notion-client-id
 NOTION_CLIENT_SECRET=your-notion-client-secret
 NOTION_REDIRECT_URI=http://localhost:3007/api/v1/notion/callback
+
+# Email (optional for local dev)
+RESEND_API_KEY=
+SMTP_FROM_NAME=RAG Platform
+RESEND_FROM_EMAIL=noreply@yourdomain.com
 ```
 
 ### 3. Start Development Server

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -11,11 +11,13 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://rag-docs.example.com',
-  baseUrl: '/',
+  url: 'https://andreliar.github.io',
+  baseUrl: '/Retrieva/',
 
-  organizationName: 'your-org',
-  projectName: 'rag-platform',
+  organizationName: 'AndreLiar',
+  projectName: 'Retrieva',
+  trailingSlash: false,
+  deploymentBranch: 'gh-pages',
 
   onBrokenLinks: 'throw',
 
@@ -66,7 +68,7 @@ const config: Config = {
           label: 'API Reference',
         },
         {
-          href: 'https://github.com/your-org/rag-platform',
+          href: 'https://github.com/AndreLiar/Retrieva',
           label: 'GitHub',
           position: 'right',
         },

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -60,6 +60,8 @@ const sidebars: SidebarsConfig = {
         'deployment/docker',
         'deployment/environment-variables',
         'deployment/production-checklist',
+        'deployment/ci-cd',
+        'deployment/email-service',
       ],
     },
     'contributing',


### PR DESCRIPTION
## Summary

- Documentation updates for the Resend email migration
- New CI/CD pipeline and email service documentation pages
- GitHub Pages deployment workflow for Docusaurus docs
- Add `paths-ignore` to CD workflow to prevent unnecessary DigitalOcean deploys on docs-only changes

## Changes

- Fix stale SMTP references to Resend across docs
- Add email config to env vars, getting-started, and production-checklist
- Create `deployment/ci-cd.md` and `deployment/email-service.md`
- Configure Docusaurus for `https://andreliar.github.io/Retrieva/`
- Add `.github/workflows/docs.yml` for GitHub Pages auto-deploy
- Add `paths-ignore` to `cd.yml` so docs-only pushes skip DigitalOcean deploy

## Test plan
- [x] `cd docs && npm run build` passes
- [x] All CI checks passed on PR #10
- [ ] docs.yml deploys site to GitHub Pages after merge
- [ ] cd.yml does NOT trigger (docs-only change, paths-ignore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)