### PR TITLE
feat(org): organization-first onboarding

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -17,6 +17,7 @@ import assessmentRoutes from './routes/assessmentRoutes.js';
 import dataSourceRoutes from './routes/dataSourceRoutes.js';
 import complianceRoutes from './routes/complianceRoutes.js';
 import questionnaireRoutes from './routes/questionnaireRoutes.js';
+import organizationRoutes from './routes/organizationRoutes.js';
 import logger from './config/logger.js';
 import { globalErrorHandler } from './utils/index.js';
 
@@ -231,6 +232,7 @@ app.use('/api/v1/assessments', assessmentRoutes);
 app.use('/api/v1/data-sources', dataSourceRoutes);
 app.use('/api/v1/compliance', complianceRoutes);
 app.use('/api/v1/questionnaires', questionnaireRoutes);
+app.use('/api/v1/organizations', organizationRoutes);
 
 app.get('/', (req, res) => {
   res.send('Hello from a secure app.js!');

--- a/backend/controllers/organizationController.js
+++ b/backend/controllers/organizationController.js
@@ -1,0 +1,345 @@
+/**
+ * Organization Controller
+ *
+ * Handles org creation, membership, and invite flows for the
+ * organization-first onboarding model.
+ */
+
+import { Organization } from '../models/Organization.js';
+import { OrganizationMember } from '../models/OrganizationMember.js';
+import { User } from '../models/User.js';
+import { emailService } from '../services/emailService.js';
+import { catchAsync, sendSuccess, sendError } from '../utils/index.js';
+import { safeDecrypt } from '../utils/security/fieldEncryption.js';
+import logger from '../config/logger.js';
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/organizations
+// ---------------------------------------------------------------------------
+export const createOrganization = catchAsync(async (req, res) => {
+  const userId = req.user.userId;
+  const { name, industry, country } = req.body;
+
+  if (!name?.trim()) {
+    return sendError(res, 400, 'Organization name is required');
+  }
+
+  // Prevent duplicate org membership
+  const existing = await OrganizationMember.findOne({ userId, status: 'active' });
+  if (existing) {
+    return sendError(res, 409, 'You already belong to an organization');
+  }
+
+  const org = await Organization.create({
+    name: name.trim(),
+    industry: industry || 'other',
+    country: country?.trim() || '',
+    ownerId: userId,
+  });
+
+  const user = await User.findById(userId);
+
+  await OrganizationMember.create({
+    organizationId: org._id,
+    userId,
+    email: user.email,
+    role: 'org_admin',
+    status: 'active',
+    joinedAt: new Date(),
+  });
+
+  await User.findByIdAndUpdate(userId, { organizationId: org._id });
+
+  logger.info('Organization created', {
+    service: 'organization',
+    orgId: org._id,
+    userId,
+  });
+
+  sendSuccess(res, 201, 'Organization created', {
+    organization: {
+      id: org._id,
+      name: org.name,
+      industry: org.industry,
+      country: org.country,
+    },
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/organizations/me
+// ---------------------------------------------------------------------------
+export const getMyOrganization = catchAsync(async (req, res) => {
+  const userId = req.user.userId;
+
+  const membership = await OrganizationMember.findOne({
+    userId,
+    status: 'active',
+  }).populate('organizationId');
+
+  if (!membership || !membership.organizationId) {
+    return sendSuccess(res, 200, 'No organization', { organization: null, role: null });
+  }
+
+  const org = membership.organizationId;
+
+  sendSuccess(res, 200, 'Organization retrieved', {
+    organization: {
+      id: org._id,
+      name: org.name,
+      industry: org.industry,
+      country: org.country,
+    },
+    role: membership.role,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/organizations/invite-info?token=XXX  (PUBLIC — no auth)
+// ---------------------------------------------------------------------------
+export const getInviteInfo = catchAsync(async (req, res) => {
+  const { token } = req.query;
+
+  if (!token) {
+    return sendError(res, 400, 'Token is required');
+  }
+
+  const member = await OrganizationMember.findByToken(token);
+
+  if (!member) {
+    return sendError(res, 404, 'Invalid or expired invite link');
+  }
+
+  const org = await Organization.findById(member.organizationId);
+  if (!org) {
+    return sendError(res, 404, 'Organization not found');
+  }
+
+  let inviterName = null;
+  if (member.invitedBy) {
+    const inviter = await User.findById(member.invitedBy).select('name email');
+    if (inviter) {
+      inviterName = safeDecrypt(inviter.name) || inviter.email;
+    }
+  }
+
+  sendSuccess(res, 200, 'Invite info retrieved', {
+    organizationName: org.name,
+    inviterName,
+    role: member.role,
+    email: member.email,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/organizations/invite
+// ---------------------------------------------------------------------------
+export const inviteMember = catchAsync(async (req, res) => {
+  const inviterId = req.user.userId;
+  const { email, role = 'analyst' } = req.body;
+
+  if (!email) {
+    return sendError(res, 400, 'Email is required');
+  }
+
+  if (!['org_admin', 'analyst', 'viewer'].includes(role)) {
+    return sendError(res, 400, 'Invalid role');
+  }
+
+  // Verify caller is org_admin
+  const callerMembership = await OrganizationMember.findOne({
+    userId: inviterId,
+    status: 'active',
+  });
+
+  if (!callerMembership) {
+    return sendError(res, 403, 'You do not belong to an organization');
+  }
+
+  if (callerMembership.role !== 'org_admin') {
+    return sendError(res, 403, 'Only org admins can invite members');
+  }
+
+  const orgId = callerMembership.organizationId;
+
+  // Check if already active
+  const existingActive = await OrganizationMember.findOne({
+    organizationId: orgId,
+    email: email.toLowerCase(),
+    status: 'active',
+  });
+
+  if (existingActive) {
+    return sendError(res, 409, 'This user is already an active member');
+  }
+
+  // Create or refresh invite
+  const { member, rawToken } = await OrganizationMember.createInvite(orgId, email, role, inviterId);
+
+  const org = await Organization.findById(orgId);
+  const inviter = await User.findById(inviterId).select('name email');
+  const inviterName = safeDecrypt(inviter?.name) || inviter?.email || 'A team member';
+
+  emailService
+    .sendOrganizationInvitation({
+      toEmail: email,
+      inviterName,
+      organizationName: org.name,
+      role,
+      inviteToken: rawToken,
+    })
+    .catch((err) => {
+      logger.warn('Failed to send org invitation email', {
+        service: 'organization',
+        error: err.message,
+      });
+    });
+
+  logger.info('Org invite sent', {
+    service: 'organization',
+    orgId,
+    email,
+    role,
+    inviterId,
+  });
+
+  sendSuccess(res, 201, 'Invitation sent', {
+    member: {
+      id: member._id,
+      email: member.email,
+      role: member.role,
+      status: member.status,
+    },
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/organizations/accept-invite  (authenticated)
+// ---------------------------------------------------------------------------
+export const acceptInvite = catchAsync(async (req, res) => {
+  const userId = req.user.userId;
+  const { token } = req.body;
+
+  if (!token) {
+    return sendError(res, 400, 'Token is required');
+  }
+
+  const member = await OrganizationMember.findByToken(token);
+
+  if (!member) {
+    return sendError(res, 404, 'Invalid or expired invite token');
+  }
+
+  const user = await User.findById(userId);
+  if (!user) {
+    return sendError(res, 404, 'User not found');
+  }
+
+  if (member.email !== user.email.toLowerCase()) {
+    return sendError(res, 403, 'This invite was sent to a different email address');
+  }
+
+  // Already in an org?
+  const existingMembership = await OrganizationMember.findOne({
+    userId,
+    status: 'active',
+  });
+
+  if (existingMembership) {
+    return sendError(res, 409, 'You already belong to an organization');
+  }
+
+  await OrganizationMember.activate(member._id, userId);
+  await User.findByIdAndUpdate(userId, { organizationId: member.organizationId });
+
+  logger.info('Org invite accepted', {
+    service: 'organization',
+    orgId: member.organizationId,
+    userId,
+  });
+
+  sendSuccess(res, 200, 'Invitation accepted');
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/organizations/members
+// ---------------------------------------------------------------------------
+export const getMembers = catchAsync(async (req, res) => {
+  const userId = req.user.userId;
+
+  const callerMembership = await OrganizationMember.findOne({
+    userId,
+    status: 'active',
+  });
+
+  if (!callerMembership) {
+    return sendError(res, 403, 'You do not belong to an organization');
+  }
+
+  const members = await OrganizationMember.find({
+    organizationId: callerMembership.organizationId,
+    status: { $ne: 'revoked' },
+  }).populate('userId', 'name email');
+
+  const memberList = members.map((m) => ({
+    id: m._id.toString(),
+    email: m.email,
+    role: m.role,
+    status: m.status,
+    joinedAt: m.joinedAt,
+    user: m.userId
+      ? {
+          id: m.userId._id.toString(),
+          name: safeDecrypt(m.userId.name),
+          email: m.userId.email,
+        }
+      : null,
+  }));
+
+  sendSuccess(res, 200, 'Members retrieved', { members: memberList });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/organizations/members/:memberId
+// ---------------------------------------------------------------------------
+export const removeMember = catchAsync(async (req, res) => {
+  const userId = req.user.userId;
+  const { memberId } = req.params;
+
+  const callerMembership = await OrganizationMember.findOne({
+    userId,
+    status: 'active',
+  });
+
+  if (!callerMembership || callerMembership.role !== 'org_admin') {
+    return sendError(res, 403, 'Only org admins can remove members');
+  }
+
+  const target = await OrganizationMember.findById(memberId);
+
+  if (!target || target.organizationId.toString() !== callerMembership.organizationId.toString()) {
+    return sendError(res, 404, 'Member not found');
+  }
+
+  if (target.userId?.toString() === userId) {
+    // Check that there is at least one other admin before allowing self-removal
+    const adminCount = await OrganizationMember.countDocuments({
+      organizationId: callerMembership.organizationId,
+      role: 'org_admin',
+      status: 'active',
+    });
+    if (adminCount <= 1) {
+      return sendError(res, 400, 'Cannot remove the only org admin');
+    }
+  }
+
+  await OrganizationMember.findByIdAndUpdate(memberId, { status: 'revoked' });
+
+  logger.info('Org member removed', {
+    service: 'organization',
+    memberId,
+    removedBy: userId,
+  });
+
+  sendSuccess(res, 200, 'Member removed');
+});

--- a/backend/models/Organization.js
+++ b/backend/models/Organization.js
@@ -1,0 +1,19 @@
+import mongoose from 'mongoose';
+
+const { Schema } = mongoose;
+
+const organizationSchema = new Schema(
+  {
+    name: { type: String, required: true, trim: true, maxlength: 100 },
+    industry: {
+      type: String,
+      enum: ['insurance', 'banking', 'investment', 'payments', 'other'],
+      default: 'other',
+    },
+    country: { type: String, maxlength: 100, default: '' },
+    ownerId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  },
+  { timestamps: true }
+);
+
+export const Organization = mongoose.model('Organization', organizationSchema);

--- a/backend/models/OrganizationMember.js
+++ b/backend/models/OrganizationMember.js
@@ -1,0 +1,91 @@
+import mongoose from 'mongoose';
+import { sha256, generateToken } from '../utils/security/crypto.js';
+
+const { Schema } = mongoose;
+
+const orgMemberSchema = new Schema(
+  {
+    organizationId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Organization',
+      required: true,
+      index: true,
+    },
+    userId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+    email: { type: String, required: true, lowercase: true, trim: true },
+    role: {
+      type: String,
+      enum: ['org_admin', 'analyst', 'viewer'],
+      default: 'analyst',
+    },
+    status: {
+      type: String,
+      enum: ['pending', 'active', 'revoked'],
+      default: 'pending',
+    },
+    inviteTokenHash: { type: String, select: false },
+    inviteTokenExpires: { type: Date },
+    invitedBy: { type: Schema.Types.ObjectId, ref: 'User' },
+    joinedAt: { type: Date },
+  },
+  { timestamps: true }
+);
+
+// Unique: one active/pending membership per email per org
+orgMemberSchema.index({ organizationId: 1, email: 1 }, { unique: true });
+orgMemberSchema.index({ userId: 1 });
+
+/**
+ * Create an invite record with a raw token.
+ * Returns { member, rawToken }
+ */
+orgMemberSchema.statics.createInvite = async function (organizationId, email, role, invitedBy) {
+  const rawToken = generateToken(32);
+  const tokenHash = sha256(rawToken);
+  const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
+
+  // Upsert: allow re-inviting an already-pending member
+  const member = await this.findOneAndUpdate(
+    { organizationId, email: email.toLowerCase() },
+    {
+      organizationId,
+      email: email.toLowerCase(),
+      role,
+      invitedBy,
+      status: 'pending',
+      inviteTokenHash: tokenHash,
+      inviteTokenExpires: expires,
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+
+  return { member, rawToken };
+};
+
+/**
+ * Find a pending member by raw token.
+ */
+orgMemberSchema.statics.findByToken = async function (rawToken) {
+  const tokenHash = sha256(rawToken);
+  return this.findOne({
+    inviteTokenHash: tokenHash,
+    status: 'pending',
+    inviteTokenExpires: { $gt: new Date() },
+  }).select('+inviteTokenHash');
+};
+
+/**
+ * Activate membership: set status=active, userId, joinedAt; clear token.
+ */
+orgMemberSchema.statics.activate = async function (memberId, userId) {
+  return this.findByIdAndUpdate(
+    memberId,
+    {
+      $set: { status: 'active', userId, joinedAt: new Date() },
+      $unset: { inviteTokenHash: 1, inviteTokenExpires: 1 },
+    },
+    { new: true }
+  );
+};
+
+export const OrganizationMember = mongoose.model('OrganizationMember', orgMemberSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -163,6 +163,11 @@ const userSchema = new mongoose.Schema(
       enum: ['notify', 'auto_reconnect'],
       default: 'notify',
     },
+    organizationId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Organization',
+      default: null,
+    },
   },
   {
     timestamps: true,

--- a/backend/models/Workspace.js
+++ b/backend/models/Workspace.js
@@ -55,6 +55,12 @@ const workspaceSchema = new mongoose.Schema(
       of: Date,
       default: {},
     },
+    organizationId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Organization',
+      default: null,
+      index: true,
+    },
   },
   {
     timestamps: true,

--- a/backend/routes/organizationRoutes.js
+++ b/backend/routes/organizationRoutes.js
@@ -1,0 +1,28 @@
+import express from 'express';
+import { authenticate } from '../middleware/auth.js';
+import {
+  createOrganization,
+  getMyOrganization,
+  getInviteInfo,
+  inviteMember,
+  acceptInvite,
+  getMembers,
+  removeMember,
+} from '../controllers/organizationController.js';
+
+const router = express.Router();
+
+// Public — no auth required (used by /join page to show org name before login)
+router.get('/invite-info', getInviteInfo);
+
+// Authenticated routes
+router.use(authenticate);
+
+router.post('/', createOrganization);
+router.get('/me', getMyOrganization);
+router.post('/invite', inviteMember);
+router.post('/accept-invite', acceptInvite);
+router.get('/members', getMembers);
+router.delete('/members/:memberId', removeMember);
+
+export default router;

--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -109,6 +109,7 @@ const remote = {
   sendQuestionnaireInvitation: (p) =>
     callEmailService('/internal/email/questionnaire-invitation', p),
   sendMonitoringAlert: (p) => callEmailService('/internal/email/monitoring-alert', p),
+  sendOrganizationInvitation: (p) => callEmailService('/internal/email/org-invitation', p),
   verifyConnection: () => callEmailService('/internal/email/health', {}),
 };
 
@@ -273,6 +274,54 @@ const local = {
 </body>
 </html>`;
 
+    return _sendEmailInProcess({ to: toEmail, subject, html });
+  },
+
+  async sendOrganizationInvitation({ toEmail, inviterName, organizationName, role, inviteToken }) {
+    const inviteUrl = `${FRONTEND_URL}/join?token=${inviteToken}`;
+    const roleLabel = { org_admin: 'Admin', analyst: 'Analyst', viewer: 'Viewer' }[role] || role;
+    const subject = `${inviterName} invited you to join ${organizationName} on Retrieva`;
+    const html = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.6; color: #1a1a1a; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <div style="border-bottom: 3px solid #0f172a; padding-bottom: 16px; margin-bottom: 24px;">
+    <span style="font-weight: 700; font-size: 18px; color: #0f172a;">Retrieva</span>
+    <span style="font-size: 12px; color: #64748b; margin-left: 8px;">Compliance Platform</span>
+  </div>
+
+  <p style="margin: 0 0 16px;">Hi there,</p>
+
+  <p style="margin: 0 0 16px;">
+    <strong>${inviterName}</strong> has invited you to join <strong>${organizationName}</strong>
+    on Retrieva as <strong>${roleLabel}</strong>.
+  </p>
+
+  <p style="margin: 0 0 16px;">
+    Retrieva is a DORA compliance platform that helps financial entities manage third-party ICT risk.
+    As a member of ${organizationName}, you'll have access to all vendor workspaces and compliance tools.
+  </p>
+
+  <div style="text-align: center; margin: 32px 0;">
+    <a href="${inviteUrl}"
+       style="display: inline-block; background: #0f172a; color: #ffffff; text-decoration: none;
+              padding: 14px 32px; border-radius: 6px; font-weight: 600; font-size: 15px;">
+      Accept Invitation
+    </a>
+  </div>
+
+  <p style="font-size: 13px; color: #64748b; margin: 24px 0 0;">
+    If the button above does not work, copy and paste this link into your browser:<br>
+    <a href="${inviteUrl}" style="color: #0f172a; word-break: break-all;">${inviteUrl}</a>
+  </p>
+
+  <div style="border-top: 1px solid #e2e8f0; margin-top: 32px; padding-top: 16px;">
+    <p style="font-size: 12px; color: #94a3b8; margin: 0;">
+      This invitation expires in 7 days. If you did not expect this invitation, you can safely ignore it.
+    </p>
+  </div>
+</body>
+</html>`;
     return _sendEmailInProcess({ to: toEmail, subject, html });
   },
 

--- a/frontend/src/app/(auth)/join/page.tsx
+++ b/frontend/src/app/(auth)/join/page.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useEffect, useState, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Loader2, Building2, UserCheck, AlertTriangle } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useAuthStore } from '@/lib/stores/auth-store';
+import { organizationsApi } from '@/lib/api/organizations';
+import { getErrorMessage } from '@/lib/api';
+
+const ROLE_LABEL: Record<string, string> = {
+  org_admin: 'Admin',
+  analyst: 'Analyst',
+  viewer: 'Viewer',
+};
+
+function JoinPageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { user, isAuthenticated, isInitialized, fetchUser } = useAuthStore();
+
+  const token = searchParams.get('token');
+
+  const [inviteInfo, setInviteInfo] = useState<{
+    organizationName: string;
+    inviterName: string | null;
+    role: string;
+    email: string;
+  } | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAccepting, setIsAccepting] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      setFetchError('No invite token provided.');
+      setIsLoading(false);
+      return;
+    }
+
+    organizationsApi
+      .getInviteInfo(token)
+      .then((res) => {
+        if (res.status === 'success' && res.data) {
+          setInviteInfo(res.data);
+        } else {
+          setFetchError('Invalid or expired invite link.');
+        }
+      })
+      .catch(() => {
+        setFetchError('Invalid or expired invite link.');
+      })
+      .finally(() => setIsLoading(false));
+  }, [token]);
+
+  const handleAccept = async () => {
+    if (!token) return;
+    setIsAccepting(true);
+    try {
+      await organizationsApi.acceptInvite(token);
+      await fetchUser();
+      toast.success(`Welcome to ${inviteInfo?.organizationName}!`);
+      router.push('/assessments');
+    } catch (err) {
+      toast.error(getErrorMessage(err));
+      setIsAccepting(false);
+    }
+  };
+
+  const handleRegisterRedirect = () => {
+    const params = new URLSearchParams();
+    if (token) params.set('token', token);
+    if (inviteInfo?.email) params.set('email', encodeURIComponent(inviteInfo.email));
+    router.push(`/register?${params.toString()}`);
+  };
+
+  if (isLoading || !isInitialized) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 gap-3">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <p className="text-muted-foreground text-sm">Loading invite...</p>
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="space-y-4 text-center py-4">
+        <AlertTriangle className="h-12 w-12 text-destructive mx-auto" />
+        <h2 className="text-xl font-semibold">Invite not found</h2>
+        <p className="text-muted-foreground text-sm">{fetchError}</p>
+        <Button variant="outline" onClick={() => router.push('/login')}>
+          Go to login
+        </Button>
+      </div>
+    );
+  }
+
+  if (!inviteInfo) return null;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2 text-center">
+        <Building2 className="h-10 w-10 mx-auto text-primary" />
+        <h2 className="text-2xl font-semibold tracking-tight">
+          You&apos;re invited to join
+        </h2>
+        <p className="text-lg font-medium">{inviteInfo.organizationName}</p>
+        {inviteInfo.inviterName && (
+          <p className="text-sm text-muted-foreground">
+            Invited by <span className="font-medium">{inviteInfo.inviterName}</span>
+          </p>
+        )}
+        <div className="flex justify-center">
+          <Badge variant="secondary" className="text-sm">
+            Role: {ROLE_LABEL[inviteInfo.role] || inviteInfo.role}
+          </Badge>
+        </div>
+      </div>
+
+      {isAuthenticated && user ? (
+        // Authenticated — show Accept button
+        <div className="space-y-4">
+          <div className="bg-muted rounded-md p-3 text-sm text-center text-muted-foreground">
+            You are signed in as <span className="font-medium">{user.email}</span>
+          </div>
+
+          {user.organizationId ? (
+            <div className="bg-destructive/10 border border-destructive/20 text-destructive text-sm rounded-md p-3 text-center">
+              You already belong to an organization. Contact support if you need to switch.
+            </div>
+          ) : (
+            <Button
+              className="w-full"
+              onClick={handleAccept}
+              disabled={isAccepting}
+            >
+              {isAccepting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Joining...
+                </>
+              ) : (
+                <>
+                  <UserCheck className="mr-2 h-4 w-4" />
+                  Accept &amp; join {inviteInfo.organizationName}
+                </>
+              )}
+            </Button>
+          )}
+        </div>
+      ) : (
+        // Not authenticated — redirect to register with token pre-filled
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground text-center">
+            Create an account to join your team on Retrieva.
+          </p>
+          <Button className="w-full" onClick={handleRegisterRedirect}>
+            Create account &amp; join
+          </Button>
+          <div className="text-center text-sm text-muted-foreground">
+            Already have an account?{' '}
+            <button
+              className="text-primary hover:underline font-medium"
+              onClick={() => router.push(`/login?redirect=/join?token=${token}`)}
+            >
+              Sign in
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function JoinPage() {
+  return (
+    <Suspense>
+      <JoinPageContent />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/(auth)/onboarding/page.tsx
+++ b/frontend/src/app/(auth)/onboarding/page.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Loader2, Building2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useAuthStore } from '@/lib/stores/auth-store';
+import { organizationsApi } from '@/lib/api/organizations';
+import { getErrorMessage } from '@/lib/api';
+
+const onboardingSchema = z.object({
+  name: z.string().min(2, 'Organization name must be at least 2 characters').max(100),
+  industry: z.enum(['insurance', 'banking', 'investment', 'payments', 'other']),
+  country: z.string().max(100).optional(),
+});
+
+type OnboardingFormData = z.infer<typeof onboardingSchema>;
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const { user, isAuthenticated, isInitialized, fetchUser } = useAuthStore();
+  const [error, setError] = useState<string | null>(null);
+
+  // Redirect if not authenticated
+  useEffect(() => {
+    if (isInitialized && !isAuthenticated) {
+      router.replace('/login');
+    }
+    // If user already has an org, skip onboarding
+    if (isInitialized && isAuthenticated && user?.organizationId) {
+      router.replace('/assessments');
+    }
+  }, [isInitialized, isAuthenticated, user?.organizationId, router]);
+
+  const form = useForm<OnboardingFormData>({
+    resolver: zodResolver(onboardingSchema),
+    defaultValues: {
+      name: '',
+      industry: 'other',
+      country: '',
+    },
+  });
+
+  const { isSubmitting } = form.formState;
+
+  const onSubmit = async (data: OnboardingFormData) => {
+    setError(null);
+    try {
+      await organizationsApi.create({
+        name: data.name,
+        industry: data.industry,
+        country: data.country || '',
+      });
+      // Re-fetch user so auth store gets org data
+      await fetchUser();
+      toast.success(`${data.name} created! Welcome to Retrieva.`);
+      router.push('/assessments');
+    } catch (err) {
+      setError(getErrorMessage(err));
+    }
+  };
+
+  if (!isInitialized || !isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2 text-center">
+        <Building2 className="h-10 w-10 mx-auto text-primary" />
+        <h2 className="text-2xl font-semibold tracking-tight">Create your organization</h2>
+        <p className="text-sm text-muted-foreground">
+          Set up your company account to manage DORA compliance for all vendors
+        </p>
+      </div>
+
+      {error && (
+        <div className="bg-destructive/10 border border-destructive/20 text-destructive text-sm rounded-md p-3">
+          {error}
+        </div>
+      )}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Organization name</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="HDI Global SE"
+                    disabled={isSubmitting}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="industry"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Industry</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                  disabled={isSubmitting}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select industry" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="insurance">Insurance</SelectItem>
+                    <SelectItem value="banking">Banking</SelectItem>
+                    <SelectItem value="investment">Investment / Asset Management</SelectItem>
+                    <SelectItem value="payments">Payments</SelectItem>
+                    <SelectItem value="other">Other Financial Services</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="country"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Country <span className="text-muted-foreground">(optional)</span></FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="Germany"
+                    disabled={isSubmitting}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Creating organization...
+              </>
+            ) : (
+              'Create organization'
+            )}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -22,6 +22,7 @@ export default function DashboardLayout({
   const isInitialized = useAuthStore((state) => state.isInitialized);
   const isLoading = useAuthStore((state) => state.isLoading);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const user = useAuthStore((state) => state.user);
   const fetchWorkspaces = useWorkspaceStore((state) => state.fetchWorkspaces);
 
   // Handle responsive behavior
@@ -41,6 +42,13 @@ export default function DashboardLayout({
       router.replace('/login');
     }
   }, [isInitialized, isAuthenticated, router]);
+
+  // Redirect to onboarding if user has no org
+  useEffect(() => {
+    if (isInitialized && isAuthenticated && user && !user.organizationId) {
+      router.replace('/onboarding');
+    }
+  }, [isInitialized, isAuthenticated, user?.organizationId, router]);
 
   // Fetch workspaces when authenticated
   useEffect(() => {

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { WorkspaceSwitcher } from './workspace-switcher';
 import { useUIStore } from '@/lib/stores/ui-store';
+import { useAuthStore } from '@/lib/stores/auth-store';
 import { usePermissions } from '@/lib/hooks/use-permissions';
 import { desktopMainNavItems, bottomNavItems, type NavItem } from '@/lib/constants/nav-items';
 
@@ -17,6 +18,7 @@ export function Sidebar() {
   const sidebarCollapsed = useUIStore((state) => state.sidebarCollapsed);
   const setSidebarCollapsed = useUIStore((state) => state.setSidebarCollapsed);
   const permissions = usePermissions();
+  const user = useAuthStore((state) => state.user);
 
   const filterNavItems = (items: NavItem[]) => {
     return items.filter((item) => {
@@ -69,6 +71,15 @@ export function Sidebar() {
           )}
         </Button>
       </div>
+
+      {/* Organization label */}
+      {!sidebarCollapsed && user?.organization && (
+        <div className="px-3 pt-2 pb-0">
+          <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider truncate">
+            {user.organization.name}
+          </p>
+        </div>
+      )}
 
       {/* Workspace Switcher */}
       {!sidebarCollapsed && (

--- a/frontend/src/lib/api/organizations.ts
+++ b/frontend/src/lib/api/organizations.ts
@@ -1,0 +1,78 @@
+import apiClient from './client';
+import type { ApiResponse } from '@/types';
+
+export interface OrganizationData {
+  id: string;
+  name: string;
+  industry: string;
+  country: string;
+}
+
+export interface OrgMember {
+  id: string;
+  email: string;
+  role: 'org_admin' | 'analyst' | 'viewer';
+  status: 'pending' | 'active' | 'revoked';
+  joinedAt?: string;
+  user?: { id: string; name: string; email: string } | null;
+}
+
+export interface InviteInfoResponse {
+  organizationName: string;
+  inviterName: string | null;
+  role: string;
+  email: string;
+}
+
+export const organizationsApi = {
+  create: async (data: { name: string; industry: string; country: string }) => {
+    const response = await apiClient.post<ApiResponse<{ organization: OrganizationData }>>(
+      '/organizations',
+      data
+    );
+    return response.data;
+  },
+
+  getMe: async () => {
+    const response = await apiClient.get<
+      ApiResponse<{ organization: OrganizationData | null; role: string | null }>
+    >('/organizations/me');
+    return response.data;
+  },
+
+  getInviteInfo: async (token: string) => {
+    const response = await apiClient.get<ApiResponse<InviteInfoResponse>>(
+      `/organizations/invite-info?token=${encodeURIComponent(token)}`
+    );
+    return response.data;
+  },
+
+  invite: async (data: { email: string; role: string }) => {
+    const response = await apiClient.post<ApiResponse<{ member: OrgMember }>>(
+      '/organizations/invite',
+      data
+    );
+    return response.data;
+  },
+
+  acceptInvite: async (token: string) => {
+    const response = await apiClient.post<ApiResponse>('/organizations/accept-invite', {
+      token,
+    });
+    return response.data;
+  },
+
+  getMembers: async () => {
+    const response = await apiClient.get<ApiResponse<{ members: OrgMember[] }>>(
+      '/organizations/members'
+    );
+    return response.data;
+  },
+
+  removeMember: async (memberId: string) => {
+    const response = await apiClient.delete<ApiResponse>(
+      `/organizations/members/${memberId}`
+    );
+    return response.data;
+  },
+};

--- a/frontend/src/lib/stores/auth-store.ts
+++ b/frontend/src/lib/stores/auth-store.ts
@@ -16,7 +16,7 @@ interface AuthState {
   updateUser: (userData: Partial<User>) => void;
   setInitialized: () => void;
   login: (email: string, password: string) => Promise<void>;
-  register: (email: string, password: string, name: string) => Promise<void>;
+  register: (email: string, password: string, name: string, inviteToken?: string) => Promise<{ needsOrganization: boolean }>;
   logout: (all?: boolean) => Promise<void>;
   fetchUser: () => Promise<void>;
   initialize: () => Promise<void>;
@@ -67,10 +67,10 @@ export const useAuthStore = create<AuthState>()(
         }
       },
 
-      register: async (email, password, name) => {
+      register: async (email, password, name, inviteToken) => {
         set({ isLoading: true });
         try {
-          const response = await authApi.register({ email, password, name });
+          const response = await authApi.register({ email, password, name, inviteToken });
           if (response.status === 'success' && response.data) {
             set({
               user: response.data.user,
@@ -78,6 +78,7 @@ export const useAuthStore = create<AuthState>()(
               isLoading: false,
             });
           }
+          return { needsOrganization: response.data?.needsOrganization ?? true };
         } catch (error) {
           set({ isLoading: false });
           throw error;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -23,6 +23,13 @@ export interface PaginatedResponse<T> {
 export type GlobalRole = 'user' | 'admin';
 export type WorkspaceRole = 'owner' | 'member' | 'viewer';
 
+export interface UserOrganization {
+  id: string;
+  name: string;
+  industry: string;
+  country: string;
+}
+
 export interface User {
   id: string;
   email: string;
@@ -31,6 +38,8 @@ export interface User {
   isEmailVerified?: boolean;
   createdAt?: string;
   lastLogin?: string;
+  organizationId?: string | null;
+  organization?: UserOrganization | null;
 }
 
 export interface AuthTokens {
@@ -42,6 +51,7 @@ export interface AuthResponse {
   user: User;
   accessToken: string;
   refreshToken: string;
+  needsOrganization?: boolean;
 }
 
 // Workspace Types
@@ -202,6 +212,7 @@ export interface RegisterData {
   email: string;
   password: string;
   name: string;
+  inviteToken?: string;
 }
 
 export interface ForgotPasswordData {


### PR DESCRIPTION
## Summary

- Adds `Organization` and `OrganizationMember` models enabling a company account (B2B) model where one CRO creates an org and invites the whole team via email link
- All org members automatically see every vendor workspace (no per-workspace membership needed), scoped by `organizationId`
- Two new frontend flows: `/onboarding` (create org after registration) and `/join` (accept email invite)
- Monitoring alerts worker and RoI Excel export are also fully implemented in this branch

## Key changes

**Backend (new)**
- `Organization` model: name, industry, country, ownerId
- `OrganizationMember` model: SHA-256 invite tokens (7-day expiry), static helpers `createInvite` / `findByToken` / `activate`
- `organizationController`: 7 handlers — create org, get my org, get invite info (public), invite member, accept invite, list members, remove member
- `organizationRoutes` at `/api/v1/organizations`

**Backend (modified)**
- `authController.register`: processes `inviteToken`, returns `needsOrganization` flag
- `authController.getMe`: populates `organization` field
- `workspaceMemberController.createWorkspace`: attaches `organizationId`
- `workspaceMemberController.getMyWorkspaces`: returns all org workspaces for org members (falls back to per-workspace for legacy users)
- `emailService`: `sendOrganizationInvitation` added (local + remote routing)
- `User` + `Workspace` models: `organizationId` reference field added

**Frontend**
- `/onboarding` page: form to create org, protected gate
- `/join` page: invite accept card (authenticated) or redirect to `/register?token=&email=` (unauthenticated)
- `organizations.ts` API client
- `register/page.tsx`: reads `?token=` & `?email=`, routes to `/onboarding` or `/assessments`
- `auth-store.ts`: `register()` accepts `inviteToken`, returns `{ needsOrganization }`
- `dashboard/layout.tsx`: redirects to `/onboarding` when `user.organizationId` is null
- `sidebar.tsx`: org name label above workspace switcher

## Test plan

- [ ] Register fresh user → redirected to `/onboarding` → create "HDI Global SE" → sidebar shows org name
- [ ] Invite thomas@hdi.de → click email link → register → land on `/assessments` without `/onboarding`
- [ ] Log in as Maria → create vendor workspace → log in as Thomas → workspace appears without manual add
- [ ] `GET /auth/me` includes `organization: { id, name, industry, country }`
- [ ] `GET /workspaces/my-workspaces` for Thomas returns org workspaces
- [ ] `GET /api/v1/organizations/invite-info?token=XXX` returns org info (no auth)
- [ ] CI passes: lint 0 errors, 1099 backend tests pass, frontend build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)