### PR TITLE
fix: qdrant auth, redis oom, frontend healthcheck

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -51,8 +51,7 @@ services:
       --maxmemory-policy noeviction
       --appendonly yes
       --appendfsync everysec
-      --save 900 1
-      --save 300 10
+      --save ""
       --requirepass ${REDIS_PASSWORD}
     ports:
       - "127.0.0.1:6379:6379"
@@ -68,7 +67,7 @@ services:
       resources:
         limits:
           cpus: '0.25'
-          memory: 300M
+          memory: 768M
     logging:
       driver: "json-file"
       options:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -51,6 +51,6 @@ ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:3000 || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000 || exit 1
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary

- **Qdrant 403 fix**: Add `QDRANT_API_KEY` to all Qdrant client instantiations (`getQdrantClient()` and both `fromExistingCollection()` calls). Missing auth caused every vector upsert/query to fail with 403 Forbidden, breaking Notion sync entirely.
- **Redis OOM fix**: Increase container memory limit from 300M to 768M and disable redundant RDB snapshots (`--save ""`) since AOF is already enabled. Prevents BGSAVE fork from triggering OOM kill restart loop.
- **Frontend healthcheck fix**: Use `http://127.0.0.1:3000` instead of `http://localhost:3000` in Dockerfile HEALTHCHECK. Alpine resolves `localhost` to `[::1]` (IPv6) but Next.js standalone binds IPv4 only.

## Test plan

- [x] All 1199 backend tests pass (50 files)
- [x] Redis container stable on server after memory limit increase (verified healthy)
- [ ] After merge + CD deploy: verify Notion sync completes without 403 errors
- [ ] After merge + CD deploy: verify frontend container shows "healthy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)