### PR TITLE
fix(frontend): fix infinite spinner and missing auth redirect for new users

### DIFF
--- a/frontend/src/app/(dashboard)/conversations/page.tsx
+++ b/frontend/src/app/(dashboard)/conversations/page.tsx
@@ -132,7 +132,7 @@ export default function ConversationsPage() {
   };
 
   // Show loading while workspaces are still being fetched
-  if (workspacesLoading || (workspaces.length === 0 && !activeWorkspace)) {
+  if (workspacesLoading) {
     return (
       <div className="flex h-full items-center justify-center">
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
@@ -143,7 +143,11 @@ export default function ConversationsPage() {
   if (!activeWorkspace) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-muted-foreground">Select a workspace to view conversations</p>
+        <p className="text-muted-foreground">
+          {workspaces.length === 0
+            ? 'Create a workspace to get started'
+            : 'Select a workspace to view conversations'}
+        </p>
       </div>
     );
   }

--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { Sidebar } from '@/components/layout/sidebar';
 import { Header } from '@/components/layout/header';
 import { MobileSidebar } from '@/components/layout/mobile-sidebar';
@@ -15,6 +16,7 @@ export default function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const router = useRouter();
   const setIsMobile = useUIStore((state) => state.setIsMobile);
   const isMobile = useUIStore((state) => state.isMobile);
   const isInitialized = useAuthStore((state) => state.isInitialized);
@@ -33,6 +35,13 @@ export default function DashboardLayout({
     return () => window.removeEventListener('resize', checkMobile);
   }, [setIsMobile]);
 
+  // Redirect to login when session is verified as invalid
+  useEffect(() => {
+    if (isInitialized && !isAuthenticated) {
+      router.replace('/login');
+    }
+  }, [isInitialized, isAuthenticated, router]);
+
   // Fetch workspaces when authenticated
   useEffect(() => {
     if (isAuthenticated && isInitialized) {
@@ -40,8 +49,8 @@ export default function DashboardLayout({
     }
   }, [isAuthenticated, isInitialized, fetchWorkspaces]);
 
-  // Show loading state while initializing
-  if (!isInitialized || isLoading) {
+  // Show loading state while initializing or redirecting unauthenticated users
+  if (!isInitialized || isLoading || !isAuthenticated) {
     return (
       <div className="flex h-screen">
         {/* Sidebar skeleton */}


### PR DESCRIPTION
## Summary

- **`conversations/page.tsx`**: Fixed infinite spinner shown to newly registered users with no workspaces. The previous condition `workspacesLoading || (workspaces.length === 0 && !activeWorkspace)` showed a permanent spinner once workspaces finished loading empty. Now only shows spinner while `workspacesLoading` is true; after that, shows "Create a workspace to get started" for new users or "Select a workspace" for users who have workspaces but none selected.
- **`(dashboard)/layout.tsx`**: Added redirect to `/login` when `isInitialized && !isAuthenticated`. Previously, the dashboard layout never redirected unauthenticated users — they were left on a broken dashboard page. Now shows loading skeleton during redirect to prevent content flash.

## Root cause of the production issue

User registered → was redirected to `/conversations` → page spun indefinitely because there were no workspaces and the loading condition was never cleared → user got confused and navigated to `/login` → the 401 on `/auth/login` was from their manual login attempt after being lost in the spin state.

## Test plan

- [x] All 357 frontend tests pass
- [x] All 1099 backend tests pass
- [ ] Register a new account → verify "Create a workspace to get started" message appears (no spinner)
- [ ] Verify that opening any `/dashboard/*` URL without a valid session redirects to `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)