### PR TITLE
docs(compliance): document phase 4 monitoring alerts and roi export

### DIFF
--- a/docs/docs/api/workspaces.md
+++ b/docs/docs/api/workspaces.md
@@ -313,6 +313,41 @@ Transfer ownership to another member (owner only).
 
 ---
 
+## Export Register of Information (RoI)
+
+```http
+GET /api/v1/workspaces/roi-export
+```
+
+Generates and downloads an EBA-compliant DORA Article 28(3) Register of Information as an XLSX file. The workbook covers **all workspaces** the authenticated user has access to.
+
+### Response
+
+```
+Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+Content-Disposition: attachment; filename="DORA_Register_of_Information_2026-02-27.xlsx"
+```
+
+Binary XLSX buffer — the browser triggers an automatic file download.
+
+### Workbook sheets
+
+| Sheet | Content |
+|-------|---------|
+| **RT.01.01 Summary** | Institution name, report date, vendor counts by criticality tier |
+| **RT.02.01 ICT Providers** | One row per vendor: country, service type, contract dates, criticality tier, questionnaire score, assessment risk, next review date |
+| **RT.03.01 Certifications** | One row per certification per vendor (type, valid until, status) |
+| **RT.04.01 Gap Summary** | One row per gap from each vendor's latest complete DORA assessment |
+
+### Notes
+
+- Requires authentication; no workspace ID parameter — all accessible workspaces are included.
+- Uses the latest **complete** assessment and latest **complete** questionnaire per workspace.
+- The institution name in RT.01.01 is configured via the `INSTITUTION_NAME` environment variable (default: `Financial Entity`).
+- Timeout: allow at least 60 seconds for large portfolios.
+
+---
+
 ## Role Permissions Matrix
 
 | Permission | Owner | Admin | Member | Viewer |

--- a/docs/docs/deployment/environment-variables.md
+++ b/docs/docs/deployment/environment-variables.md
@@ -182,7 +182,14 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 | `GUARDRAIL_LLM_SEED` | - | Seed for reproducibility |
 | `GUARDRAIL_USE_SEED_CRITICAL` | `false` | Enable for evaluation |
 
-### Monitoring
+### Compliance Monitoring
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MONITORING_INTERVAL_HOURS` | `24` | How often the compliance monitoring alert worker runs (hours) |
+| `INSTITUTION_NAME` | `Financial Entity` | Institution name written into the RT.01.01 sheet of the RoI export |
+
+### LangSmith / RAGAS Monitoring
 
 | Variable | Description |
 |----------|-------------|


### PR DESCRIPTION
## Summary

Documentation-only update for Phase 4. No code changes — all backend/frontend work was shipped in PR #48.

## Pages updated

| File | Changes |
|------|---------|
| `backend/workers.md` | Add `monitoringWorker.js` to active workers table; new section covering all 6 alert checks, dedup behaviour, configuration, and updated queue config block |
| `backend/services.md` | Add `alertMonitorService.js` and `roiExportService.js` sections; add `sendMonitoringAlert` + `sendQuestionnaireInvitation` to the email service API table |
| `backend/models.md` | New Workspace Model section with full schema, `alertsSentAt` map key reference table, and pre-save cert-status hook |
| `api/workspaces.md` | New `GET /api/v1/workspaces/roi-export` endpoint with sheet descriptions, response headers, and usage notes |
| `deployment/environment-variables.md` | New Compliance Monitoring section with `MONITORING_INTERVAL_HOURS` and `INSTITUTION_NAME` |

Merging to `main` will trigger the Docusaurus deploy workflow and publish the updated docs to GitHub Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)