### PR TITLE
feat(backend): add MCP data source connector layer

### DIFF
--- a/backend/adapters/MCPDataSourceAdapter.js
+++ b/backend/adapters/MCPDataSourceAdapter.js
@@ -1,0 +1,292 @@
+/**
+ * MCPDataSourceAdapter
+ *
+ * Implements BaseDocumentSourceAdapter using the Model Context Protocol (MCP).
+ * Retrieva acts as an MCP **client**; the external service runs an MCP **server**
+ * that exposes its documents through a standardised set of tools.
+ *
+ * Required tools the remote MCP server must expose:
+ *
+ *   get_source_info   → { name, type, totalDocuments, description }
+ *   list_documents    → [{ id, title, url, lastModified, type, parentId? }]
+ *   fetch_document    → { id, title, url, content, contentHash,
+ *                         createdAt, lastModified, author?,
+ *                         parentId?, parentType?, properties? }
+ *   get_changes       → [{ id, changeType: 'created'|'modified'|'deleted' }]
+ *                       (takes argument: { since: ISO-string })
+ *
+ * Transport: StreamableHTTP (MCP SDK v1.x).
+ * Auth:      Bearer token passed as Authorization header.
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { createHash } from 'crypto';
+import { BaseDocumentSourceAdapter } from './BaseDocumentSourceAdapter.js';
+import logger from '../config/logger.js';
+
+const CONNECT_TIMEOUT_MS = parseInt(process.env.MCP_CONNECT_TIMEOUT_MS) || 15000;
+const TOOL_TIMEOUT_MS = parseInt(process.env.MCP_TOOL_TIMEOUT_MS) || 30000;
+
+/**
+ * Wrap a promise with a hard timeout.
+ */
+function withTimeout(promise, ms, label) {
+  let timer;
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`MCP operation timed out after ${ms}ms: ${label}`)),
+        ms
+      );
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+export class MCPDataSourceAdapter extends BaseDocumentSourceAdapter {
+  /**
+   * @param {string} serverUrl  - Full HTTP URL of the MCP server endpoint
+   * @param {string} [authToken] - Bearer token for Authorization header (optional)
+   * @param {string} [sourceType] - Declared source type label (e.g. 'confluence')
+   */
+  constructor(serverUrl, authToken = null, sourceType = 'custom') {
+    super();
+    this.serverUrl = serverUrl;
+    this.authToken = authToken;
+    this.sourceType = sourceType;
+    this._client = null;
+    this._connected = false;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Connection lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Authenticate and connect to the MCP server.
+   * credentials parameter is kept for interface compatibility; the adapter
+   * uses the token passed to the constructor.
+   */
+  async authenticate(_credentials) {
+    try {
+      const headers = {};
+      if (this.authToken) {
+        headers['Authorization'] = `Bearer ${this.authToken}`;
+      }
+
+      const transport = new StreamableHTTPClientTransport(new URL(this.serverUrl), { headers });
+
+      this._client = new Client(
+        { name: 'retrieva-mcp-client', version: '1.0.0' },
+        { capabilities: { tools: {} } }
+      );
+
+      await withTimeout(this._client.connect(transport), CONNECT_TIMEOUT_MS, 'connect');
+      this._connected = true;
+
+      logger.info('MCPDataSourceAdapter connected', {
+        service: 'mcp-adapter',
+        serverUrl: this.serverUrl,
+        sourceType: this.sourceType,
+      });
+
+      return true;
+    } catch (error) {
+      logger.error('MCPDataSourceAdapter: connection failed', {
+        service: 'mcp-adapter',
+        serverUrl: this.serverUrl,
+        error: error.message,
+      });
+      throw error;
+    }
+  }
+
+  async disconnect() {
+    if (this._client && this._connected) {
+      try {
+        await this._client.close();
+      } catch (_) {
+        // best-effort
+      }
+      this._client = null;
+      this._connected = false;
+    }
+  }
+
+  async validateConnection() {
+    try {
+      await this._callTool('get_source_info', {});
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Core adapter interface
+  // ---------------------------------------------------------------------------
+
+  async getWorkspaceInfo() {
+    const raw = await this._callTool('get_source_info', {});
+    return {
+      name: raw?.name ?? 'Unknown MCP Source',
+      type: this.sourceType,
+      totalDocuments: raw?.totalDocuments ?? 0,
+      description: raw?.description ?? '',
+    };
+  }
+
+  /**
+   * Returns an array of lightweight document descriptors.
+   * @returns {Promise<Array<{id, title, url, lastModified, type, parentId}>>}
+   */
+  async listDocuments(options = {}) {
+    const raw = await this._callTool('list_documents', options);
+    const list = Array.isArray(raw) ? raw : (raw?.documents ?? []);
+
+    return list.map((doc) => ({
+      id: String(doc.id),
+      title: doc.title ?? 'Untitled',
+      url: doc.url ?? null,
+      lastModified: doc.lastModified ?? doc.last_modified ?? null,
+      type: doc.type ?? 'page',
+      parentId: doc.parentId ?? doc.parent_id ?? null,
+    }));
+  }
+
+  /**
+   * Fetch full document content from the MCP server and normalise it into
+   * the `documentContent` contract expected by documentIndexWorker.
+   *
+   * documentContent contract:
+   *   { sourceId, title, url, content (markdown), contentHash,
+   *     createdAt, lastModified, author, archived,
+   *     properties, parentId, parentType }
+   *
+   * Note: no `blocks` field — the loader falls back to character-based chunking.
+   */
+  async fetchDocument(documentId) {
+    const raw = await this._callTool('fetch_document', { document_id: String(documentId) });
+
+    if (!raw || !raw.id) {
+      throw new Error(`MCP server returned invalid document for id=${documentId}`);
+    }
+
+    const content = raw.content ?? '';
+    const contentHash = raw.contentHash ?? raw.content_hash ?? this._hashContent(content);
+
+    return {
+      sourceId: String(raw.id),
+      title: raw.title ?? 'Untitled',
+      url: raw.url ?? null,
+      content,
+      contentHash,
+      createdAt: raw.createdAt ?? raw.created_at ?? new Date().toISOString(),
+      lastModified: raw.lastModified ?? raw.last_modified ?? new Date().toISOString(),
+      author: raw.author ?? null,
+      archived: raw.archived ?? false,
+      properties: raw.properties ?? {},
+      parentId: raw.parentId ?? raw.parent_id ?? null,
+      parentType: raw.parentType ?? raw.parent_type ?? null,
+    };
+  }
+
+  /**
+   * Alias used by the sync worker to match the NotionAdapter interface.
+   */
+  async getDocumentContent(documentId) {
+    return this.fetchDocument(documentId);
+  }
+
+  /**
+   * Transform raw content from the MCP server to plain text / markdown.
+   * MCP servers are expected to send markdown already; this is a passthrough.
+   */
+  async transformToText(rawContent) {
+    if (typeof rawContent === 'string') return rawContent;
+    return rawContent?.content ?? '';
+  }
+
+  /** Extract standardised metadata from an MCP document descriptor. */
+  async extractMetadata(doc) {
+    return {
+      sourceId: String(doc.id),
+      title: doc.title ?? 'Untitled',
+      url: doc.url ?? null,
+      lastModified: doc.lastModified ?? null,
+      type: doc.type ?? 'page',
+      parentId: doc.parentId ?? null,
+    };
+  }
+
+  /**
+   * Get document IDs that changed since `lastSyncTime`.
+   * Falls back to listing all documents if the server does not implement get_changes.
+   *
+   * @param {Date} lastSyncTime
+   * @returns {Promise<Array<{id, changeType}>>}
+   */
+  async detectChanges(lastSyncTime, _options = {}) {
+    try {
+      const since = lastSyncTime instanceof Date ? lastSyncTime.toISOString() : lastSyncTime;
+
+      const raw = await this._callTool('get_changes', { since });
+      const list = Array.isArray(raw) ? raw : (raw?.changes ?? []);
+
+      return list.map((item) => ({
+        id: String(item.id),
+        changeType: item.changeType ?? item.change_type ?? 'modified',
+      }));
+    } catch (error) {
+      // Server doesn't implement get_changes — fall back to full re-index
+      logger.warn('MCP server does not support get_changes, falling back to full list', {
+        service: 'mcp-adapter',
+        serverUrl: this.serverUrl,
+        error: error.message,
+      });
+
+      const docs = await this.listDocuments();
+      return docs.map((d) => ({ id: d.id, changeType: 'modified' }));
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Call a named tool on the MCP server and parse its result.
+   * The MCP SDK returns { content: [{ type, text }] } for text tools.
+   */
+  async _callTool(toolName, args) {
+    if (!this._connected || !this._client) {
+      throw new Error('MCPDataSourceAdapter is not connected. Call authenticate() first.');
+    }
+
+    const response = await withTimeout(
+      this._client.callTool({ name: toolName, arguments: args }),
+      TOOL_TIMEOUT_MS,
+      toolName
+    );
+
+    // MCP tool results come back as an array of content blocks
+    const textBlock = (response?.content ?? []).find((b) => b.type === 'text');
+    if (!textBlock) {
+      throw new Error(`MCP tool '${toolName}' returned no text content`);
+    }
+
+    try {
+      return JSON.parse(textBlock.text);
+    } catch {
+      // If the server returned plain text (e.g. during an error), surface it
+      throw new Error(`MCP tool '${toolName}' returned non-JSON response: ${textBlock.text}`);
+    }
+  }
+
+  _hashContent(content) {
+    return createHash('sha256').update(content).digest('hex');
+  }
+}
+
+export default MCPDataSourceAdapter;

--- a/backend/app.js
+++ b/backend/app.js
@@ -25,6 +25,7 @@ import presenceRoutes from './routes/presenceRoutes.js';
 import memoryRoutes from './routes/memoryRoutes.js';
 import embeddingRoutes from './routes/embeddingRoutes.js';
 import pipelineRoutes from './routes/pipelineRoutes.js';
+import mcpDataSourceRoutes from './routes/mcpDataSourceRoutes.js';
 import logger from './config/logger.js';
 import { globalErrorHandler } from './utils/index.js';
 import { swaggerDocument } from './config/swagger.js';
@@ -267,6 +268,7 @@ app.use('/api/v1/presence', presenceRoutes);
 app.use('/api/v1/memory', memoryRoutes);
 app.use('/api/v1/embeddings', embeddingRoutes);
 app.use('/api/v1/pipeline', pipelineRoutes);
+app.use('/api/v1/mcp-sources', mcpDataSourceRoutes);
 
 // OpenAPI/Swagger documentation
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));

--- a/backend/controllers/mcpDataSourceController.js
+++ b/backend/controllers/mcpDataSourceController.js
@@ -1,0 +1,111 @@
+/**
+ * MCP Data Source Controller
+ *
+ * REST handler layer — delegates everything to mcpDataSourceService.
+ * All routes are workspace-scoped via req.user.workspaceId (set by auth middleware).
+ */
+
+import { catchAsync } from '../utils/index.js';
+import { sendSuccess } from '../utils/index.js';
+import * as mcpService from '../services/mcpDataSourceService.js';
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /api/v1/mcp-sources
+ * Register a new MCP data source and verify connectivity.
+ */
+export const registerSource = catchAsync(async (req, res) => {
+  const workspaceId = req.user.workspaceId;
+  const { name, sourceType, serverUrl, authToken, syncSettings } = req.body;
+
+  const source = await mcpService.registerMCPDataSource(workspaceId, {
+    name,
+    sourceType,
+    serverUrl,
+    authToken,
+    syncSettings,
+  });
+
+  sendSuccess(res, 201, 'MCP data source registered', { source });
+});
+
+/**
+ * GET /api/v1/mcp-sources
+ * List all MCP data sources for the current workspace.
+ */
+export const listSources = catchAsync(async (req, res) => {
+  const workspaceId = req.user.workspaceId;
+  const sources = await mcpService.listMCPDataSources(workspaceId);
+  sendSuccess(res, 200, 'MCP data sources retrieved', { sources });
+});
+
+/**
+ * GET /api/v1/mcp-sources/:id
+ * Get a single MCP data source.
+ */
+export const getSource = catchAsync(async (req, res) => {
+  const workspaceId = req.user.workspaceId;
+  const source = await mcpService.getMCPDataSource(workspaceId, req.params.id);
+  sendSuccess(res, 200, 'MCP data source retrieved', { source });
+});
+
+/**
+ * PATCH /api/v1/mcp-sources/:id
+ * Update connection settings or sync config.
+ */
+export const updateSource = catchAsync(async (req, res) => {
+  const workspaceId = req.user.workspaceId;
+  const source = await mcpService.updateMCPDataSource(workspaceId, req.params.id, req.body);
+  sendSuccess(res, 200, 'MCP data source updated', { source });
+});
+
+/**
+ * DELETE /api/v1/mcp-sources/:id
+ * Remove the MCP data source and soft-delete its indexed documents.
+ */
+export const deleteSource = catchAsync(async (req, res) => {
+  const workspaceId = req.user.workspaceId;
+  await mcpService.deleteMCPDataSource(workspaceId, req.params.id);
+  sendSuccess(res, 200, 'MCP data source deleted');
+});
+
+// ---------------------------------------------------------------------------
+// Sync & testing
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /api/v1/mcp-sources/:id/sync
+ * Trigger a manual sync (full or incremental).
+ * Body: { syncType?: 'full' | 'incremental' }
+ */
+export const triggerSync = catchAsync(async (req, res) => {
+  const workspaceId = req.user.workspaceId;
+  const syncType = req.body.syncType ?? 'full';
+  const result = await mcpService.triggerMCPSync(workspaceId, req.params.id, syncType, 'manual');
+  sendSuccess(res, 202, 'MCP sync job queued', result);
+});
+
+/**
+ * POST /api/v1/mcp-sources/test-connection
+ * Test a connection to a candidate MCP server without persisting anything.
+ * Body: { serverUrl, authToken?, sourceType? }
+ */
+export const testConnection = catchAsync(async (req, res) => {
+  const { serverUrl, authToken, sourceType } = req.body;
+  const result = await mcpService.testMCPConnection(serverUrl, authToken, sourceType);
+  const status = result.ok ? 200 : 422;
+  sendSuccess(res, status, result.ok ? 'Connection successful' : 'Connection failed', result);
+});
+
+/**
+ * GET /api/v1/mcp-sources/:id/stats
+ * Return document counts and sync statistics.
+ */
+export const getStats = catchAsync(async (req, res) => {
+  const workspaceId = req.user.workspaceId;
+  const stats = await mcpService.getMCPSourceStats(workspaceId, req.params.id);
+  sendSuccess(res, 200, 'MCP data source stats', stats);
+});

--- a/backend/loaders/notionDocumentLoader.js
+++ b/backend/loaders/notionDocumentLoader.js
@@ -197,86 +197,81 @@ export const loadAndChunkNotionBlocks = async (blocks, metadata = {}) => {
       // heading_group chunks already contain the heading text in their content.
       // All other chunk types (list, table, code, callout, paragraph_group) are
       // structural orphans — their embeddings have zero topical signal without this.
-      const needsBreadcrumb =
-        group.headingPath.length > 0 && group.category !== 'heading_group';
-      const headingPrefix = needsBreadcrumb
-        ? `[${group.headingPath.join(' > ')}]\n\n`
-        : '';
-      const overlapPrefix = group.overlapBefore
-        ? `${group.overlapBefore}\n\n`
-        : '';
+      const needsBreadcrumb = group.headingPath.length > 0 && group.category !== 'heading_group';
+      const headingPrefix = needsBreadcrumb ? `[${group.headingPath.join(' > ')}]\n\n` : '';
+      const overlapPrefix = group.overlapBefore ? `${group.overlapBefore}\n\n` : '';
 
       return {
-      pageContent: headingPrefix + overlapPrefix + group.content,
-      metadata: {
-        // Page-level metadata
-        source: metadata.url || `notion://${metadata.sourceId}`,
-        sourceType: 'notion',
-        sourceId: metadata.sourceId,
-        workspaceId: metadata.workspaceId,
-        documentTitle: metadata.title,
-        documentUrl: metadata.url,
-        documentType: metadata.documentType || 'page',
+        pageContent: headingPrefix + overlapPrefix + group.content,
+        metadata: {
+          // Page-level metadata
+          source: metadata.url || `${metadata.sourceType || 'notion'}://${metadata.sourceId}`,
+          sourceType: metadata.sourceType || 'notion',
+          sourceId: metadata.sourceId,
+          workspaceId: metadata.workspaceId,
+          documentTitle: metadata.title,
+          documentUrl: metadata.url,
+          documentType: metadata.documentType || 'page',
 
-        // Author and timestamps
-        author: metadata.author,
-        createdAt: metadata.createdAt,
-        lastModified: metadata.lastModified,
+          // Author and timestamps
+          author: metadata.author,
+          createdAt: metadata.createdAt,
+          lastModified: metadata.lastModified,
 
-        // Document classification for access control filtering
-        // Defaults to 'internal' if not specified in source document
-        classification: metadata.classification || 'internal',
+          // Document classification for access control filtering
+          // Defaults to 'internal' if not specified in source document
+          classification: metadata.classification || 'internal',
 
-        // Notion properties
-        notionProperties: metadata.properties || {},
-        archived: metadata.archived,
-        icon: metadata.icon,
+          // Notion properties
+          notionProperties: metadata.properties || {},
+          archived: metadata.archived,
+          icon: metadata.icon,
 
-        // Parent information
-        parentId: metadata.parentId,
-        parentType: metadata.parentType,
+          // Parent information
+          parentId: metadata.parentId,
+          parentType: metadata.parentType,
 
-        // Chunk-specific metadata
-        chunkIndex: index,
-        totalChunks: semanticGroups.length,
-        chunkSize: group.content.length,
-        contentFingerprint: group.content.substring(0, 150),
+          // Chunk-specific metadata
+          chunkIndex: index,
+          totalChunks: semanticGroups.length,
+          chunkSize: group.content.length,
+          contentFingerprint: group.content.substring(0, 150),
 
-        // CRITICAL NEW METADATA (Phase 2 & 3)
-        block_type: group.category, // "heading_group", "list", "code", "table", "callout"
-        heading_path: group.headingPath, // ["Finance", "Invoices", "Approval Rules"]
-        block_types_in_chunk: group.blockTypes, // ["heading_2", "paragraph", "bulleted_list_item"]
+          // CRITICAL NEW METADATA (Phase 2 & 3)
+          block_type: group.category, // "heading_group", "list", "code", "table", "callout"
+          heading_path: group.headingPath, // ["Finance", "Invoices", "Approval Rules"]
+          block_types_in_chunk: group.blockTypes, // ["heading_2", "paragraph", "bulleted_list_item"]
 
-        // Size metadata
-        estimatedTokens: group.tokens,
-        blockCount: group.blockCount,
-        startBlockIndex: group.startIndex,
+          // Size metadata
+          estimatedTokens: group.tokens,
+          blockCount: group.blockCount,
+          startBlockIndex: group.startIndex,
 
-        // Special handling flags (Phase 3)
-        is_code: group.category === 'code' || group.category === 'code_split',
-        is_table: group.category === 'table' || group.category === 'table_split',
-        is_list: group.category === 'list' || group.category === 'list_split',
-        is_callout: group.category === 'callout' || group.category === 'callout_split',
-        code_language: group.codeLanguage || null,
+          // Special handling flags (Phase 3)
+          is_code: group.category === 'code' || group.category === 'code_split',
+          is_table: group.category === 'table' || group.category === 'table_split',
+          is_list: group.category === 'list' || group.category === 'list_split',
+          is_callout: group.category === 'callout' || group.category === 'callout_split',
+          code_language: group.codeLanguage || null,
 
-        // Inter-chunk overlap tracking (P4)
-        has_overlap: !!group.overlapBefore,
-        overlap_chars: group.overlapBefore?.length || 0,
+          // Inter-chunk overlap tracking (P4)
+          has_overlap: !!group.overlapBefore,
+          overlap_chars: group.overlapBefore?.length || 0,
 
-        // Oversized chunk split tracking
-        is_oversized_split: group.isOversizedSplit || false,
-        original_tokens: group.originalTokens || null,
-        split_index: group.splitIndex !== undefined ? group.splitIndex : null,
-        split_total: group.splitTotal || null,
+          // Oversized chunk split tracking
+          is_oversized_split: group.isOversizedSplit || false,
+          original_tokens: group.originalTokens || null,
+          split_index: group.splitIndex !== undefined ? group.splitIndex : null,
+          split_total: group.splitTotal || null,
 
-        // Legacy compatibility
-        section:
-          group.headingPath.length > 0
-            ? group.headingPath[group.headingPath.length - 1]
-            : 'General',
-        positionPercent: `${(((index + 1) / processedGroups.length) * 100).toFixed(1)}%`,
-      },
-    };
+          // Legacy compatibility
+          section:
+            group.headingPath.length > 0
+              ? group.headingPath[group.headingPath.length - 1]
+              : 'General',
+          positionPercent: `${(((index + 1) / processedGroups.length) * 100).toFixed(1)}%`,
+        },
+      };
     });
 
     logger.info(`Semantic chunking complete`, {
@@ -356,9 +351,9 @@ export const loadAndSplitNotionDocument = async (content, metadata = {}) => {
         ...split,
         metadata: {
           ...split.metadata,
-          // Notion-specific metadata
+          // Source-specific metadata
           workspaceId: metadata.workspaceId,
-          sourceType: 'notion',
+          sourceType: metadata.sourceType || 'notion',
           sourceId: metadata.sourceId,
           documentTitle: metadata.title,
           documentUrl: metadata.url,
@@ -413,11 +408,13 @@ export const loadAndSplitNotionDocument = async (content, metadata = {}) => {
 export const prepareNotionDocumentForIndexing = async (
   notionDocument,
   workspaceId,
-  blocks = null
+  blocks = null,
+  sourceType = 'notion'
 ) => {
   try {
     const metadata = {
       workspaceId,
+      sourceType,
       sourceId: notionDocument.sourceId,
       title: notionDocument.title,
       url: notionDocument.url,

--- a/backend/models/DocumentSource.js
+++ b/backend/models/DocumentSource.js
@@ -17,7 +17,7 @@ const documentSourceSchema = new mongoose.Schema(
     },
     sourceType: {
       type: String,
-      enum: ['notion', 'gdrive', 'confluence', 'pdf', 'text'],
+      enum: ['notion', 'gdrive', 'confluence', 'github', 'jira', 'slack', 'pdf', 'text', 'custom'],
       required: true,
       index: true,
     },
@@ -175,7 +175,11 @@ documentSourceSchema.methods.addError = function (error, retryCount = 0) {
 };
 
 // Method to update sync status
-documentSourceSchema.methods.markAsSynced = function (vectorStoreIds = [], chunkCount = 0, embeddingMetadata = null) {
+documentSourceSchema.methods.markAsSynced = function (
+  vectorStoreIds = [],
+  chunkCount = 0,
+  embeddingMetadata = null
+) {
   this.syncStatus = 'synced';
   this.lastSyncedAt = new Date();
   this.vectorStoreIds = vectorStoreIds;

--- a/backend/models/MCPDataSource.js
+++ b/backend/models/MCPDataSource.js
@@ -1,0 +1,144 @@
+/**
+ * MCPDataSource Model
+ * Registry of external data sources connected via the Model Context Protocol (MCP).
+ * Each record represents one MCP server endpoint that exposes documents for indexing.
+ *
+ * Role in the pipeline:
+ *   MCPDataSource (connection config)
+ *     → MCPDataSourceAdapter (MCP client, fetches docs)
+ *       → documentIndexQueue (BullMQ)
+ *         → documentIndexWorker (chunks + embeds into Qdrant)
+ */
+
+import mongoose from 'mongoose';
+import { createEncryptionPlugin } from '../utils/security/fieldEncryption.js';
+
+const mcpDataSourceSchema = new mongoose.Schema(
+  {
+    workspaceId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+
+    /** Human-readable label shown in the UI, e.g. "Confluence - Engineering Wiki" */
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: [120, 'Name cannot exceed 120 characters'],
+    },
+
+    /**
+     * The semantic type of content this MCP server exposes.
+     * Stored on DocumentSource records and in Qdrant chunk metadata so that
+     * filters and citations show the correct source type.
+     */
+    sourceType: {
+      type: String,
+      enum: ['confluence', 'gdrive', 'github', 'jira', 'slack', 'custom'],
+      required: true,
+    },
+
+    /**
+     * Full HTTP URL of the MCP server's StreamableHTTP endpoint.
+     * Example: https://mcp.company.internal/confluence
+     */
+    serverUrl: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+
+    /**
+     * Bearer token used to authenticate requests to the MCP server.
+     * Encrypted at rest via fieldEncryption plugin (AES-GCM).
+     */
+    authToken: {
+      type: String,
+    },
+
+    syncStatus: {
+      type: String,
+      enum: ['active', 'syncing', 'error', 'paused', 'pending'],
+      default: 'pending',
+      index: true,
+    },
+
+    syncSettings: {
+      autoSync: { type: Boolean, default: false },
+      syncIntervalHours: { type: Number, default: 24, min: 1, max: 168 },
+    },
+
+    lastSyncedAt: { type: Date },
+    lastSyncJobId: { type: String },
+
+    stats: {
+      totalDocuments: { type: Number, default: 0 },
+      lastSyncDurationMs: { type: Number },
+      documentsIndexed: { type: Number, default: 0 },
+      documentsSkipped: { type: Number, default: 0 },
+      documentsErrored: { type: Number, default: 0 },
+    },
+
+    errorLog: {
+      type: [
+        {
+          timestamp: { type: Date, default: Date.now },
+          error: {
+            type: String,
+            maxlength: [2000, 'Error message cannot exceed 2000 characters'],
+          },
+        },
+      ],
+      validate: {
+        validator: (arr) => arr.length <= 10,
+        message: 'Error log cannot exceed 10 entries',
+      },
+    },
+  },
+  { timestamps: true }
+);
+
+// One workspace can have multiple MCP sources, but each server URL must be unique per workspace
+mcpDataSourceSchema.index({ workspaceId: 1, serverUrl: 1 }, { unique: true });
+mcpDataSourceSchema.index({ workspaceId: 1, syncStatus: 1 });
+
+/** Append an error to the capped log */
+mcpDataSourceSchema.methods.addError = function (error) {
+  const msg = typeof error === 'string' ? error : error?.message || String(error);
+  const truncated = msg.length > 2000 ? msg.substring(0, 1997) + '...' : msg;
+
+  this.errorLog.push({ timestamp: new Date(), error: truncated });
+  if (this.errorLog.length > 10) {
+    this.errorLog = this.errorLog.slice(-10);
+  }
+
+  this.syncStatus = 'error';
+  return this.save();
+};
+
+/** Mark sync as started */
+mcpDataSourceSchema.methods.markSyncing = function (jobId) {
+  this.syncStatus = 'syncing';
+  this.lastSyncJobId = jobId;
+  return this.save();
+};
+
+/** Mark sync as completed with final stats */
+mcpDataSourceSchema.methods.markSynced = function (stats = {}) {
+  this.syncStatus = 'active';
+  this.lastSyncedAt = new Date();
+  if (stats.totalDocuments !== undefined) this.stats.totalDocuments = stats.totalDocuments;
+  if (stats.documentsIndexed !== undefined) this.stats.documentsIndexed = stats.documentsIndexed;
+  if (stats.documentsSkipped !== undefined) this.stats.documentsSkipped = stats.documentsSkipped;
+  if (stats.documentsErrored !== undefined) this.stats.documentsErrored = stats.documentsErrored;
+  if (stats.durationMs !== undefined) this.stats.lastSyncDurationMs = stats.durationMs;
+  return this.save();
+};
+
+// Encrypt the authToken at rest
+mcpDataSourceSchema.plugin(createEncryptionPlugin(['authToken']));
+
+export const MCPDataSource = mongoose.model('MCPDataSource', mcpDataSourceSchema);
+export default MCPDataSource;

--- a/backend/package.json
+++ b/backend/package.json
@@ -42,6 +42,7 @@
     "@langchain/ollama": "^1.1.0",
     "@langchain/openai": "^1.2.1",
     "@langchain/qdrant": "^1.0.1",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@notionhq/client": "^2.3.0",
     "axios": "^1.13.2",
     "bcryptjs": "^3.0.3",

--- a/backend/routes/mcpDataSourceRoutes.js
+++ b/backend/routes/mcpDataSourceRoutes.js
@@ -1,0 +1,47 @@
+/**
+ * MCP Data Source Routes
+ *
+ * All routes require authentication.
+ * Workspace isolation is enforced by the controller via req.user.workspaceId.
+ *
+ * POST   /api/v1/mcp-sources                  Register a new MCP source
+ * GET    /api/v1/mcp-sources                  List all MCP sources for the workspace
+ * GET    /api/v1/mcp-sources/:id              Get a single MCP source
+ * PATCH  /api/v1/mcp-sources/:id              Update connection settings / sync config
+ * DELETE /api/v1/mcp-sources/:id              Remove MCP source + soft-delete its docs
+ * POST   /api/v1/mcp-sources/test-connection  Test connectivity without persisting
+ * POST   /api/v1/mcp-sources/:id/sync         Trigger a sync job
+ * GET    /api/v1/mcp-sources/:id/stats        Document counts + sync stats
+ */
+
+import { Router } from 'express';
+import { authenticate } from '../middleware/auth.js';
+import {
+  registerSource,
+  listSources,
+  getSource,
+  updateSource,
+  deleteSource,
+  triggerSync,
+  testConnection,
+  getStats,
+} from '../controllers/mcpDataSourceController.js';
+
+const router = Router();
+
+// All routes require a valid session
+router.use(authenticate);
+
+// Connection test — no :id param so must come before /:id routes
+router.post('/test-connection', testConnection);
+
+// Collection routes
+router.route('/').get(listSources).post(registerSource);
+
+// Member routes
+router.route('/:id').get(getSource).patch(updateSource).delete(deleteSource);
+
+router.post('/:id/sync', triggerSync);
+router.get('/:id/stats', getStats);
+
+export default router;

--- a/backend/services/mcpDataSourceService.js
+++ b/backend/services/mcpDataSourceService.js
@@ -1,0 +1,225 @@
+/**
+ * MCP Data Source Service
+ *
+ * Orchestrates CRUD and sync operations for MCP-connected data sources.
+ * Controllers call this; it talks to the database and the job queue.
+ */
+
+import { MCPDataSource } from '../models/MCPDataSource.js';
+import { DocumentSource } from '../models/DocumentSource.js';
+import { mcpSyncQueue } from '../config/queue.js';
+import { MCPDataSourceAdapter } from '../adapters/MCPDataSourceAdapter.js';
+import { AppError } from '../utils/index.js';
+import logger from '../config/logger.js';
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a new MCP data source for a workspace.
+ * Validates connectivity before persisting.
+ *
+ * @param {string} workspaceId
+ * @param {Object} data - { name, sourceType, serverUrl, authToken?, syncSettings? }
+ * @returns {Promise<MCPDataSource>}
+ */
+export async function registerMCPDataSource(workspaceId, data) {
+  const { name, sourceType, serverUrl, authToken, syncSettings } = data;
+
+  // Check for duplicate
+  const existing = await MCPDataSource.findOne({ workspaceId, serverUrl });
+  if (existing) {
+    throw new AppError('An MCP data source with this server URL already exists.', 409);
+  }
+
+  // Probe the server before saving
+  const adapter = new MCPDataSourceAdapter(serverUrl, authToken, sourceType);
+  try {
+    await adapter.authenticate();
+    const info = await adapter.getWorkspaceInfo();
+    logger.info('MCP server probe successful', {
+      service: 'mcp-service',
+      serverUrl,
+      sourceType,
+      info,
+    });
+  } catch (err) {
+    throw new AppError(`Cannot connect to MCP server at ${serverUrl}: ${err.message}`, 422);
+  } finally {
+    await adapter.disconnect().catch(() => {});
+  }
+
+  const mcpSource = await MCPDataSource.create({
+    workspaceId,
+    name,
+    sourceType,
+    serverUrl,
+    authToken: authToken || undefined,
+    syncSettings: syncSettings || {},
+  });
+
+  return mcpSource;
+}
+
+/**
+ * List all MCP data sources for a workspace.
+ * Strips the encrypted authToken from the response.
+ */
+export async function listMCPDataSources(workspaceId) {
+  const sources = await MCPDataSource.find({ workspaceId })
+    .select('-authToken')
+    .sort({ createdAt: -1 });
+  return sources;
+}
+
+/**
+ * Get a single MCP data source by ID (workspace-scoped).
+ */
+export async function getMCPDataSource(workspaceId, mcpDataSourceId) {
+  const source = await MCPDataSource.findOne({ _id: mcpDataSourceId, workspaceId }).select(
+    '-authToken'
+  );
+  if (!source) throw new AppError('MCP data source not found.', 404);
+  return source;
+}
+
+/**
+ * Update connection settings or sync configuration.
+ * Triggers a connection probe if serverUrl or authToken changes.
+ */
+export async function updateMCPDataSource(workspaceId, mcpDataSourceId, updates) {
+  const source = await MCPDataSource.findOne({ _id: mcpDataSourceId, workspaceId });
+  if (!source) throw new AppError('MCP data source not found.', 404);
+
+  const urlChanged = updates.serverUrl && updates.serverUrl !== source.serverUrl;
+  const tokenChanged = updates.authToken !== undefined;
+
+  if (urlChanged || tokenChanged) {
+    const newUrl = updates.serverUrl ?? source.serverUrl;
+    const newToken = tokenChanged ? updates.authToken : source.get('authToken');
+    const adapter = new MCPDataSourceAdapter(newUrl, newToken, source.sourceType);
+    try {
+      await adapter.authenticate();
+    } catch (err) {
+      throw new AppError(`Cannot connect to MCP server at ${newUrl}: ${err.message}`, 422);
+    } finally {
+      await adapter.disconnect().catch(() => {});
+    }
+  }
+
+  const allowed = ['name', 'serverUrl', 'authToken', 'syncSettings', 'syncStatus'];
+  for (const key of allowed) {
+    if (updates[key] !== undefined) source[key] = updates[key];
+  }
+
+  return source.save();
+}
+
+/**
+ * Remove an MCP data source and its associated DocumentSource records.
+ */
+export async function deleteMCPDataSource(workspaceId, mcpDataSourceId) {
+  const source = await MCPDataSource.findOne({ _id: mcpDataSourceId, workspaceId });
+  if (!source) throw new AppError('MCP data source not found.', 404);
+
+  // Soft-delete all indexed documents from this source
+  await DocumentSource.updateMany(
+    { workspaceId, sourceType: source.sourceType },
+    { syncStatus: 'deleted' }
+  );
+
+  await MCPDataSource.deleteOne({ _id: mcpDataSourceId });
+
+  logger.info('MCPDataSource deleted', {
+    service: 'mcp-service',
+    mcpDataSourceId,
+    workspaceId,
+    sourceType: source.sourceType,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sync control
+// ---------------------------------------------------------------------------
+
+/**
+ * Enqueue a sync job for the given MCP data source.
+ *
+ * @param {string} workspaceId
+ * @param {string} mcpDataSourceId
+ * @param {'full'|'incremental'} syncType
+ * @param {'auto'|'manual'} triggeredBy
+ * @returns {Promise<{ jobId: string }>}
+ */
+export async function triggerMCPSync(
+  workspaceId,
+  mcpDataSourceId,
+  syncType = 'full',
+  triggeredBy = 'manual'
+) {
+  const source = await MCPDataSource.findOne({ _id: mcpDataSourceId, workspaceId });
+  if (!source) throw new AppError('MCP data source not found.', 404);
+
+  if (source.syncStatus === 'syncing') {
+    throw new AppError('A sync is already in progress for this source.', 409);
+  }
+  if (source.syncStatus === 'paused') {
+    throw new AppError('This MCP data source is paused. Resume it before syncing.', 409);
+  }
+
+  const job = await mcpSyncQueue.add(
+    'mcpSync',
+    { mcpDataSourceId, workspaceId, syncType, triggeredBy },
+    { jobId: `mcp-sync-${mcpDataSourceId}-${Date.now()}` }
+  );
+
+  logger.info('MCP sync job enqueued', {
+    service: 'mcp-service',
+    jobId: job.id,
+    mcpDataSourceId,
+    workspaceId,
+    syncType,
+  });
+
+  return { jobId: job.id };
+}
+
+/**
+ * Test connectivity to the remote MCP server without persisting anything.
+ */
+export async function testMCPConnection(serverUrl, authToken, sourceType = 'custom') {
+  const adapter = new MCPDataSourceAdapter(serverUrl, authToken, sourceType);
+  try {
+    await adapter.authenticate();
+    const info = await adapter.getWorkspaceInfo();
+    return { ok: true, sourceInfo: info };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  } finally {
+    await adapter.disconnect().catch(() => {});
+  }
+}
+
+/**
+ * Return document counts indexed from an MCP source.
+ */
+export async function getMCPSourceStats(workspaceId, mcpDataSourceId) {
+  const source = await getMCPDataSource(workspaceId, mcpDataSourceId);
+
+  const counts = await DocumentSource.aggregate([
+    { $match: { workspaceId, sourceType: source.sourceType } },
+    { $group: { _id: '$syncStatus', count: { $sum: 1 } } },
+  ]);
+
+  const byStatus = Object.fromEntries(counts.map((c) => [c._id, c.count]));
+
+  return {
+    source: source.name,
+    sourceType: source.sourceType,
+    syncStatus: source.syncStatus,
+    lastSyncedAt: source.lastSyncedAt,
+    stats: source.stats,
+    documents: byStatus,
+  };
+}

--- a/backend/workers/index.js
+++ b/backend/workers/index.js
@@ -1,5 +1,6 @@
 import './notionSyncWorker.js';
 import './documentIndexWorker.js';
+import './mcpSyncWorker.js';
 import logger from '../config/logger.js';
 import { disconnectRedis } from '../config/redis.js';
 import { closeQueues } from '../config/queue.js';
@@ -14,6 +15,7 @@ logger.info('='.repeat(60));
 logger.info('Active workers:');
 logger.info('  - Notion Sync Worker (concurrency: 2)');
 logger.info(`  - Document Index Worker (concurrency: ${indexConcurrency}) [OPTIMIZED]`);
+logger.info('  - MCP Sync Worker (concurrency: 2)');
 logger.info(`  - Batch size: ${batchSize} documents per batch`);
 logger.info(`  - API rate limit: ${process.env.NOTION_API_RATE_LIMIT || 2} req/sec`);
 logger.info('='.repeat(60));

--- a/backend/workers/mcpSyncWorker.js
+++ b/backend/workers/mcpSyncWorker.js
@@ -1,0 +1,394 @@
+/**
+ * MCP Sync Worker
+ *
+ * Mirrors the pattern of notionSyncWorker.js but operates on any data source
+ * connected via the Model Context Protocol (MCP).
+ *
+ * Job shape:
+ *   {
+ *     mcpDataSourceId: string,   // MCPDataSource._id
+ *     workspaceId:     string,
+ *     syncType:        'full' | 'incremental',
+ *     triggeredBy:     'auto' | 'manual',
+ *   }
+ *
+ * Pipeline:
+ *   1. Load MCPDataSource record (connection config + decrypted token)
+ *   2. Connect MCPDataSourceAdapter to the remote MCP server
+ *   3. Determine which documents to sync (full vs incremental)
+ *   4. For each document: fetch content, check hash, enqueue to documentIndexQueue
+ *   5. Detect and soft-delete removed documents
+ *   6. Update MCPDataSource with stats
+ */
+
+import { Worker } from 'bullmq';
+import { redisConnection } from '../config/redis.js';
+import { documentIndexQueue, mcpSyncQueue } from '../config/queue.js';
+import { MCPDataSource } from '../models/MCPDataSource.js';
+import { DocumentSource } from '../models/DocumentSource.js';
+import { MCPDataSourceAdapter } from '../adapters/MCPDataSourceAdapter.js';
+import logger from '../config/logger.js';
+import { connectDB } from '../config/database.js';
+import { setupDLQListener } from '../services/deadLetterQueue.js';
+import {
+  emitSyncStart,
+  emitSyncProgress,
+  emitSyncPageFetched,
+  emitSyncComplete,
+  emitSyncError,
+} from '../services/realtimeEvents.js';
+
+const BATCH_SIZE = parseInt(process.env.MCP_SYNC_BATCH_SIZE) || 20;
+const MCP_WORKER_CONCURRENCY = parseInt(process.env.MCP_WORKER_CONCURRENCY) || 2;
+
+// ---------------------------------------------------------------------------
+// Main job processor
+// ---------------------------------------------------------------------------
+
+async function processMCPSyncJob(job) {
+  const { mcpDataSourceId, workspaceId, syncType = 'full', triggeredBy = 'auto' } = job.data;
+
+  const startTime = Date.now();
+
+  logger.info('MCP sync job started', {
+    service: 'mcp-sync',
+    jobId: job.id,
+    mcpDataSourceId,
+    workspaceId,
+    syncType,
+    triggeredBy,
+  });
+
+  // ── 1. Load connection config ──────────────────────────────────────────────
+  const mcpSource = await MCPDataSource.findById(mcpDataSourceId);
+  if (!mcpSource) {
+    throw new Error(`MCPDataSource not found: ${mcpDataSourceId}`);
+  }
+  if (mcpSource.workspaceId !== workspaceId) {
+    throw new Error('MCPDataSource workspace mismatch');
+  }
+  if (mcpSource.syncStatus === 'syncing') {
+    logger.warn('MCP sync already in progress, skipping', {
+      service: 'mcp-sync',
+      mcpDataSourceId,
+    });
+    return { aborted: true, reason: 'already_syncing' };
+  }
+
+  await mcpSource.markSyncing(job.id);
+  emitSyncStart(workspaceId, triggeredBy, {
+    jobId: job.id,
+    syncType,
+    sourceName: mcpSource.name,
+  });
+
+  // ── 2. Connect adapter ─────────────────────────────────────────────────────
+  // Decrypt the authToken — fieldEncryption plugin stores the decrypted value
+  // on the plain model instance via the virtual getter pattern.
+  const plainToken = mcpSource.get('authToken');
+  const adapter = new MCPDataSourceAdapter(mcpSource.serverUrl, plainToken, mcpSource.sourceType);
+
+  try {
+    await adapter.authenticate();
+  } catch (connErr) {
+    await mcpSource.addError(connErr);
+    emitSyncError(workspaceId, { error: connErr.message, sourceName: mcpSource.name });
+    throw connErr;
+  }
+
+  const stats = {
+    total: 0,
+    indexed: 0,
+    skipped: 0,
+    errored: 0,
+    deleted: 0,
+  };
+
+  try {
+    // ── 3. Determine documents to sync ───────────────────────────────────────
+    let docsToSync;
+
+    if (syncType === 'incremental' && mcpSource.lastSyncedAt) {
+      const changes = await adapter.detectChanges(mcpSource.lastSyncedAt);
+      const toDelete = changes.filter((c) => c.changeType === 'deleted').map((c) => c.id);
+      const toSync = changes.filter((c) => c.changeType !== 'deleted').map((c) => ({ id: c.id }));
+
+      docsToSync = toSync;
+
+      // Soft-delete removed documents
+      if (toDelete.length > 0) {
+        await _handleDeletedDocuments(workspaceId, mcpSource.sourceType, toDelete);
+        stats.deleted = toDelete.length;
+      }
+    } else {
+      // Full sync: list everything
+      const allDocs = await adapter.listDocuments();
+      docsToSync = allDocs;
+
+      // Detect documents that exist in DB but are gone from the source
+      const sourceIds = allDocs.map((d) => d.id);
+      await _detectAndSoftDeleteRemovedDocs(workspaceId, mcpSource.sourceType, sourceIds);
+    }
+
+    stats.total = docsToSync.length;
+    await setJobProgress(job, { phase: 'fetching', total: stats.total, synced: 0 });
+    emitSyncProgress(workspaceId, {
+      jobId: job.id,
+      totalDocuments: stats.total,
+      syncedDocuments: 0,
+      sourceName: mcpSource.name,
+    });
+
+    // ── 4. Process in batches ─────────────────────────────────────────────────
+    for (let i = 0; i < docsToSync.length; i += BATCH_SIZE) {
+      const batch = docsToSync.slice(i, i + BATCH_SIZE);
+
+      await Promise.allSettled(
+        batch.map(async (docMeta) => {
+          try {
+            await _processDocument(adapter, workspaceId, mcpSource, docMeta, stats);
+          } catch (docErr) {
+            stats.errored++;
+            logger.error('MCP document processing failed', {
+              service: 'mcp-sync',
+              docId: docMeta.id,
+              workspaceId,
+              error: docErr.message,
+            });
+          }
+        })
+      );
+
+      await setJobProgress(job, {
+        phase: 'fetching',
+        total: stats.total,
+        synced: stats.indexed + stats.skipped,
+      });
+      emitSyncProgress(workspaceId, {
+        jobId: job.id,
+        totalDocuments: stats.total,
+        syncedDocuments: stats.indexed + stats.skipped,
+        sourceName: mcpSource.name,
+      });
+    }
+
+    // ── 5. Finalise ──────────────────────────────────────────────────────────
+    const durationMs = Date.now() - startTime;
+    await mcpSource.markSynced({
+      totalDocuments: stats.total,
+      documentsIndexed: stats.indexed,
+      documentsSkipped: stats.skipped,
+      documentsErrored: stats.errored,
+      durationMs,
+    });
+
+    emitSyncComplete(workspaceId, {
+      jobId: job.id,
+      syncType,
+      sourceName: mcpSource.name,
+      stats,
+      durationMs,
+    });
+
+    logger.info('MCP sync job completed', {
+      service: 'mcp-sync',
+      jobId: job.id,
+      mcpDataSourceId,
+      workspaceId,
+      ...stats,
+      durationMs,
+    });
+
+    return { success: true, stats, durationMs };
+  } catch (error) {
+    await mcpSource.addError(error).catch(() => {});
+    emitSyncError(workspaceId, { error: error.message, sourceName: mcpSource.name });
+    throw error;
+  } finally {
+    await adapter.disconnect().catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch a single document from the MCP server, check its content hash,
+ * and enqueue to documentIndexQueue only if it has changed.
+ */
+async function _processDocument(adapter, workspaceId, mcpSource, docMeta, stats) {
+  const docId = docMeta.id;
+
+  // Fetch full document content from MCP server
+  const documentContent = await adapter.getDocumentContent(docId);
+
+  if (!documentContent.content || documentContent.content.trim().length < 50) {
+    logger.debug('MCP document skipped: content too short', {
+      service: 'mcp-sync',
+      docId,
+    });
+    stats.skipped++;
+    return;
+  }
+
+  // Check if content changed since last sync
+  const existing = await DocumentSource.findOne({
+    workspaceId,
+    sourceId: docId,
+    sourceType: mcpSource.sourceType,
+  });
+
+  if (existing?.contentHash === documentContent.contentHash && existing.syncStatus === 'synced') {
+    stats.skipped++;
+    emitSyncPageFetched(workspaceId, {
+      pageId: docId,
+      title: documentContent.title,
+      status: 'skipped',
+    });
+    return;
+  }
+
+  const operation = existing ? 'update' : 'add';
+
+  // Upsert DocumentSource registry record
+  await DocumentSource.findOneAndUpdate(
+    { workspaceId, sourceId: docId },
+    {
+      workspaceId,
+      sourceId: docId,
+      sourceType: mcpSource.sourceType,
+      documentType: 'page',
+      title: documentContent.title,
+      url: documentContent.url,
+      parentId: documentContent.parentId,
+      contentHash: documentContent.contentHash,
+      lastModifiedInSource: documentContent.lastModified
+        ? new Date(documentContent.lastModified)
+        : new Date(),
+      syncStatus: 'pending',
+      metadata: {
+        author: documentContent.author,
+        createdAt: documentContent.createdAt ? new Date(documentContent.createdAt) : new Date(),
+        properties: documentContent.properties,
+      },
+    },
+    { upsert: true, new: true }
+  );
+
+  // Enqueue for embedding + vector indexing
+  await documentIndexQueue.add(
+    'indexDocument',
+    {
+      workspaceId,
+      sourceId: docId,
+      sourceType: mcpSource.sourceType,
+      documentContent,
+      operation,
+      skipM3: true, // Run M3 enrichment separately after bulk sync
+    },
+    { priority: 10 }
+  );
+
+  stats.indexed++;
+  emitSyncPageFetched(workspaceId, {
+    pageId: docId,
+    title: documentContent.title,
+    status: 'queued',
+  });
+}
+
+/** Soft-delete documents that are explicitly flagged as deleted by the MCP server */
+async function _handleDeletedDocuments(workspaceId, sourceType, deletedIds) {
+  for (const sourceId of deletedIds) {
+    const doc = await DocumentSource.findOne({ workspaceId, sourceId, sourceType });
+    if (doc) {
+      await documentIndexQueue.add('indexDocument', {
+        workspaceId,
+        sourceId,
+        sourceType,
+        operation: 'delete',
+        vectorStoreIds: doc.vectorStoreIds ?? [],
+      });
+    }
+  }
+}
+
+/** Compare current source document list against DB to find orphans */
+async function _detectAndSoftDeleteRemovedDocs(workspaceId, sourceType, liveIds) {
+  const liveSet = new Set(liveIds);
+  const dbDocs = await DocumentSource.find({
+    workspaceId,
+    sourceType,
+    syncStatus: { $ne: 'deleted' },
+  }).select('sourceId vectorStoreIds');
+
+  const removedIds = dbDocs.filter((d) => !liveSet.has(d.sourceId)).map((d) => d.sourceId);
+
+  if (removedIds.length > 0) {
+    await _handleDeletedDocuments(workspaceId, sourceType, removedIds);
+    logger.info('MCP sync: queued deletion of removed documents', {
+      service: 'mcp-sync',
+      workspaceId,
+      count: removedIds.length,
+    });
+  }
+}
+
+async function setJobProgress(job, data) {
+  try {
+    await job.updateProgress(data);
+  } catch (_) {
+    // non-critical
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Worker registration
+// ---------------------------------------------------------------------------
+
+export const mcpSyncWorker = new Worker('mcpSync', processMCPSyncJob, {
+  connection: redisConnection,
+  concurrency: MCP_WORKER_CONCURRENCY,
+  lockDuration: 600000, // 10 minutes
+  lockRenewTime: 240000, // Renew every 4 minutes
+  maxStalledCount: 3,
+  stalledInterval: 300000,
+});
+
+mcpSyncWorker.on('completed', (job, result) => {
+  logger.info(`MCP sync job ${job.id} completed`, { result });
+});
+
+mcpSyncWorker.on('failed', (job, err) => {
+  logger.error(`MCP sync job ${job.id} failed:`, err);
+});
+
+mcpSyncWorker.on('error', (err) => {
+  logger.error('MCP sync worker error:', err);
+});
+
+setupDLQListener(mcpSyncWorker, 'mcpSync');
+
+(async () => {
+  await connectDB();
+  logger.info('MCP sync worker started', {
+    concurrency: MCP_WORKER_CONCURRENCY,
+    batchSize: BATCH_SIZE,
+  });
+})();
+
+export async function gracefulShutdown() {
+  logger.info('MCP sync worker shutting down...');
+  try {
+    await mcpSyncWorker.close();
+    logger.info('MCP sync worker shutdown complete');
+  } catch (err) {
+    logger.error('Error during MCP sync worker shutdown', { error: err.message });
+  }
+}
+
+process.on('SIGTERM', gracefulShutdown);
+process.on('SIGINT', gracefulShutdown);
+
+export default mcpSyncWorker;

--- a/mcp-servers/example-confluence/index.js
+++ b/mcp-servers/example-confluence/index.js
@@ -1,0 +1,291 @@
+/**
+ * Retrieva MCP Server — Confluence Example
+ *
+ * This is a reference implementation that shows how to expose a data source
+ * (Confluence in this case) to Retrieva using the Model Context Protocol.
+ *
+ * Retrieva connects to this server as an MCP client and calls the tools below
+ * to discover and fetch documents for indexing into its vector store.
+ *
+ * ──────────────────────────────────────────────────────────────────────────────
+ * CONTRACT: Tools this server must expose
+ * ──────────────────────────────────────────────────────────────────────────────
+ *
+ *  get_source_info   → { name, type, totalDocuments, description }
+ *  list_documents    → [{ id, title, url, lastModified, type, parentId? }]
+ *  fetch_document    → { id, title, url, content (markdown), contentHash,
+ *                        createdAt, lastModified, author?, properties? }
+ *  get_changes       → [{ id, changeType: 'created'|'modified'|'deleted' }]
+ *                       (argument: { since: ISO-8601 string })
+ *
+ * All tools return JSON encoded as a text MCP content block.
+ *
+ * ──────────────────────────────────────────────────────────────────────────────
+ * Configuration (environment variables)
+ * ──────────────────────────────────────────────────────────────────────────────
+ *  PORT                     HTTP port (default 3100)
+ *  MCP_AUTH_TOKEN           Secret that Retrieva must send as Bearer token
+ *  CONFLUENCE_BASE_URL      e.g. https://company.atlassian.net
+ *  CONFLUENCE_USERNAME      Atlassian account email
+ *  CONFLUENCE_API_TOKEN     Atlassian API token (not password)
+ *  CONFLUENCE_SPACE_KEY     Space to expose (e.g. ENG). Omit for all spaces.
+ *
+ * ──────────────────────────────────────────────────────────────────────────────
+ * Usage
+ * ──────────────────────────────────────────────────────────────────────────────
+ *  npm install
+ *  MCP_AUTH_TOKEN=my-secret node index.js
+ *
+ * Then register in Retrieva:
+ *  POST /api/v1/mcp-sources
+ *  { "name": "Confluence - Engineering", "sourceType": "confluence",
+ *    "serverUrl": "http://localhost:3100/mcp", "authToken": "my-secret" }
+ */
+
+import express from 'express';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createHash } from 'crypto';
+import { z } from 'zod';
+
+const PORT = parseInt(process.env.PORT) || 3100;
+const AUTH_TOKEN = process.env.MCP_AUTH_TOKEN || null;
+
+// ---------------------------------------------------------------------------
+// Confluence API client (thin wrapper over the REST API v2)
+// ---------------------------------------------------------------------------
+
+const CONFLUENCE_BASE = process.env.CONFLUENCE_BASE_URL?.replace(/\/$/, '') ?? '';
+const CONFLUENCE_AUTH = Buffer.from(
+  `${process.env.CONFLUENCE_USERNAME}:${process.env.CONFLUENCE_API_TOKEN}`
+).toString('base64');
+const SPACE_KEY = process.env.CONFLUENCE_SPACE_KEY ?? null;
+
+async function confluenceFetch(path) {
+  const url = `${CONFLUENCE_BASE}/wiki/rest/api${path}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Basic ${CONFLUENCE_AUTH}`,
+      Accept: 'application/json',
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Confluence API error ${res.status}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+/** Convert Confluence storage format body to readable markdown (simplified). */
+function bodyToMarkdown(body) {
+  if (!body) return '';
+  const raw = body.storage?.value ?? body.view?.value ?? '';
+  // Strip HTML tags (good enough for searchable text; a real impl would use a proper parser)
+  return raw
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n\n')
+    .replace(/<\/h[1-6]>/gi, '\n')
+    .replace(/<li>/gi, '\n- ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function hashContent(content) {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// MCP Tool implementations
+// ---------------------------------------------------------------------------
+
+async function toolGetSourceInfo() {
+  let total = 0;
+  try {
+    const params = SPACE_KEY
+      ? `?spaceKey=${SPACE_KEY}&type=page&limit=1`
+      : '?type=page&limit=1';
+    const data = await confluenceFetch(`/content${params}`);
+    total = data.size ?? 0;
+  } catch (_) {
+    // non-critical
+  }
+
+  return {
+    name: SPACE_KEY ? `Confluence Space: ${SPACE_KEY}` : 'Confluence (all spaces)',
+    type: 'confluence',
+    totalDocuments: total,
+    description: `Confluence pages exposed via MCP from ${CONFLUENCE_BASE}`,
+  };
+}
+
+async function toolListDocuments() {
+  const results = [];
+  let start = 0;
+  const limit = 50;
+
+  while (true) {
+    const spaceFilter = SPACE_KEY ? `spaceKey=${SPACE_KEY}&` : '';
+    const data = await confluenceFetch(
+      `/content?${spaceFilter}type=page&status=current&expand=version,ancestors&start=${start}&limit=${limit}`
+    );
+
+    for (const page of data.results ?? []) {
+      results.push({
+        id: page.id,
+        title: page.title,
+        url: `${CONFLUENCE_BASE}/wiki${page._links?.webui ?? ''}`,
+        lastModified: page.version?.when ?? null,
+        type: 'page',
+        parentId: page.ancestors?.at(-1)?.id ?? null,
+      });
+    }
+
+    if (data.size < limit || !data._links?.next) break;
+    start += limit;
+  }
+
+  return results;
+}
+
+async function toolFetchDocument(documentId) {
+  const page = await confluenceFetch(
+    `/content/${documentId}?expand=body.storage,version,ancestors,space`
+  );
+
+  const content = bodyToMarkdown(page.body);
+
+  return {
+    id: page.id,
+    title: page.title,
+    url: `${CONFLUENCE_BASE}/wiki${page._links?.webui ?? ''}`,
+    content,
+    contentHash: hashContent(content),
+    createdAt: page.history?.createdDate ?? null,
+    lastModified: page.version?.when ?? null,
+    author: page.version?.by?.displayName ?? null,
+    parentId: page.ancestors?.at(-1)?.id ?? null,
+    parentType: page.ancestors?.length > 0 ? 'page' : 'space',
+    properties: {
+      spaceKey: page.space?.key,
+      spaceTitle: page.space?.name,
+      version: page.version?.number,
+    },
+  };
+}
+
+async function toolGetChanges(since) {
+  const sinceDate = since ? new Date(since) : new Date(0);
+  const changes = [];
+
+  const spaceFilter = SPACE_KEY ? `spaceKey=${SPACE_KEY}&` : '';
+  const data = await confluenceFetch(
+    `/content?${spaceFilter}type=page&status=current&expand=version&limit=100`
+  );
+
+  for (const page of data.results ?? []) {
+    const modifiedAt = page.version?.when ? new Date(page.version.when) : null;
+    if (modifiedAt && modifiedAt > sinceDate) {
+      changes.push({ id: page.id, changeType: 'modified' });
+    }
+  }
+
+  // Note: Confluence doesn't expose deletions via this API; a real impl would
+  // compare against the stored document list to detect removals.
+  return changes;
+}
+
+// ---------------------------------------------------------------------------
+// MCP Server setup
+// ---------------------------------------------------------------------------
+
+function createMCPServer() {
+  const server = new McpServer({
+    name: 'retrieva-confluence-mcp',
+    version: '1.0.0',
+  });
+
+  server.tool('get_source_info', 'Return metadata about this data source', {}, async () => {
+    const result = await toolGetSourceInfo();
+    return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+  });
+
+  server.tool(
+    'list_documents',
+    'List all available documents with lightweight metadata',
+    {},
+    async () => {
+      const result = await toolListDocuments();
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    }
+  );
+
+  server.tool(
+    'fetch_document',
+    'Fetch the full content of a single document by ID',
+    { document_id: z.string().describe('The document ID') },
+    async ({ document_id }) => {
+      const result = await toolFetchDocument(document_id);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    }
+  );
+
+  server.tool(
+    'get_changes',
+    'Return documents that changed since a given ISO-8601 timestamp',
+    { since: z.string().describe('ISO-8601 timestamp') },
+    async ({ since }) => {
+      const result = await toolGetChanges(since);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    }
+  );
+
+  return server;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP server with Bearer auth guard
+// ---------------------------------------------------------------------------
+
+const app = express();
+app.use(express.json());
+
+/** Middleware: enforce Bearer token if MCP_AUTH_TOKEN is set */
+function authGuard(req, res, next) {
+  if (!AUTH_TOKEN) return next();
+
+  const header = req.headers.authorization ?? '';
+  const token = header.startsWith('Bearer ') ? header.slice(7) : null;
+
+  if (token !== AUTH_TOKEN) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  next();
+}
+
+app.post('/mcp', authGuard, async (req, res) => {
+  const server = createMCPServer();
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => crypto.randomUUID(),
+  });
+
+  res.on('close', () => transport.close());
+
+  await server.connect(transport);
+  await transport.handleRequest(req, res, req.body);
+});
+
+// Health check (no auth required)
+app.get('/health', (_req, res) => {
+  res.json({ ok: true, service: 'retrieva-mcp-confluence' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Retrieva MCP Confluence server running on http://localhost:${PORT}/mcp`);
+  console.log(`Auth: ${AUTH_TOKEN ? 'Bearer token required' : 'DISABLED (set MCP_AUTH_TOKEN)'}`);
+  console.log(`Source: ${CONFLUENCE_BASE || '(CONFLUENCE_BASE_URL not set)'}`);
+});

--- a/mcp-servers/example-confluence/package.json
+++ b/mcp-servers/example-confluence/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "retrieva-mcp-confluence-example",
+  "version": "1.0.0",
+  "description": "Reference MCP server that exposes Confluence content to Retrieva",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "node --watch index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "express": "^4.19.2"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@langchain/ollama": "^1.1.0",
         "@langchain/openai": "^1.2.1",
         "@langchain/qdrant": "^1.0.1",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "@notionhq/client": "^2.3.0",
         "axios": "^1.13.2",
         "bcryptjs": "^3.0.3",
@@ -1008,17 +1009,6 @@
         "@types/webidl-conversions": "*"
       }
     },
-    "backend/node_modules/accepts": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "backend/node_modules/afinn-165": {
       "version": "1.0.4",
       "license": "MIT",
@@ -1101,28 +1091,6 @@
         "bcrypt": "bin/bcrypt"
       }
     },
-    "backend/node_modules/body-parser": {
-      "version": "2.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "backend/node_modules/bson": {
       "version": "7.0.0",
       "license": "Apache-2.0",
@@ -1182,13 +1150,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "backend/node_modules/bytes": {
-      "version": "3.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "backend/node_modules/chalk": {
@@ -1304,31 +1265,6 @@
         "simple-wcswidth": "^1.1.2"
       }
     },
-    "backend/node_modules/content-disposition": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "backend/node_modules/content-type": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "backend/node_modules/cookie": {
-      "version": "0.7.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "backend/node_modules/cookie-parser": {
       "version": "1.4.7",
       "license": "MIT",
@@ -1343,17 +1279,6 @@
     "backend/node_modules/cookie-parser/node_modules/cookie-signature": {
       "version": "1.0.6",
       "license": "MIT"
-    },
-    "backend/node_modules/cors": {
-      "version": "2.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "backend/node_modules/corser": {
       "version": "2.0.1",
@@ -1386,13 +1311,6 @@
         "node": ">=0.10"
       }
     },
-    "backend/node_modules/depd": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "backend/node_modules/dotenv": {
       "version": "16.4.5",
       "license": "BSD-2-Clause",
@@ -1408,17 +1326,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "backend/node_modules/ee-first": {
-      "version": "1.1.1",
-      "license": "MIT"
-    },
-    "backend/node_modules/encodeurl": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "backend/node_modules/engine.io": {
@@ -1474,61 +1381,9 @@
         "node": ">= 0.6"
       }
     },
-    "backend/node_modules/escape-html": {
-      "version": "1.0.3",
-      "license": "MIT"
-    },
-    "backend/node_modules/etag": {
-      "version": "1.8.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "backend/node_modules/eventemitter3": {
       "version": "4.0.7",
       "license": "MIT"
-    },
-    "backend/node_modules/express": {
-      "version": "5.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "backend/node_modules/express-mongo-sanitize": {
       "version": "2.2.0",
@@ -1537,60 +1392,11 @@
         "node": ">=10"
       }
     },
-    "backend/node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "10.0.1"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
-    "backend/node_modules/finalhandler": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "backend/node_modules/flat": {
       "version": "5.0.2",
       "license": "BSD-3-Clause",
       "bin": {
         "flat": "cli.js"
-      }
-    },
-    "backend/node_modules/forwarded": {
-      "version": "0.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "backend/node_modules/fresh": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "backend/node_modules/generic-pool": {
@@ -1689,24 +1495,6 @@
         "node": ">=12"
       }
     },
-    "backend/node_modules/http-errors": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "backend/node_modules/http-proxy": {
       "version": "1.18.1",
       "license": "MIT",
@@ -1744,24 +1532,6 @@
         "node": ">=12"
       }
     },
-    "backend/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "backend/node_modules/inherits": {
-      "version": "2.0.4",
-      "license": "ISC"
-    },
     "backend/node_modules/ioredis": {
       "version": "5.9.1",
       "license": "MIT",
@@ -1784,20 +1554,6 @@
         "url": "https://opencollective.com/ioredis"
       }
     },
-    "backend/node_modules/ip-address": {
-      "version": "10.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "backend/node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "backend/node_modules/is-network-error": {
       "version": "1.3.0",
       "license": "MIT",
@@ -1807,10 +1563,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "backend/node_modules/is-promise": {
-      "version": "4.0.0",
-      "license": "MIT"
     },
     "backend/node_modules/js-tiktoken": {
       "version": "1.0.21",
@@ -2003,28 +1755,11 @@
       "version": "2.0.7",
       "license": "MIT"
     },
-    "backend/node_modules/media-typer": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "backend/node_modules/memjs": {
       "version": "1.3.2",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "backend/node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "backend/node_modules/mime": {
@@ -2042,20 +1777,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "backend/node_modules/mime-types": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "backend/node_modules/mongodb": {
@@ -2318,13 +2039,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "backend/node_modules/negotiator": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "backend/node_modules/neo-async": {
       "version": "2.6.2",
       "license": "MIT"
@@ -2389,16 +2103,6 @@
       "license": "MIT",
       "dependencies": {
         "whatwg-fetch": "^3.6.20"
-      }
-    },
-    "backend/node_modules/on-finished": {
-      "version": "2.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "backend/node_modules/on-headers": {
@@ -2468,21 +2172,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "backend/node_modules/parseurl": {
-      "version": "1.3.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "backend/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "backend/node_modules/pdf-parse": {
@@ -2618,37 +2307,6 @@
         "node": ">=0.10.0"
       }
     },
-    "backend/node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "backend/node_modules/range-parser": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "backend/node_modules/raw-body": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "backend/node_modules/redis": {
       "version": "4.7.1",
       "license": "MIT",
@@ -2685,20 +2343,6 @@
       "version": "1.0.0",
       "license": "MIT"
     },
-    "backend/node_modules/router": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "backend/node_modules/safe-buffer": {
       "version": "5.1.2",
       "license": "MIT"
@@ -2706,51 +2350,6 @@
     "backend/node_modules/secure-compare": {
       "version": "3.0.1",
       "license": "MIT"
-    },
-    "backend/node_modules/send": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "backend/node_modules/serve-static": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "backend/node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "license": "ISC"
     },
     "backend/node_modules/sift": {
       "version": "17.1.3",
@@ -2830,13 +2429,6 @@
       "version": "2.1.0",
       "license": "MIT"
     },
-    "backend/node_modules/statuses": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "backend/node_modules/stopwords-iso": {
       "version": "1.1.0",
       "license": "MIT",
@@ -2868,25 +2460,6 @@
       "version": "0.0.12",
       "engines": {
         "node": ">=0.2.6"
-      }
-    },
-    "backend/node_modules/toidentifier": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "backend/node_modules/type-is": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "backend/node_modules/typescript": {
@@ -2931,23 +2504,9 @@
         "node": ">= 0.8.0"
       }
     },
-    "backend/node_modules/unpipe": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "backend/node_modules/url-join": {
       "version": "4.0.1",
       "license": "MIT"
-    },
-    "backend/node_modules/vary": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "backend/node_modules/whatwg-encoding": {
       "version": "2.0.0",
@@ -4757,6 +4316,18 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
@@ -5399,6 +4970,46 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -8367,6 +7978,44 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -8404,7 +8053,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -8415,6 +8063,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -8897,6 +8562,46 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -8973,6 +8678,15 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cac": {
@@ -9480,6 +9194,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
@@ -9532,6 +9268,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
@@ -9547,6 +9292,23 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
@@ -9597,7 +9359,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -10043,6 +9804,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -10157,6 +9927,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.279",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.279.tgz",
@@ -10170,6 +9946,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -10487,6 +10272,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -11206,6 +10997,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -11220,6 +11020,27 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -11256,6 +11077,92 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/fast-copy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
@@ -11267,7 +11174,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -11338,7 +11244,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11385,6 +11290,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-cache-dir": {
@@ -11557,6 +11483,15 @@
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -11596,6 +11531,15 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/frontend": {
@@ -12039,6 +11983,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
+      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -12058,6 +12011,26 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -12211,6 +12184,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/ini": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
@@ -12243,6 +12222,24 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -12555,6 +12552,12 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -12737,7 +12740,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -12849,6 +12851,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {
@@ -12988,8 +12999,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -13471,6 +13487,15 @@
       "devOptional": true,
       "license": "CC0-1.0"
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
@@ -13485,6 +13510,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13816,6 +13853,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/new-find-package-json": {
       "version": "2.0.0",
@@ -14159,6 +14205,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -14314,6 +14372,15 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
@@ -14328,7 +14395,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14364,6 +14430,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -14537,6 +14613,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -14903,6 +14988,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -14977,6 +15075,46 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/react": {
       "version": "19.2.3",
@@ -15285,7 +15423,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15455,6 +15592,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -15614,6 +15767,76 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -15662,6 +15885,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -15712,7 +15941,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -15725,7 +15953,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15962,6 +16189,15 @@
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/std-env": {
@@ -16770,6 +17006,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/touch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
@@ -16878,6 +17123,45 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -17042,6 +17326,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -17188,6 +17481,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/victory-vendor": {
@@ -17431,7 +17733,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -17895,6 +18196,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zod-validation-error": {


### PR DESCRIPTION
## Summary

- Introduces MCP (Model Context Protocol) as a standard adapter protocol for connecting external data sources (Confluence, GitHub, Jira, etc.) to the Retrieva indexing pipeline — without writing custom per-source adapter code
- Retrieva acts as an MCP **client**; each external service runs a lightweight MCP **server** exposing 4 standard tools: `list_documents`, `fetch_document`, `get_changes`, `get_source_info`
- Includes a fully working reference MCP server for Confluence in `mcp-servers/example-confluence/`

## Changes

**New (backend):**
- `MCPDataSourceAdapter` — implements `BaseDocumentSourceAdapter` over MCP `StreamableHTTP` transport
- `MCPDataSource` model — connection registry with encrypted auth token, sync settings, and stats
- `mcpSyncWorker` — BullMQ worker for full and incremental MCP syncs (mirrors `notionSyncWorker` pattern)
- `mcpDataSourceService` — register (with live connectivity probe), CRUD, sync trigger, connection test
- REST API at `/api/v1/mcp-sources` (register, list, get, update, delete, sync, test-connection, stats)
- `mcpSync` BullMQ queue added alongside `notionSync`

**Modified (backward-compatible):**
- `prepareNotionDocumentForIndexing` gains a `sourceType` param (default `'notion'`) — flows into every chunk's Qdrant metadata
- `documentIndexWorker` forwards `sourceType` from job data to the loader
- `DocumentSource.sourceType` enum extended: `github`, `jira`, `slack`, `custom`

**New (mcp-servers):**
- `mcp-servers/example-confluence/` — reference MCP server any team can adapt for their data source

## Test plan

- [ ] All existing backend tests pass (no regressions to Notion pipeline)
- [ ] All existing frontend tests pass
- [ ] `POST /api/v1/mcp-sources/test-connection` rejects unreachable URLs with 422
- [ ] `POST /api/v1/mcp-sources` persists a new source after successful probe
- [ ] `POST /api/v1/mcp-sources/:id/sync` enqueues a job and returns 202
- [ ] MCP server example starts and responds to tool calls at `/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)