### PR TITLE
fix(assessments): correct file upload field name 'documents' → 'files'

### DIFF
--- a/frontend/src/app/(dashboard)/assessments/new/page.tsx
+++ b/frontend/src/app/(dashboard)/assessments/new/page.tsx
@@ -53,7 +53,7 @@ export default function NewAssessmentPage() {
       formData.append('name', values.name);
       formData.append('vendorName', values.vendorName);
       if (activeWorkspace?.id) formData.append('workspaceId', activeWorkspace.id);
-      files.forEach((file) => formData.append('documents', file));
+      files.forEach((file) => formData.append('files', file));
       return assessmentsApi.create(formData);
     },
     onSuccess: (res) => {


### PR DESCRIPTION
## Summary
- Multer on the backend registers the upload field as `files` (`.array('files', 5)` in `middleware/fileUpload.js`)
- The frontend was appending files to FormData under the field name `documents`
- This caused every assessment creation to fail with `400 "Upload error: Unexpected field"` (multer's `LIMIT_UNEXPECTED_FILE` error)

**One-line fix:** `formData.append('documents', file)` → `formData.append('files', file)` in `assessments/new/page.tsx`

## Test plan
- [ ] Go to Gap Analysis → New Assessment
- [ ] Fill in Vendor name + Assessment name, upload a PDF
- [ ] Click Start Assessment → should succeed (201) and redirect to the assessment detail page
- [ ] Assessment should progress through `indexing` → `analyzing` → `complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)