### PR TITLE
fix(infra): use bash tcp probe for qdrant healthcheck

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -90,10 +90,11 @@ services:
     environment:
       - QDRANT__SERVICE__GRPC_PORT=6334
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:6333/readyz"]
+      test: ["CMD-SHELL", "bash -c ':>/dev/tcp/0.0.0.0/6333' || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 30s
     restart: unless-stopped
     deploy:
       resources:

--- a/docs/docs/deployment/docker.md
+++ b/docs/docs/deployment/docker.md
@@ -436,10 +436,11 @@ qdrant:
   environment:
     - QDRANT__SERVICE__GRPC_PORT=6334
   healthcheck:
-    test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:6333/readyz"]
+    test: ["CMD-SHELL", "bash -c ':>/dev/tcp/0.0.0.0/6333' || exit 1"]
     interval: 10s
     timeout: 5s
     retries: 5
+    start_period: 30s
   restart: unless-stopped
   deploy:
     resources:
@@ -452,7 +453,7 @@ Key configuration choices:
 - **Pinned version** (`v1.13.2`): Matches development for consistency. Avoids surprise breaking changes from `:latest`.
 - **1G memory limit**: Sufficient for ~3,200 documents with dense + sparse vectors. Actual usage ~200-400MB.
 - **Volume persistence** (`qdrant_data`): Data survives container restarts.
-- **Health check** via `/readyz` endpoint: Backend depends on this to start only after Qdrant is ready.
+- **Health check** via bash TCP probe on port 6333: Backend depends on this to start only after Qdrant is ready. Uses `start_period: 30s` for first-boot initialization.
 - **No API key needed**: Ports bind to `127.0.0.1` only — no external access possible.
 
 ### 5. Resource Limits


### PR DESCRIPTION
## Summary

- Fix Qdrant healthcheck: the `qdrant/qdrant:v1.13.2` image (debian:12-slim) does not include `wget`
- Switch to bash built-in TCP probe: `bash -c ':>/dev/tcp/0.0.0.0/6333'`
- Add `start_period: 30s` to allow Qdrant initialization on first boot

## Context

The previous deploy (PR #18) failed because the Qdrant container healthcheck used `wget` which isn't available in the Qdrant Docker image. This caused the backend to fail its `depends_on: qdrant: condition: service_healthy` check.

## Test plan

- [ ] CD deploys successfully
- [ ] Qdrant container reports healthy
- [ ] Backend starts after Qdrant is ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)