### PR TITLE
fix(ci): remove deprecated script_stop and fix layout exhaustive-deps

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -104,7 +104,6 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          script_stop: true
           script: |
             set -e
             cd /opt/rag

--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -22,7 +22,7 @@ export default function DashboardLayout({
   const isInitialized = useAuthStore((state) => state.isInitialized);
   const isLoading = useAuthStore((state) => state.isLoading);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const user = useAuthStore((state) => state.user);
+  const organizationId = useAuthStore((state) => state.user?.organizationId);
   const fetchWorkspaces = useWorkspaceStore((state) => state.fetchWorkspaces);
 
   // Handle responsive behavior
@@ -45,10 +45,10 @@ export default function DashboardLayout({
 
   // Redirect to onboarding if user has no org
   useEffect(() => {
-    if (isInitialized && isAuthenticated && user && !user.organizationId) {
+    if (isInitialized && isAuthenticated && !organizationId) {
       router.replace('/onboarding');
     }
-  }, [isInitialized, isAuthenticated, user?.organizationId, router]);
+  }, [isInitialized, isAuthenticated, organizationId, router]);
 
   // Fetch workspaces when authenticated
   useEffect(() => {


### PR DESCRIPTION
## Summary

Two CI/lint warnings from the PR #55 deployment, now resolved.

- **`cd.yml`**: removed `script_stop: true` (invalid input in `appleboy/ssh-action@v1`; `set -e` in the script body already provides stop-on-error)
- **`dashboard/layout.tsx`**: select `organizationId` directly from the auth store so the onboarding-gate `useEffect` dep array is exact — eliminates the `react-hooks/exhaustive-deps` warning with no behaviour change

## Test plan

- [ ] Backend lint: 0 errors
- [ ] Frontend lint: 0 errors (layout.tsx warning gone)
- [ ] Backend tests: 1099/1099
- [ ] Frontend build: clean
- [ ] CD run annotations: no more `script_stop` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)