### PR TITLE
feat(compliance): add monitoring alerts and roi export

### DIFF
--- a/backend/controllers/exportController.js
+++ b/backend/controllers/exportController.js
@@ -1,0 +1,28 @@
+/**
+ * Export Controller
+ *
+ * Handles on-demand report generation and download endpoints.
+ */
+
+import { catchAsync } from '../utils/index.js';
+import { generateRoiWorkbook } from '../services/roiExportService.js';
+
+/**
+ * GET /api/v1/workspaces/roi-export
+ *
+ * Generates and streams a DORA Article 28(3) Register of Information XLSX
+ * workbook for all workspaces accessible by the authenticated user.
+ */
+export const exportRoi = catchAsync(async (req, res) => {
+  const buffer = await generateRoiWorkbook(req.user.userId);
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const filename = `DORA_Register_of_Information_${dateStr}.xlsx`;
+
+  res.setHeader(
+    'Content-Type',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  );
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+  res.setHeader('Content-Length', buffer.length);
+  res.end(buffer);
+});

--- a/backend/models/Workspace.js
+++ b/backend/models/Workspace.js
@@ -50,6 +50,11 @@ const workspaceSchema = new mongoose.Schema(
     vendorStatus: { type: String, enum: ['active', 'under-review', 'exited'], default: 'active' },
     certifications: [certificationSchema],
     exitStrategyDoc: { type: String, default: null },
+    alertsSentAt: {
+      type: Map,
+      of: Date,
+      default: {},
+    },
   },
   {
     timestamps: true,

--- a/backend/routes/workspaceRoutes.js
+++ b/backend/routes/workspaceRoutes.js
@@ -16,6 +16,7 @@ import {
 } from '../controllers/workspaceMemberController.js';
 import { authenticate } from '../middleware/auth.js';
 import { canInviteMembers } from '../middleware/workspaceAuth.js';
+import { exportRoi } from '../controllers/exportController.js';
 
 const router = express.Router();
 
@@ -24,6 +25,7 @@ router.use(authenticate);
 // Workspace CRUD
 router.post('/', createWorkspace);
 router.get('/my-workspaces', getMyWorkspaces);
+router.get('/roi-export', exportRoi);
 router.get('/:workspaceId', getWorkspace);
 router.patch('/:workspaceId', updateWorkspace);
 router.delete('/:workspaceId', deleteWorkspace);

--- a/backend/services/alertMonitorService.js
+++ b/backend/services/alertMonitorService.js
@@ -1,0 +1,276 @@
+/**
+ * Alert Monitor Service
+ *
+ * Runs compliance checks across all workspaces and sends email alerts to
+ * workspace owners when thresholds are breached. Deduplication via the
+ * Workspace.alertsSentAt map prevents repeated alerts within 20 hours.
+ *
+ * Checks:
+ *  - Certification expiry (90 / 30 / 7 day warnings)
+ *  - Contract renewal (60 days before contractEnd)
+ *  - Annual review overdue (nextReviewDate < now)
+ *  - Assessment overdue (no complete assessment in 12 months)
+ */
+
+import { Workspace } from '../models/Workspace.js';
+import { WorkspaceMember } from '../models/WorkspaceMember.js';
+import { Assessment } from '../models/Assessment.js';
+import emailService from './emailService.js';
+import logger from '../config/logger.js';
+
+const DEDUP_WINDOW_MS = 20 * 60 * 60 * 1000; // 20 hours
+
+/**
+ * Orchestrator — runs all 4 checks in parallel (allSettled so one failure
+ * does not block the others).
+ */
+export async function runMonitoringAlerts() {
+  logger.info('Starting monitoring alert checks', { service: 'alertMonitor' });
+
+  const results = await Promise.allSettled([
+    checkCertificationExpiry(),
+    checkContractRenewal(),
+    checkAnnualReviewOverdue(),
+    checkAssessmentOverdue(),
+  ]);
+
+  const [certs, contracts, reviews, assessments] = results;
+  if (certs.status === 'rejected')
+    logger.error('Cert expiry check failed', {
+      error: certs.reason?.message,
+      service: 'alertMonitor',
+    });
+  if (contracts.status === 'rejected')
+    logger.error('Contract renewal check failed', {
+      error: contracts.reason?.message,
+      service: 'alertMonitor',
+    });
+  if (reviews.status === 'rejected')
+    logger.error('Annual review check failed', {
+      error: reviews.reason?.message,
+      service: 'alertMonitor',
+    });
+  if (assessments.status === 'rejected')
+    logger.error('Assessment overdue check failed', {
+      error: assessments.reason?.message,
+      service: 'alertMonitor',
+    });
+
+  logger.info('Monitoring alert checks complete', { service: 'alertMonitor' });
+}
+
+// ---------------------------------------------------------------------------
+// Check 1 — Certification expiry (90 / 30 / 7 day windows)
+// ---------------------------------------------------------------------------
+
+async function checkCertificationExpiry() {
+  const workspaces = await Workspace.find({ 'certifications.0': { $exists: true } });
+  const now = new Date();
+
+  for (const workspace of workspaces) {
+    for (const cert of workspace.certifications) {
+      if (!cert.validUntil) continue;
+
+      const msUntilExpiry = cert.validUntil - now;
+      const daysUntilExpiry = msUntilExpiry / (24 * 60 * 60 * 1000);
+
+      // Determine which threshold applies (most urgent wins)
+      let threshold = null;
+      if (daysUntilExpiry > 0 && daysUntilExpiry <= 7) threshold = 7;
+      else if (daysUntilExpiry > 7 && daysUntilExpiry <= 30) threshold = 30;
+      else if (daysUntilExpiry > 30 && daysUntilExpiry <= 90) threshold = 90;
+
+      if (!threshold) continue;
+
+      const alertKey = `cert-expiry-${threshold}-${cert.type}`;
+      if (isWithinDedupWindow(workspace, alertKey)) continue;
+
+      const alertType = `cert-expiry-${threshold}`;
+      const details = {
+        certType: cert.type,
+        expiryDate: cert.validUntil.toLocaleDateString('en-GB', {
+          day: 'numeric',
+          month: 'long',
+          year: 'numeric',
+        }),
+      };
+
+      await sendAlertToOwners(workspace, alertType, details);
+      workspace.alertsSentAt.set(alertKey, new Date());
+      await Workspace.updateOne(
+        { _id: workspace._id },
+        { $set: { alertsSentAt: workspace.alertsSentAt } }
+      );
+
+      logger.info('Cert expiry alert sent', {
+        service: 'alertMonitor',
+        workspaceId: workspace._id,
+        certType: cert.type,
+        threshold,
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Check 2 — Contract renewal (60 days before contractEnd)
+// ---------------------------------------------------------------------------
+
+async function checkContractRenewal() {
+  const now = new Date();
+  const in60Days = new Date(now.getTime() + 60 * 24 * 60 * 60 * 1000);
+
+  const workspaces = await Workspace.find({
+    contractEnd: { $ne: null, $gte: now, $lte: in60Days },
+  });
+
+  for (const workspace of workspaces) {
+    const alertKey = 'contract-renewal-60';
+    if (isWithinDedupWindow(workspace, alertKey)) continue;
+
+    const details = {
+      contractEnd: workspace.contractEnd.toLocaleDateString('en-GB', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+      }),
+    };
+
+    await sendAlertToOwners(workspace, 'contract-renewal-60', details);
+    workspace.alertsSentAt.set(alertKey, new Date());
+    await Workspace.updateOne(
+      { _id: workspace._id },
+      { $set: { alertsSentAt: workspace.alertsSentAt } }
+    );
+
+    logger.info('Contract renewal alert sent', {
+      service: 'alertMonitor',
+      workspaceId: workspace._id,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Check 3 — Annual review overdue (nextReviewDate < now)
+// ---------------------------------------------------------------------------
+
+async function checkAnnualReviewOverdue() {
+  const now = new Date();
+
+  const workspaces = await Workspace.find({
+    nextReviewDate: { $ne: null, $lt: now },
+  });
+
+  for (const workspace of workspaces) {
+    const alertKey = 'annual-review-overdue';
+    if (isWithinDedupWindow(workspace, alertKey)) continue;
+
+    const details = {
+      reviewDate: workspace.nextReviewDate.toLocaleDateString('en-GB', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+      }),
+    };
+
+    await sendAlertToOwners(workspace, 'annual-review-overdue', details);
+    workspace.alertsSentAt.set(alertKey, new Date());
+    await Workspace.updateOne(
+      { _id: workspace._id },
+      { $set: { alertsSentAt: workspace.alertsSentAt } }
+    );
+
+    logger.info('Annual review overdue alert sent', {
+      service: 'alertMonitor',
+      workspaceId: workspace._id,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Check 4 — Assessment overdue (no complete assessment in 12 months)
+// ---------------------------------------------------------------------------
+
+async function checkAssessmentOverdue() {
+  const workspaces = await Workspace.find({});
+  const twelveMonthsAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
+
+  const perWorkspace = workspaces.map(async (workspace) => {
+    const latest = await Assessment.findOne({
+      workspaceId: workspace._id,
+      status: 'complete',
+    }).sort({ createdAt: -1 });
+
+    const isOverdue = !latest || latest.createdAt < twelveMonthsAgo;
+    if (!isOverdue) return;
+
+    const alertKey = 'assessment-overdue-12mo';
+    if (isWithinDedupWindow(workspace, alertKey)) return;
+
+    const details = {
+      lastAssessmentDate: latest
+        ? latest.createdAt.toLocaleDateString('en-GB', {
+            day: 'numeric',
+            month: 'long',
+            year: 'numeric',
+          })
+        : null,
+    };
+
+    await sendAlertToOwners(workspace, 'assessment-overdue-12mo', details);
+    workspace.alertsSentAt.set(alertKey, new Date());
+    await Workspace.updateOne(
+      { _id: workspace._id },
+      { $set: { alertsSentAt: workspace.alertsSentAt } }
+    );
+
+    logger.info('Assessment overdue alert sent', {
+      service: 'alertMonitor',
+      workspaceId: workspace._id,
+    });
+  });
+
+  await Promise.allSettled(perWorkspace);
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function isWithinDedupWindow(workspace, alertKey) {
+  const lastSent = workspace.alertsSentAt?.get(alertKey);
+  if (!lastSent) return false;
+  return Date.now() - lastSent.getTime() < DEDUP_WINDOW_MS;
+}
+
+async function sendAlertToOwners(workspace, alertType, details) {
+  const members = await WorkspaceMember.find({
+    workspaceId: workspace._id,
+    role: 'owner',
+    status: 'active',
+  }).populate('userId', 'email name notificationPreferences');
+
+  for (const member of members) {
+    const user = member.userId;
+    if (!user?.email) continue;
+    if (user.notificationPreferences?.email?.system_alert === false) continue;
+
+    try {
+      await emailService.sendMonitoringAlert({
+        toEmail: user.email,
+        toName: user.name,
+        workspaceName: workspace.name,
+        alertType,
+        details,
+      });
+    } catch (err) {
+      logger.error('Failed to send monitoring alert email', {
+        service: 'alertMonitor',
+        userId: user._id,
+        workspaceId: workspace._id,
+        alertType,
+        error: err.message,
+      });
+    }
+  }
+}

--- a/backend/services/roiExportService.js
+++ b/backend/services/roiExportService.js
@@ -1,0 +1,168 @@
+/**
+ * RoI Export Service
+ *
+ * Generates an EBA-compliant DORA Article 28(3) Register of Information
+ * workbook (XLSX) for all workspaces accessible by the requesting user.
+ *
+ * Sheets produced:
+ *   RT.01.01 — Summary (entity-level metadata)
+ *   RT.02.01 — ICT Third-Party Service Providers (one row per workspace/vendor)
+ *   RT.03.01 — Certifications (one row per cert per vendor)
+ *   RT.04.01 — Gap Summary (one row per gap from latest complete assessment)
+ */
+
+import XLSX from 'xlsx';
+import { Workspace } from '../models/Workspace.js';
+import { WorkspaceMember } from '../models/WorkspaceMember.js';
+import { Assessment } from '../models/Assessment.js';
+import { VendorQuestionnaire } from '../models/VendorQuestionnaire.js';
+
+const INSTITUTION_NAME = process.env.INSTITUTION_NAME || 'Financial Entity';
+
+function fmtDate(d) {
+  if (!d) return '';
+  const date = d instanceof Date ? d : new Date(d);
+  if (isNaN(date.getTime())) return '';
+  return date.toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+export async function generateRoiWorkbook(userId) {
+  // 1. Collect all workspaces the user has access to
+  const memberships = await WorkspaceMember.find({ userId, status: 'active' });
+  const workspaceIds = memberships.map((m) => m.workspaceId);
+  const workspaces = await Workspace.find({ _id: { $in: workspaceIds } });
+
+  // 2. Latest complete assessment per workspace
+  const latestAssessments = await Assessment.aggregate([
+    { $match: { workspaceId: { $in: workspaceIds }, status: 'complete' } },
+    { $sort: { createdAt: -1 } },
+    { $group: { _id: '$workspaceId', doc: { $first: '$$ROOT' } } },
+  ]);
+
+  // 3. Latest complete questionnaire per workspace
+  const latestQuestionnaires = await VendorQuestionnaire.aggregate([
+    { $match: { workspaceId: { $in: workspaceIds }, status: 'complete' } },
+    { $sort: { createdAt: -1 } },
+    { $group: { _id: '$workspaceId', doc: { $first: '$$ROOT' } } },
+  ]);
+
+  // O(1) lookup maps
+  const assessmentMap = Object.fromEntries(latestAssessments.map((a) => [a._id.toString(), a.doc]));
+  const questionnaireMap = Object.fromEntries(
+    latestQuestionnaires.map((q) => [q._id.toString(), q.doc])
+  );
+
+  const wb = XLSX.utils.book_new();
+
+  // -------------------------------------------------------------------------
+  // Sheet 1: RT.01.01 — Summary
+  // -------------------------------------------------------------------------
+  const summaryRows = [
+    ['EBA DORA Register of Information — RT.01.01 Summary'],
+    [],
+    ['Institution Name', INSTITUTION_NAME],
+    ['Report Generated', new Date().toISOString()],
+    ['Total Vendors', workspaces.length],
+    ['Critical Vendors', workspaces.filter((w) => w.vendorTier === 'critical').length],
+    ['Important Vendors', workspaces.filter((w) => w.vendorTier === 'important').length],
+    ['Standard Vendors', workspaces.filter((w) => w.vendorTier === 'standard').length],
+  ];
+  const wsSummary = XLSX.utils.aoa_to_sheet(summaryRows);
+  XLSX.utils.book_append_sheet(wb, wsSummary, 'RT.01.01 Summary');
+
+  // -------------------------------------------------------------------------
+  // Sheet 2: RT.02.01 — ICT Third-Party Service Providers
+  // -------------------------------------------------------------------------
+  const providersHeader = [
+    'B_01.01.0010 Institution Name',
+    'B_01.02.0030 Vendor Name',
+    'B_01.02.0040 Country',
+    'B_01.02.0080 Service Type',
+    'B_01.02.0090 Contract Start',
+    'B_01.02.0100 Contract End',
+    'B_01.02.0110 Criticality Tier',
+    'B_01.02.0120 Vendor Status',
+    'B_01.02.0130 Questionnaire Score',
+    'B_01.02.0140 Assessment Risk',
+    'B_01.02.0150 Next Review Date',
+  ];
+
+  const providersRows = [providersHeader];
+  for (const ws of workspaces) {
+    const wsId = ws._id.toString();
+    const assessment = assessmentMap[wsId];
+    const questionnaire = questionnaireMap[wsId];
+
+    providersRows.push([
+      INSTITUTION_NAME,
+      ws.name,
+      ws.country || '',
+      ws.serviceType || '',
+      fmtDate(ws.contractStart),
+      fmtDate(ws.contractEnd),
+      ws.vendorTier || '',
+      ws.vendorStatus || '',
+      questionnaire?.overallScore !== null && questionnaire?.overallScore !== undefined
+        ? questionnaire.overallScore
+        : '',
+      assessment?.results?.overallRisk || '',
+      fmtDate(ws.nextReviewDate),
+    ]);
+  }
+  const wsProviders = XLSX.utils.aoa_to_sheet(providersRows);
+  XLSX.utils.book_append_sheet(wb, wsProviders, 'RT.02.01 ICT Providers');
+
+  // -------------------------------------------------------------------------
+  // Sheet 3: RT.03.01 — Certifications
+  // -------------------------------------------------------------------------
+  const certsHeader = ['Vendor Name', 'Certification Type', 'Valid Until', 'Status'];
+  const certsRows = [certsHeader];
+  for (const ws of workspaces) {
+    if (!ws.certifications?.length) {
+      certsRows.push([ws.name, '', '', '']);
+      continue;
+    }
+    for (const cert of ws.certifications) {
+      certsRows.push([ws.name, cert.type, fmtDate(cert.validUntil), cert.status]);
+    }
+  }
+  const wsCerts = XLSX.utils.aoa_to_sheet(certsRows);
+  XLSX.utils.book_append_sheet(wb, wsCerts, 'RT.03.01 Certifications');
+
+  // -------------------------------------------------------------------------
+  // Sheet 4: RT.04.01 — Gap Summary
+  // -------------------------------------------------------------------------
+  const gapsHeader = [
+    'Vendor Name',
+    'Article',
+    'Domain',
+    'Requirement',
+    'Gap Level',
+    'Recommendation',
+  ];
+  const gapsRows = [gapsHeader];
+  for (const ws of workspaces) {
+    const wsId = ws._id.toString();
+    const assessment = assessmentMap[wsId];
+    const gaps = assessment?.results?.gaps;
+
+    if (!gaps?.length) {
+      gapsRows.push([ws.name, '', '', '', '', '']);
+      continue;
+    }
+    for (const gap of gaps) {
+      gapsRows.push([
+        ws.name,
+        gap.article || '',
+        gap.domain || '',
+        gap.requirement || '',
+        gap.gapLevel || '',
+        gap.recommendation || '',
+      ]);
+    }
+  }
+  const wsGaps = XLSX.utils.aoa_to_sheet(gapsRows);
+  XLSX.utils.book_append_sheet(wb, wsGaps, 'RT.04.01 Gap Summary');
+
+  return XLSX.write(wb, { bookType: 'xlsx', type: 'buffer' });
+}

--- a/backend/workers/monitoringWorker.js
+++ b/backend/workers/monitoringWorker.js
@@ -1,0 +1,57 @@
+/**
+ * Monitoring Worker
+ *
+ * BullMQ worker that processes scheduled compliance monitoring alert jobs.
+ * Runs every 24 hours (configurable via MONITORING_INTERVAL_HOURS).
+ */
+
+import { Worker } from 'bullmq';
+import { redisConnection } from '../config/redis.js';
+import { runMonitoringAlerts } from '../services/alertMonitorService.js';
+import logger from '../config/logger.js';
+
+const worker = new Worker(
+  'monitoringJobs',
+  async (job) => {
+    if (job.name === 'run-monitoring-alerts') {
+      logger.info('Running monitoring alerts', { service: 'monitoringWorker', jobId: job.id });
+      await runMonitoringAlerts();
+      return { ran: true, timestamp: new Date().toISOString() };
+    }
+    logger.warn('Unknown monitoring job type', { jobName: job.name, jobId: job.id });
+  },
+  {
+    connection: redisConnection,
+    concurrency: 1,
+    lockDuration: 5 * 60 * 1000, // 5 minutes
+    lockRenewTime: 2 * 60 * 1000, // Renew every 2 minutes
+  }
+);
+
+worker.on('completed', (job) => {
+  logger.info('Monitoring job completed', {
+    service: 'monitoringWorker',
+    jobId: job.id,
+  });
+});
+
+worker.on('failed', (job, err) => {
+  logger.error('Monitoring job failed', {
+    service: 'monitoringWorker',
+    jobId: job?.id,
+    error: err.message,
+  });
+});
+
+worker.on('error', (err) => {
+  logger.error('Monitoring worker error', {
+    service: 'monitoringWorker',
+    error: err.message,
+  });
+});
+
+export async function closeMonitoringWorker() {
+  await worker.close();
+}
+
+export default worker;

--- a/frontend/src/app/(dashboard)/questionnaires/page.tsx
+++ b/frontend/src/app/(dashboard)/questionnaires/page.tsx
@@ -12,6 +12,7 @@ import {
   Check,
   Loader2,
   AlertCircle,
+  FileSpreadsheet,
 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -38,6 +39,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import { questionnairesApi } from '@/lib/api/questionnaires';
+import { workspacesApi } from '@/lib/api/workspaces';
 import { useActiveWorkspace } from '@/lib/stores/workspace-store';
 import type { VendorQuestionnaire, QuestionnaireStatus } from '@/lib/api/questionnaires';
 
@@ -112,6 +114,14 @@ export default function QuestionnairesPage() {
     onSettled: () => setDeletingId(null),
   });
 
+  const exportMutation = useMutation({
+    mutationFn: () => workspacesApi.exportRoi(),
+    onError: () =>
+      toast.error('Export failed', {
+        description: 'Could not generate the RoI workbook.',
+      }),
+  });
+
   const copyVendorLink = (q: VendorQuestionnaire) => {
     if (!q.token) {
       toast.error('No link yet — send the questionnaire first');
@@ -148,10 +158,24 @@ export default function QuestionnairesPage() {
             DORA Art.28/30 vendor due diligence questionnaires
           </p>
         </div>
-        <Button onClick={() => router.push('/questionnaires/new')}>
-          <Plus className="h-4 w-4 mr-2" />
-          Send Questionnaire
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            onClick={() => exportMutation.mutate()}
+            disabled={exportMutation.isPending}
+          >
+            {exportMutation.isPending ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            ) : (
+              <FileSpreadsheet className="h-4 w-4 mr-2" />
+            )}
+            Export RoI (Excel)
+          </Button>
+          <Button onClick={() => router.push('/questionnaires/new')}>
+            <Plus className="h-4 w-4 mr-2" />
+            Send Questionnaire
+          </Button>
+        </div>
       </div>
 
       {/* Table */}

--- a/frontend/src/lib/api/workspaces.ts
+++ b/frontend/src/lib/api/workspaces.ts
@@ -137,4 +137,25 @@ export const workspacesApi = {
       return response.data;
     },
   },
+
+  /**
+   * Download a DORA Article 28(3) Register of Information XLSX workbook
+   * covering all workspaces accessible by the current user.
+   */
+  exportRoi: async () => {
+    const response = await apiClient.get('/workspaces/roi-export', {
+      responseType: 'blob',
+      timeout: 60_000,
+    });
+    const dateStr = new Date().toISOString().slice(0, 10);
+    const filename = `DORA_Register_of_Information_${dateStr}.xlsx`;
+    const url = window.URL.createObjectURL(new Blob([response.data]));
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', filename);
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.URL.revokeObjectURL(url);
+  },
 };


### PR DESCRIPTION
## Summary

Phase 4 of the Retrieva compliance platform: automated vendor monitoring alerts and EBA DORA Article 28(3) Register of Information export.

- **Automated Alerts** — BullMQ worker runs every 24 h, checks all workspaces for compliance thresholds (cert expiry 90/30/7d, contract renewal 60d, annual review overdue, assessment overdue 12mo), and emails workspace owners. Deduplication via `alertsSentAt` map on the Workspace model (20-hour window) prevents repeated alerts from the daily cron.
- **RoI Export** — Single "Export RoI (Excel)" button on the Questionnaires page generates a 4-sheet EBA-compliant XLSX workbook (RT.01.01 Summary, RT.02.01 ICT Providers, RT.03.01 Certifications, RT.04.01 Gap Summary) for all the user's workspaces and streams it as a file download.

## Changes

### Backend (9 files)
| File | Change |
|------|--------|
| `models/Workspace.js` | Add `alertsSentAt: Map<String, Date>` for per-alert dedup timestamps |
| `config/queue.js` | Add `monitoringQueue` + `scheduleMonitoringJob()` (24 h repeatable job) |
| `services/emailService.js` | Add `sendMonitoringAlert` (remote + local) with branded HTML template |
| `services/alertMonitorService.js` | *(new)* 4 check functions + `runMonitoringAlerts()` orchestrator |
| `workers/monitoringWorker.js` | *(new)* BullMQ worker, concurrency 1, 5-min lock |
| `services/roiExportService.js` | *(new)* XLSX generator: 4 EBA sheets, one aggregation query per data type |
| `controllers/exportController.js` | *(new)* `GET /workspaces/roi-export` — streams XLSX buffer as attachment |
| `routes/workspaceRoutes.js` | Register `/roi-export` before `/:workspaceId` to prevent param collision |
| `index.js` | Import monitoringWorker + call `scheduleMonitoringJob()` on startup |

### Frontend (2 files)
| File | Change |
|------|--------|
| `lib/api/workspaces.ts` | Add `workspacesApi.exportRoi()` blob-download helper |
| `app/(dashboard)/questionnaires/page.tsx` | Add "Export RoI (Excel)" button with loading state |

## Test plan
- [x] Backend lint — 0 errors
- [x] Frontend lint — 0 errors
- [x] Backend tests — 1099/1099 passed (44 test files)
- [x] Frontend build — 19 routes, no errors
- [ ] Confirm monitoring worker appears in startup logs: `Monitoring Worker: Active (24h schedule)`
- [ ] Trigger `runMonitoringAlerts()` directly — verify emails sent for threshold conditions, skipped on second call within 20 h
- [ ] `GET /api/v1/workspaces/roi-export` returns `Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` with 4-sheet workbook
- [ ] "Export RoI (Excel)" button on `/questionnaires` — spinner visible, file downloads automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)