### PR TITLE
fix(auth): include org in login response and fix join page lint warning

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -199,6 +199,20 @@ export const login = async (req, res) => {
     const deviceInfo = getDeviceInfo(req);
     await user.addRefreshToken(tokenHash, deviceInfo);
 
+    // Populate organization data so the frontend skips the onboarding gate
+    let organization = null;
+    if (user.organizationId) {
+      const org = await Organization.findById(user.organizationId).select('name industry country');
+      if (org) {
+        organization = {
+          id: org._id,
+          name: org.name,
+          industry: org.industry,
+          country: org.country,
+        };
+      }
+    }
+
     logger.info('User logged in', {
       userId: user._id,
       email: user.email,
@@ -214,6 +228,8 @@ export const login = async (req, res) => {
         name: safeDecrypt(user.name),
         role: user.role,
         isEmailVerified: user.isEmailVerified,
+        organizationId: user.organizationId ? user.organizationId.toString() : null,
+        organization,
       },
       // Tokens also returned in body for API clients (mobile apps, etc.)
       ...tokens,

--- a/frontend/src/app/(auth)/join/page.tsx
+++ b/frontend/src/app/(auth)/join/page.tsx
@@ -31,15 +31,11 @@ function JoinPageContent() {
     email: string;
   } | null>(null);
   const [fetchError, setFetchError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(!!token);
   const [isAccepting, setIsAccepting] = useState(false);
 
   useEffect(() => {
-    if (!token) {
-      setFetchError('No invite token provided.');
-      setIsLoading(false);
-      return;
-    }
+    if (!token) return;
 
     organizationsApi
       .getInviteInfo(token)
@@ -76,6 +72,19 @@ function JoinPageContent() {
     if (inviteInfo?.email) params.set('email', encodeURIComponent(inviteInfo.email));
     router.push(`/register?${params.toString()}`);
   };
+
+  if (!token) {
+    return (
+      <div className="space-y-4 text-center py-4">
+        <AlertTriangle className="h-12 w-12 text-destructive mx-auto" />
+        <h2 className="text-xl font-semibold">Invite not found</h2>
+        <p className="text-muted-foreground text-sm">No invite token provided.</p>
+        <Button variant="outline" onClick={() => router.push('/login')}>
+          Go to login
+        </Button>
+      </div>
+    );
+  }
 
   if (isLoading || !isInitialized) {
     return (


### PR DESCRIPTION
## Summary
- **Onboarding redirect bug**: The `login` endpoint now returns `organizationId` and `organization` in the user object (same enrichment as `GET /auth/me`). Previously, the frontend auth-provider would call `setInitialized()` on the login route without fetching the user profile, leaving `organizationId` null — which triggered the `/onboarding` redirect even for users already in an org.
- **`join/page.tsx` lint warning**: Moved the no-token check from a synchronous `setFetchError()` call inside `useEffect` to a render-time branch. The effect now only runs async work when a token is present, eliminating the `react-hooks/set-state-in-effect` warning.

## Test plan
- [ ] Log in with an existing account that has an organization → should land on `/assessments`, NOT `/onboarding`
- [ ] Visit `/join` with no token in URL → should render the error card without lint warnings
- [ ] Visit `/join?token=<valid>` → invite info loads normally
- [ ] Backend lint: 0 errors
- [ ] Frontend lint: 0 errors
- [ ] Backend tests: 1099 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)