### PR TITLE
chore(docker): harden local and staging compose for production parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Retrieva is a RAG (Retrieval-Augmented Generation) knowledge retrieval platform. It ingests content from Notion workspaces, stores vector embeddings in Qdrant, and provides conversational question-answering via Azure OpenAI (gpt-4o-mini + text-embedding-3-small). The project is a monorepo with three services: a Node.js/Express backend, a Next.js frontend, and a Python RAGAS evaluation service.
+Retrieva is a RAG (Retrieval-Augmented Generation) knowledge retrieval platform. It ingests content from Notion workspaces, stores vector embeddings in Qdrant, and provides conversational question-answering via Azure OpenAI (gpt-4o-mini + text-embedding-3-small). The project is a monorepo with two application services: a Node.js/Express backend and a Next.js frontend.
 
 ## Monorepo Structure
 
 ```
 backend/     - Express 5 API server (ES modules, Node.js 20)
 frontend/    - Next.js 16 App Router (React 19, TypeScript)
-ragas-service/ - Python FastAPI for answer quality evaluation
 infra/       - Terraform (DigitalOcean & Azure)
 nginx/       - Reverse proxy configuration
 docs/        - Docusaurus documentation site

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -2,16 +2,18 @@
 # Docker Compose - Staging Environment
 # =============================================================================
 # Usage:
-#   docker-compose -f docker-compose.staging.yml up -d
-#   docker-compose -f docker-compose.staging.yml logs -f backend
-#   docker-compose -f docker-compose.staging.yml down
+#   docker compose -f docker-compose.staging.yml up -d
+#   docker compose -f docker-compose.staging.yml logs -f backend
+#   docker compose -f docker-compose.staging.yml down
 #
-# NOTE: This configuration uses EXTERNAL managed services:
-# - MongoDB Atlas for database
-# - External Redis (or local for cost savings)
-# - External Qdrant (or local for cost savings)
+# External Managed Services (NOT in this compose):
+#   - MongoDB Atlas for database  → MONGODB_URI in backend/.env
 #
-# Configure via .env file with staging values.
+# Self-Hosted Services (IN this compose):
+#   - Redis 7-alpine (local, AOF persistence)
+#   - Qdrant v1.13.2 (pinned to match production)
+#
+# Configure via backend/.env file with staging values.
 # =============================================================================
 
 version: '3.8'
@@ -24,7 +26,7 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-      target: runner  # Use production stage
+      target: runner
     container_name: rag-backend-staging
     ports:
       - "3007:3007"
@@ -32,13 +34,18 @@ services:
       - ./backend/.env
     environment:
       - NODE_ENV=staging
+      - DOCKER_ENV=true
     depends_on:
       redis:
         condition: service_healthy
       qdrant:
-        condition: service_started
-    networks:
-      - rag-network-staging
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3007/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
     deploy:
       resources:
@@ -53,18 +60,12 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3007/health"]
-      interval: 30s
-      timeout: 10s
-      start_period: 10s
-      retries: 3
+    networks:
+      - rag-network-staging
 
   # ===========================================================================
-  # Redis (Local for staging - can use managed service instead)
+  # Redis (Local for staging)
   # ===========================================================================
-  # For cost-effective staging, run Redis locally
-  # For production-like staging, use managed Redis and remove this service
   redis:
     image: redis:7-alpine
     container_name: rag-redis-staging
@@ -72,28 +73,31 @@ services:
       - "6378:6379"
     volumes:
       - redis_staging_data:/data
-    command: ["redis-server", "--appendonly", "yes"]
+    command: ["redis-server", "--appendonly", "yes", "--appendfsync", "everysec"]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
-    networks:
-      - rag-network-staging
     restart: unless-stopped
     deploy:
       resources:
         limits:
           cpus: '0.25'
           memory: 256M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - rag-network-staging
 
   # ===========================================================================
-  # Qdrant Vector Database (Local for staging)
+  # Qdrant Vector Database (pinned to match production)
   # ===========================================================================
-  # For cost-effective staging, run Qdrant locally
-  # For production-like staging, use Qdrant Cloud and remove this service
   qdrant:
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.13.2
     container_name: rag-qdrant-staging
     ports:
       - "6333:6333"
@@ -102,14 +106,25 @@ services:
       - qdrant_staging_data:/qdrant/storage
     environment:
       - QDRANT__SERVICE__GRPC_PORT=6334
-    networks:
-      - rag-network-staging
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c ':>/dev/tcp/0.0.0.0/6333' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
     deploy:
       resources:
         limits:
           cpus: '0.5'
           memory: 1G
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - rag-network-staging
 
 # =============================================================================
 # Networks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,30 @@
 # =============================================================================
 # Docker Compose - Local Development
 # =============================================================================
+# Mirrors production as closely as possible to catch environment bugs early.
+#
+# Key parity points:
+#   - Same image versions as docker-compose.production.yml
+#   - Same healthchecks on every service (app + infra)
+#   - JSON-file logging with rotation (prevents log bloat)
+#   - DOCKER_ENV=true so logger.js skips pino-roll file rotation
+#   - NEXT_PUBLIC_WS_URL build arg set (was absent, broke WebSocket locally)
+#   - Qdrant GRPC port env matches production
+#
+# Intentional local-only differences:
+#   - Backend source code mounted (./backend:/app) for hot-reload
+#   - Ports exposed on 0.0.0.0 (not loopback-only) for easy host access
+#   - Redis has no password (REDIS_URL stays simple)
+#   - MongoDB runs as a container (production uses Atlas)
+#   - NODE_ENV=development (enables pino-pretty console logs)
+#   - No resource limits (avoid throttling dev machines)
+#
 # Usage:
-#   docker-compose up -d              # Start all services
-#   docker-compose up -d backend      # Start only backend
-#   docker-compose logs -f backend    # View backend logs
-#   docker-compose down               # Stop all services
+#   docker compose up -d              # Start all services
+#   docker compose up -d backend      # Start only backend
+#   docker compose logs -f backend    # Follow backend logs
+#   docker compose down -v            # Stop and remove volumes
+# =============================================================================
 
 version: '3.8'
 
@@ -19,12 +38,24 @@ services:
       dockerfile: Dockerfile
       args:
         - NEXT_PUBLIC_API_URL=http://localhost:3007/api/v1
+        - NEXT_PUBLIC_WS_URL=http://localhost:3007
         - NEXT_PUBLIC_APP_NAME=Retrieva
     container_name: rag-frontend
     ports:
       - "3000:3000"
     environment:
       - NODE_ENV=development
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     networks:
       - rag-network
     restart: unless-stopped
@@ -60,6 +91,17 @@ services:
     volumes:
       - ./backend:/app
       - /app/node_modules
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3007/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     networks:
       - rag-network
     restart: unless-stopped
@@ -81,6 +123,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     networks:
       - rag-network
     restart: unless-stopped
@@ -100,6 +147,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     networks:
       - rag-network
     restart: unless-stopped
@@ -115,12 +167,19 @@ services:
       - "6334:6334"
     volumes:
       - qdrant_data:/qdrant/storage
+    environment:
+      - QDRANT__SERVICE__GRPC_PORT=6334
     healthcheck:
       test: ["CMD-SHELL", "bash -c ':>/dev/tcp/0.0.0.0/6333' || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 30s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     networks:
       - rag-network
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- **`docker-compose.yml`** — 5 production parity gaps closed:
  - Add `NEXT_PUBLIC_WS_URL` build arg so WebSocket works locally (was `undefined`, breaking real-time features)
  - Add healthchecks to `frontend` and `backend` (same `wget` checks as production) — startup failures now visible immediately via `docker compose ps`
  - Add `json-file` logging driver with rotation to all services (prevents unbounded log disk usage in long-running dev sessions)
  - Add `QDRANT__SERVICE__GRPC_PORT=6334` env to Qdrant (matches production)
  - Add explanatory header documenting intentional local-only differences

- **`docker-compose.staging.yml`** — 4 gaps closed:
  - Pin Qdrant from `:latest` → `v1.13.2` to match production (eliminates silent version drift risk)
  - Add Qdrant healthcheck (TCP check identical to production)
  - Change `depends_on.qdrant` from `service_started` → `service_healthy` (fixes race condition on slow startup)
  - Add `DOCKER_ENV=true`, `QDRANT__SERVICE__GRPC_PORT=6334`, Redis AOF flags, and `json-file` logging

- **`CLAUDE.md`** — Remove non-existent `ragas-service/` Python service from project overview and monorepo structure (never implemented)

## Test Plan

- [x] All three compose files pass `docker compose config --quiet` validation
- [x] `docker compose up -d` — all 5 containers start and reach `(healthy)` status
- [x] `GET /health` returns `{"status":"up"}` confirming backend healthcheck works

🤖 Generated with [Claude Code](https://claude.com/claude-code)