### PR TITLE
feat(assessments): add contract clause review framework (article 30)

### DIFF
--- a/backend/controllers/assessmentController.js
+++ b/backend/controllers/assessmentController.js
@@ -207,7 +207,8 @@ export const downloadReport = catchAsync(async (req, res) => {
 
   const safeVendorName = assessment.vendorName.replace(/[^a-z0-9]/gi, '_').slice(0, 50);
   const dateStr = new Date().toISOString().slice(0, 10);
-  const filename = `DORA_Assessment_${safeVendorName}_${dateStr}.docx`;
+  const prefix = assessment.framework === 'CONTRACT_A30' ? 'ContractA30_Review' : 'DORA_Assessment';
+  const filename = `${prefix}_${safeVendorName}_${dateStr}.docx`;
 
   res.setHeader(
     'Content-Type',

--- a/backend/models/Assessment.js
+++ b/backend/models/Assessment.js
@@ -55,7 +55,7 @@ const assessmentSchema = new mongoose.Schema(
     },
     framework: {
       type: String,
-      enum: ['DORA'],
+      enum: ['DORA', 'CONTRACT_A30'],
       default: 'DORA',
     },
     status: {

--- a/backend/services/reportGenerator.js
+++ b/backend/services/reportGenerator.js
@@ -150,12 +150,15 @@ function gapBadge(level) {
 
 function buildCoverPage(assessment) {
   const risk = assessment.results?.overallRisk || 'N/A';
+  const isContract = assessment.framework === 'CONTRACT_A30';
   return [
     new Paragraph({ children: [new PageBreak()] }),
     new Paragraph({
       children: [
         new TextRun({
-          text: 'DORA Compliance Assessment Report',
+          text: isContract
+            ? 'Article 30 Contract Clause Review'
+            : 'DORA Compliance Assessment Report',
           bold: true,
           size: 56,
           color: COLOUR.primary,
@@ -217,7 +220,9 @@ function buildCoverPage(assessment) {
     new Paragraph({
       children: [
         new TextRun({
-          text: `Regulatory Framework: Regulation (EU) 2022/2554 (DORA)`,
+          text: isContract
+            ? 'Regulatory Framework: DORA Article 30 — ICT Contract Clause Requirements'
+            : 'Regulatory Framework: Regulation (EU) 2022/2554 (DORA)',
           size: 20,
           color: COLOUR.muted,
           italics: true,
@@ -298,6 +303,7 @@ function buildExecutiveSummary(assessment) {
 
 function buildGapTable(assessment) {
   const gaps = assessment.results?.gaps || [];
+  const isContract = assessment.framework === 'CONTRACT_A30';
 
   const rows = [
     new TableRow({
@@ -305,7 +311,7 @@ function buildGapTable(assessment) {
         headerCell('Article', 12),
         headerCell('Domain', 15),
         headerCell('Requirement', 28),
-        headerCell('Vendor Coverage', 25),
+        headerCell(isContract ? 'Contract Coverage' : 'Vendor Coverage', 25),
         headerCell('Gap Level', 10),
         headerCell('Recommendation', 10),
       ],
@@ -334,9 +340,11 @@ function buildGapTable(assessment) {
 
   return [
     new Paragraph({ children: [new PageBreak()] }),
-    heading1('Compliance Gap Analysis'),
+    heading1(isContract ? 'Contract Clause Review' : 'Compliance Gap Analysis'),
     para(
-      `The following table maps each assessed DORA obligation to the evidence found in ${assessment.vendorName}'s documentation.`,
+      isContract
+        ? `The following table maps each DORA Article 30 mandatory clause to the evidence found in the uploaded contract for ${assessment.vendorName}.`
+        : `The following table maps each assessed DORA obligation to the evidence found in ${assessment.vendorName}'s documentation.`,
       { color: COLOUR.muted, italics: true }
     ),
     new Paragraph({ spacing: { before: 200 } }),
@@ -350,7 +358,11 @@ function buildGapTable(assessment) {
 function buildDomainBreakdown(assessment) {
   const gaps = assessment.results?.gaps || [];
   const domains = [...new Set(gaps.map((g) => g.domain))];
-  const sections = [new Paragraph({ children: [new PageBreak()] }), heading1('Domain Breakdown')];
+  const isContract = assessment.framework === 'CONTRACT_A30';
+  const sections = [
+    new Paragraph({ children: [new PageBreak()] }),
+    heading1(isContract ? 'Clause Category Breakdown' : 'Domain Breakdown'),
+  ];
 
   for (const domain of domains) {
     const domainGaps = gaps.filter((g) => g.domain === domain);
@@ -413,7 +425,9 @@ function buildMethodology(assessment) {
     ),
     heading2('Assessment Methodology'),
     para(
-      'Vendor documentation was parsed and semantically indexed. Relevant content was extracted using vector similarity search across multiple compliance-focused query prompts. DORA obligations were retrieved from a pre-loaded regulatory knowledge base containing verbatim article texts. Gap assessment was performed using Azure OpenAI (gpt-4o-mini) function calling to produce structured, auditable output.',
+      assessment.framework === 'CONTRACT_A30'
+        ? 'The uploaded contract was parsed and semantically indexed. Relevant clauses were extracted using vector similarity search across 12 targeted Article 30 compliance queries. Gap assessment was performed using Azure OpenAI (gpt-4o-mini) to produce a structured, auditable clause-by-clause review.'
+        : 'Vendor documentation was parsed and semantically indexed. Relevant content was extracted using vector similarity search across multiple compliance-focused query prompts. DORA obligations were retrieved from a pre-loaded regulatory knowledge base containing verbatim article texts. Gap assessment was performed using Azure OpenAI (gpt-4o-mini) function calling to produce structured, auditable output.',
       { color: COLOUR.text }
     ),
     heading2('Source Documents Analysed'),

--- a/frontend/src/app/(dashboard)/assessments/new/page.tsx
+++ b/frontend/src/app/(dashboard)/assessments/new/page.tsx
@@ -40,6 +40,7 @@ export default function NewAssessmentPage() {
   const router = useRouter();
   const activeWorkspace = useActiveWorkspace();
   const [files, setFiles] = useState<FileWithId[]>([]);
+  const [framework, setFramework] = useState<'DORA' | 'CONTRACT_A30'>('DORA');
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
@@ -52,6 +53,7 @@ export default function NewAssessmentPage() {
       const formData = new FormData();
       formData.append('name', values.name);
       formData.append('vendorName', values.vendorName);
+      formData.append('framework', framework);
       if (activeWorkspace?.id) formData.append('workspaceId', activeWorkspace.id);
       files.forEach((file) => formData.append('files', file));
       return assessmentsApi.create(formData);
@@ -89,9 +91,13 @@ export default function NewAssessmentPage() {
 
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-semibold">New DORA Assessment</h1>
+        <h1 className="text-2xl font-semibold">
+          {framework === 'CONTRACT_A30' ? 'New Contract Review (Art. 30)' : 'New DORA Assessment'}
+        </h1>
         <p className="text-muted-foreground mt-1">
-          Upload vendor ICT documentation to run a gap analysis against Regulation (EU) 2022/2554.
+          {framework === 'CONTRACT_A30'
+            ? 'Upload the ICT contract to check all 12 mandatory DORA Article 30 clauses.'
+            : 'Upload vendor ICT documentation to run a gap analysis against Regulation (EU) 2022/2554.'}
         </p>
       </div>
 
@@ -101,6 +107,29 @@ export default function NewAssessmentPage() {
           onSubmit={form.handleSubmit((v) => createMutation.mutate(v))}
           className="space-y-6"
         >
+          {/* Framework toggle */}
+          <div className="space-y-2">
+            <p className="text-sm font-medium leading-none">Assessment type</p>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant={framework === 'DORA' ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setFramework('DORA')}
+              >
+                Gap Analysis (Art. 28/29)
+              </Button>
+              <Button
+                type="button"
+                variant={framework === 'CONTRACT_A30' ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setFramework('CONTRACT_A30')}
+              >
+                Contract Review (Art. 30)
+              </Button>
+            </div>
+          </div>
+
           <FormField
             control={form.control}
             name="vendorName"
@@ -137,7 +166,9 @@ export default function NewAssessmentPage() {
 
           {/* File upload */}
           <div className="space-y-2">
-            <p className="text-sm font-medium leading-none">Vendor documents</p>
+            <p className="text-sm font-medium leading-none">
+              {framework === 'CONTRACT_A30' ? 'Contract document' : 'Vendor documents'}
+            </p>
             <FileUploadZone files={files} onChange={setFiles} />
             {files.length === 0 && createMutation.isError && (
               <p className="text-xs text-destructive">

--- a/frontend/src/app/(dashboard)/assessments/page.tsx
+++ b/frontend/src/app/(dashboard)/assessments/page.tsx
@@ -94,8 +94,8 @@ export default function AssessmentsPage() {
   });
 
   const downloadMutation = useMutation({
-    mutationFn: ({ id, vendorName }: { id: string; vendorName: string }) =>
-      assessmentsApi.downloadReport(id, vendorName),
+    mutationFn: ({ id, vendorName, framework }: { id: string; vendorName: string; framework: Assessment['framework'] }) =>
+      assessmentsApi.downloadReport(id, vendorName, framework),
     onError: () => toast.error('Failed to download report'),
   });
 
@@ -168,7 +168,12 @@ export default function AssessmentsPage() {
                   onClick={() => router.push(`/assessments/${a._id}`)}
                 >
                   <TableCell className="font-medium">{a.vendorName}</TableCell>
-                  <TableCell className="text-muted-foreground">{a.name}</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {a.name}
+                    {a.framework === 'CONTRACT_A30' && (
+                      <Badge variant="outline" className="text-xs ml-2">Art. 30</Badge>
+                    )}
+                  </TableCell>
                   <TableCell>
                     <Badge variant={STATUS_VARIANT[a.status]}>
                       {a.status === 'indexing' || a.status === 'analyzing' ? (
@@ -201,7 +206,7 @@ export default function AssessmentsPage() {
                           className="h-7 w-7"
                           title="Download report"
                           onClick={() =>
-                            downloadMutation.mutate({ id: a._id, vendorName: a.vendorName })
+                            downloadMutation.mutate({ id: a._id, vendorName: a.vendorName, framework: a.framework })
                           }
                           disabled={downloadMutation.isPending}
                         >

--- a/frontend/src/lib/api/assessments.ts
+++ b/frontend/src/lib/api/assessments.ts
@@ -27,7 +27,7 @@ export interface Assessment {
   workspaceId: string;
   name: string;
   vendorName: string;
-  framework: 'DORA';
+  framework: 'DORA' | 'CONTRACT_A30';
   status: AssessmentStatus;
   statusMessage: string;
   documents: AssessmentDocument[];
@@ -90,9 +90,9 @@ export const assessmentsApi = {
   },
 
   /**
-   * Download the DORA compliance report as a .docx file
+   * Download the compliance report as a .docx file
    */
-  downloadReport: async (id: string, vendorName: string) => {
+  downloadReport: async (id: string, vendorName: string, framework?: 'DORA' | 'CONTRACT_A30') => {
     const response = await apiClient.get(`/assessments/${id}/report`, {
       responseType: 'blob',
       timeout: 60_000,
@@ -102,7 +102,8 @@ export const assessmentsApi = {
     const link = document.createElement('a');
     link.href = url;
     const dateStr = new Date().toISOString().slice(0, 10);
-    link.setAttribute('download', `DORA_Assessment_${vendorName.replace(/\s+/g, '_')}_${dateStr}.docx`);
+    const prefix = framework === 'CONTRACT_A30' ? 'ContractA30_Review' : 'DORA_Assessment';
+    link.setAttribute('download', `${prefix}_${vendorName.replace(/\s+/g, '_')}_${dateStr}.docx`);
     document.body.appendChild(link);
     link.click();
     link.remove();


### PR DESCRIPTION
## Summary

- Adds a new `CONTRACT_A30` framework option alongside the existing `DORA` gap analysis
- Users can toggle between **Gap Analysis (Art. 28/29)** and **Contract Review (Art. 30)** when creating an assessment
- The Article 30 agent checks all 12 mandatory DORA Article 30 clauses (`Art.30(2)(a-h)` + `Art.30(3)(a-d)`) using a purpose-built ReAct agent with a direct fallback pipeline
- Reports, filenames, badges, and status messages are all branched on `framework`

## Changes

**Backend**
- `Assessment.js` — added `CONTRACT_A30` to `framework` enum
- `assessmentController.js` — `downloadReport` branches filename on `assessment.framework`
- `gapAnalysisAgent.js` — `CONTRACT_A30_CLAUSES`, `CONTRACT_A30_DOMAINS`, `CONTRACT_A30_SYSTEM_PROMPT`, `buildContractA30Tools()`, `runContractA30ReActAgent()`, `runContractA30FallbackPipeline()`; `runGapAnalysis()` branches on framework with correct domain normalization
- `reportGenerator.js` — cover page title, gap table heading, domain breakdown heading, and methodology text all branch on `assessment.framework === 'CONTRACT_A30'`

**Frontend**
- `assessments.ts` — `framework` type widened to `'DORA' | 'CONTRACT_A30'`; `downloadReport` accepts optional `framework` for filename
- `new/page.tsx` — segmented toggle (Gap Analysis / Contract Review), dynamic title/description/document label, `framework` appended to `FormData`
- `[id]/page.tsx` — framework badge in header, contract-specific analyzing message, `RISK_DESCRIPTION_CONTRACT` map, "Clause Review" heading
- `page.tsx` — `Art. 30` badge on `CONTRACT_A30` rows in the assessments table

## Test plan

- [ ] All 357 existing tests still pass (verified by pre-push hook)
- [ ] DORA gap analysis flow (`framework: 'DORA'`) unchanged — toggle defaults to "Gap Analysis"
- [ ] New assessment → toggle "Contract Review (Art. 30)" → title/description/label update
- [ ] Submit → `POST /api/v1/assessments` with `framework: 'CONTRACT_A30'` returns `201`
- [ ] Detail page shows "Art. 30 Contract Review" badge; in-progress message is contract-specific
- [ ] Completed assessment → clause rows in `GapAnalysisTable` with `Art.30(2)(a)` etc.
- [ ] Download → `ContractA30_Review_<vendor>_<date>.docx` with correct cover title
- [ ] Assessments list → "Art. 30" badge on CONTRACT_A30 rows, no badge on DORA rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)