### PR TITLE
fix(backend): add qdrant api key to all client instances

### DIFF
--- a/backend/services/backup/vectorStoreBackup.js
+++ b/backend/services/backup/vectorStoreBackup.js
@@ -40,7 +40,8 @@ class VectorStoreBackupManager {
    */
   async _ensureClient() {
     if (!this.client) {
-      this.client = new QdrantClient({ url: this.qdrantUrl });
+      const apiKey = process.env.QDRANT_API_KEY;
+      this.client = new QdrantClient({ url: this.qdrantUrl, ...(apiKey && { apiKey }) });
     }
     return this.client;
   }

--- a/backend/services/pipeline/embeddingMigration.js
+++ b/backend/services/pipeline/embeddingMigration.js
@@ -285,7 +285,8 @@ async function migrateDocument(workspaceId, sourceId) {
       const { QdrantClient } = await import('@qdrant/js-client-rest');
       const qdrantUrl = process.env.QDRANT_URL || 'http://localhost:6333';
       const collectionName = process.env.QDRANT_COLLECTION_NAME || 'langchain-rag';
-      const client = new QdrantClient({ url: qdrantUrl });
+      const apiKey = process.env.QDRANT_API_KEY;
+      const client = new QdrantClient({ url: qdrantUrl, ...(apiKey && { apiKey }) });
 
       await client.delete(collectionName, {
         filter: {

--- a/backend/services/search/sparseVector.js
+++ b/backend/services/search/sparseVector.js
@@ -614,7 +614,9 @@ class SparseVectorManager {
         sparseRank: entry.sparseRank,
         denseScore: entry.denseScore,
         sparseScore: entry.sparseScore,
-        normalizedSparseScore: entry.sparseScore ? (entry.sparseScore / maxSparseScore).toFixed(3) : null,
+        normalizedSparseScore: entry.sparseScore
+          ? (entry.sparseScore / maxSparseScore).toFixed(3)
+          : null,
         doc: entry.doc,
       });
     }
@@ -622,8 +624,12 @@ class SparseVectorManager {
     merged.sort((a, b) => b.rrfScore - a.rrfScore);
 
     // Debug logging
-    const sparseOnlyWithVectorId = merged.filter(m => m.sparseRank && !m.denseRank && m.vectorStoreId);
-    const sparseOnlyWithoutVectorId = merged.filter(m => m.sparseRank && !m.denseRank && !m.vectorStoreId);
+    const sparseOnlyWithVectorId = merged.filter(
+      (m) => m.sparseRank && !m.denseRank && m.vectorStoreId
+    );
+    const sparseOnlyWithoutVectorId = merged.filter(
+      (m) => m.sparseRank && !m.denseRank && !m.vectorStoreId
+    );
 
     logger.info('Hybrid search completed', {
       service: 'sparse-vector',
@@ -718,7 +724,8 @@ class SparseVectorManager {
       const qdrantUrl = process.env.QDRANT_URL || 'http://localhost:6333';
       const collectionName = process.env.QDRANT_COLLECTION_NAME || 'langchain-rag';
 
-      const client = new QdrantClient({ url: qdrantUrl });
+      const apiKey = process.env.QDRANT_API_KEY;
+      const client = new QdrantClient({ url: qdrantUrl, ...(apiKey && { apiKey }) });
 
       // Fetch all documents for this workspace from Qdrant
       const documents = [];

--- a/backend/workers/notionSyncHelpers.js
+++ b/backend/workers/notionSyncHelpers.js
@@ -64,13 +64,16 @@ export async function detectDesyncedDocuments(workspaceId) {
       workspaceId,
       chunkCount: { $gt: 0 },
       syncStatus: { $ne: 'deleted' },
-    }).select('sourceId chunkCount').lean();
+    })
+      .select('sourceId chunkCount')
+      .lean();
 
     if (docsWithChunks.length === 0) {
       return desyncedIds;
     }
 
-    const client = new QdrantClient({ url: QDRANT_URL });
+    const apiKey = process.env.QDRANT_API_KEY;
+    const client = new QdrantClient({ url: QDRANT_URL, ...(apiKey && { apiKey }) });
 
     // Check each document in Qdrant (batch for efficiency)
     // Process in batches of 50 to avoid overwhelming Qdrant


### PR DESCRIPTION
## Summary

- Add `QDRANT_API_KEY` to 7 remaining `QdrantClient` instantiations across the backend that were missing authentication
- Fixes 403 Forbidden errors on: verification queries, vector deletion, context expansion, sparse vector search, retrieval strategies, embedding migration, and vector store backup

Follows up on PR #16 which fixed the 3 primary instances in `vectorStore.js`.

## Files changed

- `workers/documentIndexWorker.js` — verification client
- `workers/notionSyncHelpers.js` — desync detection client  
- `services/rag/contextExpansion.js` — sibling chunk fetching
- `services/backup/vectorStoreBackup.js` — backup client
- `services/pipeline/embeddingMigration.js` — migration cleanup
- `services/search/sparseVector.js` — hybrid search
- `services/intent/retrievalStrategies.js` — sparse-only result fetching

## Test plan

- [x] All 1199 backend tests pass
- [ ] After deploy: verify no more "Qdrant verification error: Forbidden" in logs
- [ ] Notion sync completes fully without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)