### PR TITLE
feat: inherent/residual risk scoring, clause sign-off, and vendor risk register

### DIFF
--- a/backend/models/Assessment.js
+++ b/backend/models/Assessment.js
@@ -1,5 +1,30 @@
 import mongoose from 'mongoose';
 
+// ── Formal risk decision recorded by a compliance officer ──────────────────────
+const riskDecisionSchema = new mongoose.Schema(
+  {
+    decision: { type: String, enum: ['proceed', 'conditional', 'reject'], required: true },
+    setBy: { type: String, required: true }, // userId
+    setByName: { type: String, default: '' },
+    rationale: { type: String, default: '' },
+    setAt: { type: Date, default: Date.now },
+  },
+  { _id: false }
+);
+
+// ── Art. 30 clause-level sign-off ──────────────────────────────────────────────
+const clauseSignoffSchema = new mongoose.Schema(
+  {
+    clauseRef: { type: String, required: true }, // e.g. 'Art.30(2)(a)'
+    status: { type: String, enum: ['accepted', 'rejected', 'waived'], required: true },
+    signedBy: { type: String, required: true }, // userId
+    signedByName: { type: String, default: '' },
+    note: { type: String, default: '' },
+    signedAt: { type: Date, default: Date.now },
+  },
+  { _id: false }
+);
+
 const gapSchema = new mongoose.Schema(
   {
     article: { type: String, required: true }, // e.g. "DORA Article 28(4)(a)"
@@ -77,6 +102,9 @@ const assessmentSchema = new mongoose.Schema(
       domainsAnalyzed: [String],
     },
     reportPath: { type: String }, // path to generated .docx
+    // Formal compliance decisions (set by compliance officer after review)
+    riskDecision: { type: riskDecisionSchema, default: null },
+    clauseSignoffs: [clauseSignoffSchema],
     createdBy: {
       type: String,
       required: true,

--- a/backend/routes/assessmentRoutes.js
+++ b/backend/routes/assessmentRoutes.js
@@ -5,6 +5,8 @@ import {
   getAssessment,
   downloadReport,
   deleteAssessment,
+  setRiskDecision,
+  setClauseSignoff,
 } from '../controllers/assessmentController.js';
 import { authenticate } from '../middleware/auth.js';
 import { requireWorkspaceAccess } from '../middleware/workspaceAuth.js';
@@ -43,6 +45,20 @@ router.get('/:id', authenticate, requireWorkspaceAccess, getAssessment);
  * @access Private
  */
 router.get('/:id/report', authenticate, requireWorkspaceAccess, downloadReport);
+
+/**
+ * @route  PATCH /api/v1/assessments/:id/risk-decision
+ * @desc   Record a formal risk decision (proceed / conditional / reject)
+ * @access Private
+ */
+router.patch('/:id/risk-decision', authenticate, requireWorkspaceAccess, setRiskDecision);
+
+/**
+ * @route  PATCH /api/v1/assessments/:id/clause-signoff
+ * @desc   Sign off a single Art. 30 contract clause (accepted / rejected / waived)
+ * @access Private — CONTRACT_A30 assessments only
+ */
+router.patch('/:id/clause-signoff', authenticate, requireWorkspaceAccess, setClauseSignoff);
 
 /**
  * @route  DELETE /api/v1/assessments/:id

--- a/frontend/src/app/(dashboard)/risk-register/page.tsx
+++ b/frontend/src/app/(dashboard)/risk-register/page.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+/**
+ * Vendor Risk Register — portfolio-level DORA compliance view
+ *
+ * Shows all vendor workspaces as rows with columns:
+ *   Vendor · Tier · Service · DORA Risk · Gaps · Q Score · Contract · Certs · Next Review · Status
+ *
+ * This is the Art. 28(3) Register of Information in UI form.
+ * The RoI Excel export (EBA Master Template) is available on the Questionnaires page.
+ */
+
+import { useMemo } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { format } from 'date-fns';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Circle,
+  Building2,
+  FileDown,
+  ExternalLink,
+} from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useWorkspaceStore } from '@/lib/stores/workspace-store';
+import { assessmentsApi } from '@/lib/api/assessments';
+import { questionnairesApi } from '@/lib/api/questionnaires';
+import { workspacesApi } from '@/lib/api/workspaces';
+import type { Assessment, OverallRisk } from '@/lib/api/assessments';
+import type { VendorQuestionnaire } from '@/lib/api/questionnaires';
+import type { WorkspaceWithMembership } from '@/types';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function daysFrom(date: string | null | undefined): number | null {
+  if (!date) return null;
+  return Math.ceil((new Date(date).getTime() - new Date().getTime()) / 86_400_000);
+}
+
+function RiskBadge({ risk }: { risk: OverallRisk | null | undefined }) {
+  if (!risk) return <span className="text-muted-foreground text-xs">—</span>;
+  return (
+    <Badge
+      variant={risk === 'High' ? 'destructive' : risk === 'Medium' ? 'secondary' : 'default'}
+      className="text-xs"
+    >
+      {risk}
+    </Badge>
+  );
+}
+
+function TierBadge({ tier }: { tier: string | null | undefined }) {
+  if (!tier) return <span className="text-muted-foreground text-xs">—</span>;
+  if (tier === 'critical')
+    return <Badge variant="destructive" className="text-xs">Critical</Badge>;
+  if (tier === 'important')
+    return <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100 text-xs">Important</Badge>;
+  return <Badge variant="outline" className="text-xs">Standard</Badge>;
+}
+
+function ComplianceStatus({ steps }: { steps: number }) {
+  if (steps === 5) return <span className="flex items-center gap-1 text-green-600 text-xs font-medium"><CheckCircle2 className="h-3.5 w-3.5" />Complete</span>;
+  if (steps >= 3)  return <span className="flex items-center gap-1 text-amber-600 text-xs font-medium"><AlertTriangle className="h-3.5 w-3.5" />{steps}/5 steps</span>;
+  return <span className="flex items-center gap-1 text-muted-foreground text-xs"><Circle className="h-3.5 w-3.5" />{steps}/5 steps</span>;
+}
+
+function CertChip({ days }: { days: number | null }) {
+  if (days === null) return <span className="text-muted-foreground text-xs">—</span>;
+  if (days < 0)  return <span className="text-xs font-medium text-destructive">Expired</span>;
+  if (days <= 30) return <span className="text-xs font-medium text-destructive">{days}d</span>;
+  if (days <= 90) return <span className="text-xs font-medium text-amber-600">{days}d</span>;
+  return <span className="text-xs font-medium text-green-600">{days}d</span>;
+}
+
+// ── Risk register row data builder ────────────────────────────────────────────
+
+interface RegisterRow {
+  workspace:         WorkspaceWithMembership;
+  latestDora:        Assessment | null;
+  latestA30:         Assessment | null;
+  latestQ:           VendorQuestionnaire | null;
+  stepsComplete:     number;
+  nearestCertDays:   number | null;
+  contractDays:      number | null;
+  reviewDays:        number | null;
+}
+
+function buildRow(
+  workspace: WorkspaceWithMembership,
+  assessments: Assessment[],
+  questionnaires: VendorQuestionnaire[]
+): RegisterRow {
+  const wsAssessments = assessments.filter((a) => a.workspaceId === workspace.id);
+  const wsQs          = questionnaires.filter((q) => q.workspaceId === workspace.id);
+
+  const latestDora = wsAssessments
+    .filter((a) => a.framework === 'DORA' && a.status === 'complete')
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0] ?? null;
+
+  const latestA30 = wsAssessments
+    .filter((a) => a.framework === 'CONTRACT_A30' && a.status === 'complete')
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0] ?? null;
+
+  const latestQ = wsQs
+    .sort((a, b) => new Date(b.createdAt ?? 0).getTime() - new Date(a.createdAt ?? 0).getTime())[0] ?? null;
+
+  // Step completion count (mirrors ComplianceChecklist logic)
+  let steps = 0;
+  if (workspace.vendorTier && workspace.serviceType) steps++;
+  if (latestQ?.status === 'complete') steps++;
+  if (latestDora) steps++;
+  if (latestA30) steps++;
+  if ((workspace.certifications?.length ?? 0) > 0 && workspace.nextReviewDate) steps++;
+
+  // Nearest cert expiry
+  const certDays = (workspace.certifications ?? [])
+    .map((c) => daysFrom(c.validUntil))
+    .filter((d): d is number => d !== null);
+  const nearestCertDays = certDays.length > 0 ? Math.min(...certDays) : null;
+
+  return {
+    workspace,
+    latestDora,
+    latestA30,
+    latestQ,
+    stepsComplete: steps,
+    nearestCertDays,
+    contractDays: daysFrom(workspace.contractEnd),
+    reviewDays:   daysFrom(workspace.nextReviewDate),
+  };
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function RiskRegisterPage() {
+  const router     = useRouter();
+  const workspaces = useWorkspaceStore((state) => state.workspaces);
+
+  // Fetch full workspace details (certifications etc. may not be in store)
+  const { data: allWorkspaces, isLoading: wsLoading } = useQuery({
+    queryKey: ['workspaces-list'],
+    queryFn: async () => {
+      const res = await workspacesApi.list();
+      return (res.data?.workspaces ?? []) as WorkspaceWithMembership[];
+    },
+  });
+
+  // All assessments across all workspaces (no workspaceId filter)
+  const { data: allAssessments, isLoading: assLoading } = useQuery({
+    queryKey: ['all-assessments'],
+    queryFn: async () => {
+      const res = await assessmentsApi.list({ limit: 500 });
+      return res.data?.assessments ?? [];
+    },
+  });
+
+  // All questionnaires across all workspaces
+  const { data: allQuestionnaires, isLoading: qLoading } = useQuery({
+    queryKey: ['all-questionnaires'],
+    queryFn: async () => {
+      const res = await questionnairesApi.list({});
+      return (res.data?.questionnaires ?? []) as VendorQuestionnaire[];
+    },
+  });
+
+  const isLoading = wsLoading || assLoading || qLoading;
+
+  const rows: RegisterRow[] = useMemo(() => {
+    const ws  = allWorkspaces ?? workspaces;
+    const ass = allAssessments ?? [];
+    const qs  = allQuestionnaires ?? [];
+    return ws.map((w) => buildRow(w as WorkspaceWithMembership, ass, qs));
+  }, [allWorkspaces, workspaces, allAssessments, allQuestionnaires]);
+
+  // Summary stats
+  const highRiskCount  = rows.filter((r) => r.latestDora?.results?.overallRisk === 'High').length;
+  const completeCount  = rows.filter((r) => r.stepsComplete === 5).length;
+  const expiringCount  = rows.filter((r) => r.nearestCertDays !== null && r.nearestCertDays <= 90).length;
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto space-y-6">
+      {/* Page header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Vendor Risk Register</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            DORA Art. 28(3) — portfolio-level ICT third-party risk overview
+          </p>
+        </div>
+        <Link href="/questionnaires">
+          <Button variant="outline" size="sm">
+            <FileDown className="h-4 w-4 mr-2" />
+            Export RoI (Excel)
+          </Button>
+        </Link>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-3 gap-4">
+        {[
+          { label: 'Total vendors',       value: rows.length,    color: '' },
+          { label: 'High risk',           value: highRiskCount,  color: highRiskCount > 0 ? 'text-destructive' : 'text-green-600' },
+          { label: 'Fully compliant',     value: completeCount,  color: 'text-green-600' },
+        ].map((s) => (
+          <div key={s.label} className="rounded-lg border p-4 text-center">
+            <p className={`text-3xl font-bold ${s.color}`}>{s.value}</p>
+            <p className="text-xs text-muted-foreground mt-1">{s.label}</p>
+          </div>
+        ))}
+      </div>
+      {expiringCount > 0 && (
+        <div className="flex items-center gap-2 text-sm text-amber-600 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-md px-3 py-2">
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          {expiringCount} vendor{expiringCount > 1 ? 's' : ''} with certifications expiring within 90 days
+        </div>
+      )}
+
+      {/* Register table */}
+      {isLoading ? (
+        <div className="space-y-3">
+          {[...Array(5)].map((_, i) => <Skeleton key={i} className="h-12 w-full" />)}
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+          <Building2 className="h-12 w-12 text-muted-foreground/40" />
+          <p className="text-muted-foreground">No vendors yet.</p>
+          <Button size="sm" onClick={() => router.push('/workspaces')}>Add your first vendor</Button>
+        </div>
+      ) : (
+        <div className="rounded-md border overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="min-w-[160px]">Vendor</TableHead>
+                <TableHead>Tier</TableHead>
+                <TableHead>Service</TableHead>
+                <TableHead>DORA Risk</TableHead>
+                <TableHead>Gaps</TableHead>
+                <TableHead>Q Score</TableHead>
+                <TableHead>Contract</TableHead>
+                <TableHead>Certs</TableHead>
+                <TableHead>Next Review</TableHead>
+                <TableHead>Compliance</TableHead>
+                <TableHead className="w-8"></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map(({ workspace, latestDora, latestA30, latestQ, stepsComplete, nearestCertDays, reviewDays }) => {
+                const missing = latestDora?.results?.gaps.filter((g) => g.gapLevel === 'missing').length ?? null;
+                const partial = latestDora?.results?.gaps.filter((g) => g.gapLevel === 'partial').length ?? null;
+                const qScore  = latestQ?.status === 'complete' ? (latestQ.overallScore ?? null) : null;
+                const contractOk = latestA30?.status === 'complete' &&
+                  (latestA30.results?.gaps.filter((g) => g.gapLevel === 'missing').length ?? 0) === 0;
+
+                return (
+                  <TableRow
+                    key={workspace.id}
+                    className="cursor-pointer"
+                    onClick={() => router.push(`/workspaces/${workspace.id}`)}
+                  >
+                    <TableCell className="font-medium">
+                      <div className="flex items-center gap-2">
+                        <Building2 className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                        {workspace.name}
+                      </div>
+                    </TableCell>
+                    <TableCell><TierBadge tier={workspace.vendorTier} /></TableCell>
+                    <TableCell>
+                      <span className="text-xs capitalize text-muted-foreground">
+                        {workspace.serviceType ?? '—'}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <RiskBadge risk={latestDora?.results?.overallRisk} />
+                    </TableCell>
+                    <TableCell>
+                      {latestDora ? (
+                        <span className="text-xs">
+                          <span className="text-destructive font-medium">{missing}</span>
+                          <span className="text-muted-foreground"> / </span>
+                          <span className="text-amber-600 font-medium">{partial}</span>
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {qScore !== null ? (
+                        <span className={`text-xs font-medium ${qScore >= 70 ? 'text-green-600' : qScore >= 40 ? 'text-amber-600' : 'text-destructive'}`}>
+                          {qScore}/100
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {latestA30 ? (
+                        contractOk
+                          ? <span className="flex items-center gap-1 text-xs text-green-600"><CheckCircle2 className="h-3.5 w-3.5" />OK</span>
+                          : <span className="flex items-center gap-1 text-xs text-amber-600"><AlertTriangle className="h-3.5 w-3.5" />Gaps</span>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell><CertChip days={nearestCertDays} /></TableCell>
+                    <TableCell>
+                      {reviewDays !== null ? (
+                        <span className={`text-xs font-medium ${reviewDays < 0 ? 'text-destructive' : reviewDays <= 30 ? 'text-amber-600' : 'text-muted-foreground'}`}>
+                          {reviewDays < 0 ? `${Math.abs(reviewDays)}d overdue` : format(new Date(workspace.nextReviewDate!), 'dd MMM yy')}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell><ComplianceStatus steps={stepsComplete} /></TableCell>
+                    <TableCell>
+                      <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/assessment/ClauseSignoffPanel.tsx
+++ b/frontend/src/components/assessment/ClauseSignoffPanel.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+/**
+ * ClauseSignoffPanel — Step 4 gap fixes
+ *
+ * Adds to CONTRACT_A30 assessment reports:
+ *  1. Per-clause Accept / Reject / Waive sign-off buttons
+ *  2. Sign-off progress counter ("X of 12 reviewed")
+ *  3. Negotiation round indicator ("Round N of M")
+ */
+
+import { useState } from 'react';
+import { format } from 'date-fns';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { CheckCircle2, XCircle, AlertTriangle, MinusCircle, ChevronDown, ChevronUp } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { assessmentsApi } from '@/lib/api/assessments';
+import type { Assessment, Gap, ClauseSignoff, ClauseSignoffStatus } from '@/lib/api/assessments';
+
+// ── Art. 30 clauses constant (must match gapAnalysisAgent.js) ─────────────────
+
+export const ART30_CLAUSES = [
+  { ref: 'Art.30(2)(a)', category: 'Service Description',   text: 'Clear and complete description of all ICT services and functions to be provided' },
+  { ref: 'Art.30(2)(b)', category: 'Data Governance',       text: 'Locations (countries/regions) where data will be processed and stored' },
+  { ref: 'Art.30(2)(c)', category: 'Security & Resilience', text: 'Provisions on availability, authenticity, integrity and confidentiality of data' },
+  { ref: 'Art.30(2)(d)', category: 'Data Governance',       text: 'Provisions for accessibility, return, recovery and secure deletion of data on exit' },
+  { ref: 'Art.30(2)(e)', category: 'Subcontracting',        text: 'Full description of all subcontractors and their data processing locations' },
+  { ref: 'Art.30(2)(f)', category: 'Business Continuity',   text: 'ICT service continuity conditions including service level objective amendments' },
+  { ref: 'Art.30(2)(g)', category: 'Business Continuity',   text: "Business continuity plan provisions relevant to the financial entity's services" },
+  { ref: 'Art.30(2)(h)', category: 'Termination & Exit',    text: 'Termination rights of the financial entity including adequate notice periods' },
+  { ref: 'Art.30(3)(a)', category: 'Service Description',   text: 'Full service level descriptions with quantitative and qualitative performance targets' },
+  { ref: 'Art.30(3)(b)', category: 'Regulatory Compliance', text: 'Advance notification obligations for material changes to ICT services' },
+  { ref: 'Art.30(3)(c)', category: 'Audit & Inspection',    text: 'Right to carry out full audits and on-site inspections of the ICT provider' },
+  { ref: 'Art.30(3)(d)', category: 'Security & Resilience', text: 'Obligation to assist the financial entity in ICT-related incident management' },
+] as const;
+
+// ── Sign-off config ────────────────────────────────────────────────────────────
+
+const SIGNOFF_CONFIG: Record<ClauseSignoffStatus, { label: string; icon: React.ElementType; badgeClass: string; variant: 'default' | 'destructive' | 'outline' }> = {
+  accepted: { label: 'Accepted',  icon: CheckCircle2,  badgeClass: 'bg-green-100 text-green-800 border-green-200 hover:bg-green-100', variant: 'default' },
+  rejected: { label: 'Rejected',  icon: XCircle,       badgeClass: '', variant: 'destructive' },
+  waived:   { label: 'Waived',    icon: MinusCircle,   badgeClass: 'bg-slate-100 text-slate-700 border-slate-200 hover:bg-slate-100', variant: 'outline' },
+};
+
+// ── Negotiation round indicator ───────────────────────────────────────────────
+
+export function NegotiationRoundBadge({
+  assessments,
+  currentId,
+}: {
+  assessments: Assessment[];
+  currentId: string;
+}) {
+  const sorted = [...assessments].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  );
+  const roundN = sorted.findIndex((a) => a._id === currentId) + 1;
+  const total  = sorted.length;
+  if (total <= 1) return null;
+
+  return (
+    <Badge variant="outline" className="text-xs font-medium">
+      Round {roundN} of {total}
+    </Badge>
+  );
+}
+
+// ── Clause sign-off row ────────────────────────────────────────────────────────
+
+function ClauseSignoffRow({
+  clause,
+  gap,
+  signoff,
+  assessmentId,
+}: {
+  clause: typeof ART30_CLAUSES[number];
+  gap: Gap | undefined;
+  signoff: ClauseSignoff | undefined;
+  assessmentId: string;
+}) {
+  const queryClient = useQueryClient();
+  const [expanded, setExpanded] = useState(false);
+  const [note, setNote]         = useState('');
+
+  const mutation = useMutation({
+    mutationFn: (status: ClauseSignoffStatus) =>
+      assessmentsApi.setClauseSignoff(assessmentId, clause.ref, status, note),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['assessment', assessmentId] });
+      toast.success(`Clause ${clause.ref} ${note ? 'noted and ' : ''}signed off`);
+      setExpanded(false);
+      setNote('');
+    },
+    onError: () => toast.error('Sign-off failed'),
+  });
+
+  const gapLevel = gap?.gapLevel ?? 'covered';
+  const GapIcon =
+    gapLevel === 'covered'  ? CheckCircle2
+    : gapLevel === 'partial' ? AlertTriangle
+    : XCircle;
+  const gapIconClass =
+    gapLevel === 'covered'  ? 'text-green-500'
+    : gapLevel === 'partial' ? 'text-amber-500'
+    : 'text-destructive';
+  const rowClass =
+    gapLevel === 'missing' ? 'bg-destructive/5'
+    : gapLevel === 'partial' ? 'bg-amber-50/50 dark:bg-amber-950/10'
+    : '';
+
+  return (
+    <div className={`px-4 py-3 ${rowClass}`}>
+      <div className="flex items-start gap-3">
+        <GapIcon className={`h-4 w-4 mt-0.5 shrink-0 ${gapIconClass}`} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-mono text-xs font-semibold text-muted-foreground">{clause.ref}</span>
+            <Badge variant="outline" className="text-xs">{clause.category}</Badge>
+            <Badge
+              variant={gapLevel === 'covered' ? 'default' : gapLevel === 'partial' ? 'secondary' : 'destructive'}
+              className="text-xs capitalize"
+            >
+              {gapLevel}
+            </Badge>
+            {signoff && (
+              <Badge
+                variant={SIGNOFF_CONFIG[signoff.status].variant}
+                className={`text-xs ml-auto ${SIGNOFF_CONFIG[signoff.status].badgeClass}`}
+              >
+                {SIGNOFF_CONFIG[signoff.status].label}
+              </Badge>
+            )}
+          </div>
+          <p className="text-sm mt-1">{clause.text}</p>
+          {gap?.recommendation && gapLevel !== 'covered' && (
+            <p className={`text-xs mt-1 ${gapLevel === 'missing' ? 'text-destructive' : 'text-amber-600 dark:text-amber-400'}`}>
+              → {gap.recommendation}
+            </p>
+          )}
+          {signoff && (
+            <p className="text-xs text-muted-foreground mt-1">
+              {SIGNOFF_CONFIG[signoff.status].label} by {signoff.signedByName || 'compliance officer'}{' '}
+              · {format(new Date(signoff.signedAt), 'dd MMM yyyy')}{signoff.note ? ` — "${signoff.note}"` : ''}
+            </p>
+          )}
+        </div>
+        {/* Sign-off toggle */}
+        <button
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+        </button>
+      </div>
+
+      {/* Sign-off panel */}
+      {expanded && (
+        <div className="mt-3 ml-7 space-y-2">
+          <Input
+            placeholder="Optional note (e.g. 'Accepted pending SLA amendment')"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            className="h-8 text-xs"
+          />
+          <div className="flex gap-1.5 flex-wrap">
+            {(['accepted', 'waived', 'rejected'] as const).map((s) => {
+              const cfg = SIGNOFF_CONFIG[s];
+              const Icon = cfg.icon;
+              return (
+                <Button
+                  key={s}
+                  size="sm"
+                  variant={cfg.variant}
+                  disabled={mutation.isPending}
+                  onClick={() => mutation.mutate(s)}
+                  className="h-7 px-2.5 text-xs"
+                >
+                  <Icon className="h-3 w-3 mr-1" />
+                  {cfg.label}
+                </Button>
+              );
+            })}
+            <Button size="sm" variant="ghost" className="h-7 px-2 text-xs" onClick={() => setExpanded(false)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main export: Art30 Clause Scorecard with sign-off ─────────────────────────
+
+export function Art30ClauseScorecardWithSignoff({
+  assessment,
+}: {
+  assessment: Assessment;
+}) {
+  const gaps         = assessment.results?.gaps ?? [];
+  const signoffs     = assessment.clauseSignoffs ?? [];
+  const assessmentId = assessment._id;
+
+  const results = ART30_CLAUSES.map((clause) => {
+    const matchedGap = gaps.find((g) => g.article === clause.ref)
+      ?? gaps.find((g) =>
+          g.article?.startsWith(clause.ref.split('(')[0]) &&
+          g.domain?.toLowerCase().includes(clause.category.split(' ')[0].toLowerCase())
+        );
+    const signoff = signoffs.find((s) => s.clauseRef === clause.ref);
+    return { clause, gap: matchedGap, signoff };
+  });
+
+  const covered  = results.filter((r) => !r.gap || r.gap.gapLevel === 'covered').length;
+  const partial  = results.filter((r) => r.gap?.gapLevel === 'partial').length;
+  const missing  = results.filter((r) => r.gap?.gapLevel === 'missing').length;
+  const reviewed = signoffs.length;
+
+  return (
+    <div className="space-y-3">
+      {/* Summary row */}
+      <div className="flex items-center gap-4 text-sm flex-wrap">
+        <span className="flex items-center gap-1.5 text-green-600 font-medium">
+          <CheckCircle2 className="h-4 w-4" /> {covered} covered
+        </span>
+        <span className="flex items-center gap-1.5 text-amber-600 font-medium">
+          <AlertTriangle className="h-4 w-4" /> {partial} partial
+        </span>
+        <span className="flex items-center gap-1.5 text-destructive font-medium">
+          <XCircle className="h-4 w-4" /> {missing} missing
+        </span>
+        <span className="ml-auto text-xs text-muted-foreground">
+          {reviewed} / {ART30_CLAUSES.length} signed off
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+        <div
+          className="h-full bg-primary rounded-full transition-all"
+          style={{ width: `${(reviewed / ART30_CLAUSES.length) * 100}%` }}
+        />
+      </div>
+
+      {/* Clause rows */}
+      <div className="rounded-md border divide-y overflow-hidden">
+        {results.map(({ clause, gap, signoff }) => (
+          <ClauseSignoffRow
+            key={clause.ref}
+            clause={clause}
+            gap={gap}
+            signoff={signoff}
+            assessmentId={assessmentId}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/assessment/RiskScoringPanel.tsx
+++ b/frontend/src/components/assessment/RiskScoringPanel.tsx
@@ -1,0 +1,348 @@
+'use client';
+
+/**
+ * RiskScoringPanel — Step 3 gap fixes
+ *
+ * Adds to DORA gap analysis reports:
+ *  1. Inherent vs Residual risk panel
+ *  2. Weighted DORA domain breakdown
+ *  3. Formal risk decision (proceed / conditional / reject)
+ */
+
+import { useState } from 'react';
+import { format } from 'date-fns';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import {
+  CheckCircle2,
+  AlertTriangle,
+  XCircle,
+  ArrowRight,
+  ShieldCheck,
+  TrendingDown,
+  Minus,
+} from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import { assessmentsApi } from '@/lib/api/assessments';
+import type { Assessment, OverallRisk, RiskDecision, RiskDecisionValue } from '@/lib/api/assessments';
+import type { WorkspaceWithMembership } from '@/types';
+
+// ── Domain weights (DORA Art. 28–30) ──────────────────────────────────────────
+
+const DOMAIN_WEIGHTS: Record<string, number> = {
+  'ICT Governance':      0.20,
+  'Security Controls':   0.25,
+  'Incident Management': 0.20,
+  'Business Continuity': 0.15,
+  'Audit Rights':        0.05,
+  'Subcontracting':      0.05,
+  'Data Governance':     0.05,
+  'Exit Planning':       0.03,
+  'Regulatory History':  0.02,
+};
+
+// ── Inherent risk matrix ───────────────────────────────────────────────────────
+
+function computeInherentRisk(
+  vendorTier: string | null | undefined,
+  serviceType: string | null | undefined
+): OverallRisk {
+  const tier    = vendorTier  ?? 'standard';
+  const service = serviceType ?? 'other';
+
+  if (tier === 'critical') return 'High';
+  if (tier === 'important' && (service === 'cloud' || service === 'data' || service === 'network')) return 'High';
+  if (tier === 'important') return 'Medium';
+  return 'Low';
+}
+
+const RISK_COLOR: Record<OverallRisk, string> = {
+  High:   'text-destructive',
+  Medium: 'text-amber-600',
+  Low:    'text-green-600',
+};
+
+const RISK_BG: Record<OverallRisk, string> = {
+  High:   'bg-destructive/10 border-destructive/30',
+  Medium: 'bg-amber-50 border-amber-200 dark:bg-amber-950/20 dark:border-amber-800',
+  Low:    'bg-green-50 border-green-200 dark:bg-green-950/20 dark:border-green-800',
+};
+
+// ── 1. Inherent vs Residual panel ─────────────────────────────────────────────
+
+export function InherentResidualPanel({
+  assessment,
+  workspace,
+}: {
+  assessment: Assessment;
+  workspace: WorkspaceWithMembership | null;
+}) {
+  const residualRisk   = assessment.results?.overallRisk;
+  const inherentRisk   = computeInherentRisk(workspace?.vendorTier, workspace?.serviceType);
+  if (!residualRisk) return null;
+
+  const riskOrder: Record<OverallRisk, number> = { Low: 0, Medium: 1, High: 2 };
+  const reduced = riskOrder[residualRisk] < riskOrder[inherentRisk];
+  const same    = residualRisk === inherentRisk;
+
+  const ArrowIcon = reduced ? TrendingDown : same ? Minus : ArrowRight;
+  const arrowColor = reduced ? 'text-green-500' : same ? 'text-muted-foreground' : 'text-destructive';
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wide flex items-center gap-2">
+          <ShieldCheck className="h-4 w-4" />
+          Risk Scoring
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-3 items-center gap-3">
+          {/* Inherent risk */}
+          <div className={`rounded-lg border p-3 text-center ${RISK_BG[inherentRisk]}`}>
+            <p className="text-xs text-muted-foreground mb-1">Inherent risk</p>
+            <p className={`text-lg font-bold ${RISK_COLOR[inherentRisk]}`}>{inherentRisk}</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {workspace?.vendorTier ?? 'unclassified'} · {workspace?.serviceType ?? 'unknown'}
+            </p>
+          </div>
+          {/* Arrow */}
+          <div className="flex flex-col items-center gap-1">
+            <ArrowIcon className={`h-6 w-6 ${arrowColor}`} />
+            <span className="text-xs text-muted-foreground">
+              {reduced ? 'reduced by controls' : same ? 'unchanged' : 'elevated by gaps'}
+            </span>
+          </div>
+          {/* Residual risk */}
+          <div className={`rounded-lg border p-3 text-center ${RISK_BG[residualRisk]}`}>
+            <p className="text-xs text-muted-foreground mb-1">Residual risk</p>
+            <p className={`text-lg font-bold ${RISK_COLOR[residualRisk]}`}>{residualRisk}</p>
+            <p className="text-xs text-muted-foreground mt-1">after vendor controls</p>
+          </div>
+        </div>
+        <p className="text-xs text-muted-foreground mt-3">
+          Inherent risk is derived from vendor classification ({workspace?.vendorTier ?? '—'}) and
+          service type ({workspace?.serviceType ?? '—'}) before any controls are applied. Residual
+          risk is the AI-assessed remaining risk after evaluating vendor documentation.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── 2. Weighted domain breakdown ──────────────────────────────────────────────
+
+export function WeightedDomainChart({ assessment }: { assessment: Assessment }) {
+  const gaps = assessment.results?.gaps ?? [];
+  if (gaps.length === 0) return null;
+
+  // Group gaps by domain
+  const domainMap: Record<string, { covered: number; partial: number; missing: number }> = {};
+  for (const gap of gaps) {
+    const d = gap.domain ?? 'Unknown';
+    if (!domainMap[d]) domainMap[d] = { covered: 0, partial: 0, missing: 0 };
+    domainMap[d][gap.gapLevel]++;
+  }
+
+  // Score each domain: covered=1, partial=0.5, missing=0
+  const domainScores = Object.entries(domainMap).map(([domain, counts]) => {
+    const total = counts.covered + counts.partial + counts.missing;
+    const score = total > 0 ? ((counts.covered + counts.partial * 0.5) / total) * 100 : 100;
+    const weight = DOMAIN_WEIGHTS[domain] ?? 0;
+    return { domain, score, weight, counts, total };
+  });
+
+  // Sort by weight desc, then by score asc (worst first in same weight)
+  domainScores.sort((a, b) => b.weight - a.weight || a.score - b.score);
+
+  const weightedTotal = domainScores.reduce((sum, d) => sum + d.score * d.weight, 0);
+  const totalWeight   = domainScores.reduce((sum, d) => sum + d.weight, 0);
+  const overallScore  = totalWeight > 0 ? Math.round(weightedTotal / totalWeight) : 0;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+            Weighted Domain Coverage
+          </CardTitle>
+          <span className={`text-sm font-bold ${overallScore >= 70 ? 'text-green-600' : overallScore >= 40 ? 'text-amber-600' : 'text-destructive'}`}>
+            {overallScore}% weighted
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2.5">
+        {domainScores.map(({ domain, score, weight, counts }) => (
+          <div key={domain}>
+            <div className="flex items-center justify-between text-xs mb-1">
+              <span className="font-medium truncate">{domain}</span>
+              <span className="text-muted-foreground ml-2 shrink-0">
+                {Math.round(score)}% · {Math.round(weight * 100)}% weight
+              </span>
+            </div>
+            <div className="h-2 bg-muted rounded-full overflow-hidden">
+              <div
+                className={`h-full rounded-full ${score >= 70 ? 'bg-green-500' : score >= 40 ? 'bg-amber-400' : 'bg-destructive'}`}
+                style={{ width: `${score}%` }}
+              />
+            </div>
+            <div className="flex gap-3 mt-0.5 text-xs text-muted-foreground">
+              <span className="text-green-600">{counts.covered} ✓</span>
+              <span className="text-amber-600">{counts.partial} ~</span>
+              <span className="text-destructive">{counts.missing} ✗</span>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── 3. Formal risk decision ────────────────────────────────────────────────────
+
+const DECISION_CONFIG = {
+  proceed: {
+    label: 'Proceed',
+    description: 'Vendor risk is acceptable. Proceed to contract review.',
+    icon: CheckCircle2,
+    color: 'text-green-600',
+    badgeClass: 'bg-green-100 text-green-800 border-green-200 hover:bg-green-100',
+  },
+  conditional: {
+    label: 'Proceed with Conditions',
+    description: 'Acceptable with conditions. Remediation plan required before contract execution.',
+    icon: AlertTriangle,
+    color: 'text-amber-600',
+    badgeClass: 'bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100',
+  },
+  reject: {
+    label: 'Reject',
+    description: 'Residual risk too high. Vendor cannot be onboarded under current controls.',
+    icon: XCircle,
+    color: 'text-destructive',
+    badgeClass: '',
+  },
+} as const;
+
+export function FormalRiskDecision({
+  assessment,
+  assessmentId,
+}: {
+  assessment: Assessment;
+  assessmentId: string;
+}) {
+  const queryClient = useQueryClient();
+  const [rationale, setRationale]         = useState('');
+  const [pendingDecision, setPending]     = useState<RiskDecisionValue | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: ({ decision, rat }: { decision: RiskDecisionValue; rat: string }) =>
+      assessmentsApi.setRiskDecision(assessmentId, decision, rat),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['assessment', assessmentId] });
+      toast.success('Risk decision recorded');
+      setPending(null);
+      setRationale('');
+    },
+    onError: () => toast.error('Failed to record decision'),
+  });
+
+  const existing: RiskDecision | null | undefined = assessment.riskDecision;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+          Formal Risk Decision
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {existing ? (
+          <>
+            {/* Current decision */}
+            <div className="flex items-center gap-3">
+              {(() => {
+                const cfg = DECISION_CONFIG[existing.decision];
+                const Icon = cfg.icon;
+                return (
+                  <>
+                    <Icon className={`h-5 w-5 shrink-0 ${cfg.color}`} />
+                    <div className="flex-1">
+                      <Badge className={`text-xs ${cfg.badgeClass}`} variant={existing.decision === 'reject' ? 'destructive' : 'outline'}>
+                        {cfg.label}
+                      </Badge>
+                      {existing.rationale && (
+                        <p className="text-sm text-muted-foreground mt-1">&quot;{existing.rationale}&quot;</p>
+                      )}
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Recorded by {existing.setByName || 'compliance officer'} · {format(new Date(existing.setAt), 'dd MMM yyyy HH:mm')}
+                      </p>
+                    </div>
+                  </>
+                );
+              })()}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              To change this decision, record a new one below.
+            </p>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No formal decision recorded yet. Record your compliance decision to proceed to the next
+            step or formally reject this vendor.
+          </p>
+        )}
+
+        {/* Decision buttons */}
+        {!pendingDecision ? (
+          <div className="flex gap-2 flex-wrap">
+            {(['proceed', 'conditional', 'reject'] as const).map((d) => {
+              const cfg = DECISION_CONFIG[d];
+              const Icon = cfg.icon;
+              return (
+                <Button
+                  key={d}
+                  size="sm"
+                  variant={d === 'reject' ? 'destructive' : d === 'proceed' ? 'default' : 'outline'}
+                  onClick={() => setPending(d)}
+                >
+                  <Icon className="h-3.5 w-3.5 mr-1.5" />
+                  {cfg.label}
+                </Button>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <p className="text-sm font-medium">
+              Recording: <span className={DECISION_CONFIG[pendingDecision].color}>{DECISION_CONFIG[pendingDecision].label}</span>
+            </p>
+            <Textarea
+              placeholder="Rationale (optional) — e.g. 'Acceptable subject to ISO 27001 renewal by Q3'"
+              value={rationale}
+              onChange={(e) => setRationale(e.target.value)}
+              className="text-sm h-20 resize-none"
+            />
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant={pendingDecision === 'reject' ? 'destructive' : 'default'}
+                disabled={mutation.isPending}
+                onClick={() => mutation.mutate({ decision: pendingDecision, rat: rationale })}
+              >
+                {mutation.isPending ? 'Saving…' : 'Confirm'}
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => { setPending(null); setRationale(''); }}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/lib/api/assessments.ts
+++ b/frontend/src/lib/api/assessments.ts
@@ -4,6 +4,25 @@ import type { ApiResponse } from '@/types';
 export type GapLevel = 'covered' | 'partial' | 'missing';
 export type OverallRisk = 'High' | 'Medium' | 'Low';
 export type AssessmentStatus = 'pending' | 'indexing' | 'analyzing' | 'complete' | 'failed';
+export type RiskDecisionValue = 'proceed' | 'conditional' | 'reject';
+export type ClauseSignoffStatus = 'accepted' | 'rejected' | 'waived';
+
+export interface RiskDecision {
+  decision: RiskDecisionValue;
+  setBy: string;
+  setByName: string;
+  rationale: string;
+  setAt: string;
+}
+
+export interface ClauseSignoff {
+  clauseRef: string;
+  status: ClauseSignoffStatus;
+  signedBy: string;
+  signedByName: string;
+  note: string;
+  signedAt: string;
+}
 
 export interface Gap {
   article: string;
@@ -38,6 +57,8 @@ export interface Assessment {
     domainsAnalyzed: string[];
     generatedAt: string;
   };
+  riskDecision?: RiskDecision | null;
+  clauseSignoffs?: ClauseSignoff[];
   createdBy: string;
   createdAt: string;
   updatedAt: string;
@@ -115,6 +136,33 @@ export const assessmentsApi = {
    */
   delete: async (id: string) => {
     const response = await apiClient.delete<ApiResponse>(`/assessments/${id}`);
+    return response.data;
+  },
+
+  /**
+   * Record a formal risk decision (proceed / conditional / reject)
+   */
+  setRiskDecision: async (id: string, decision: RiskDecisionValue, rationale?: string) => {
+    const response = await apiClient.patch<ApiResponse<{ riskDecision: RiskDecision }>>(
+      `/assessments/${id}/risk-decision`,
+      { decision, rationale }
+    );
+    return response.data;
+  },
+
+  /**
+   * Sign off a single Art. 30 clause
+   */
+  setClauseSignoff: async (
+    id: string,
+    clauseRef: string,
+    status: ClauseSignoffStatus,
+    note?: string
+  ) => {
+    const response = await apiClient.patch<ApiResponse<{ clauseSignoffs: ClauseSignoff[] }>>(
+      `/assessments/${id}/clause-signoff`,
+      { clauseRef, status, note }
+    );
     return response.data;
   },
 };

--- a/frontend/src/lib/constants/nav-items.ts
+++ b/frontend/src/lib/constants/nav-items.ts
@@ -6,6 +6,7 @@ import {
   Building2,
   ShieldCheck,
   ClipboardList,
+  BarChart3,
 } from 'lucide-react';
 
 export interface NavItem {
@@ -16,12 +17,13 @@ export interface NavItem {
 }
 
 export const desktopMainNavItems: NavItem[] = [
+  { title: 'Risk Register', href: '/risk-register', icon: BarChart3 },
+  { title: 'Vendors', href: '/workspaces', icon: Building2 },
   { title: 'Gap Analysis', href: '/assessments', icon: ShieldCheck },
   { title: 'Questionnaires', href: '/questionnaires', icon: ClipboardList, workspaceRoles: ['owner', 'member'] },
   { title: 'Ask AI', href: '/chat', icon: MessageSquare },
   { title: 'Documents', href: '/sources', icon: Database, workspaceRoles: ['owner', 'member'] },
   { title: 'History', href: '/conversations', icon: FolderOpen },
-  { title: 'Vendors', href: '/workspaces', icon: Building2 },
 ];
 
 export const mobileMainNavItems: NavItem[] = [


### PR DESCRIPTION
## Summary

### Step 3 gap fixes — Risk Scoring
- **Inherent vs Residual Risk panel**: computes inherent risk from vendor tier × service type matrix (critical=High, important+cloud/data=High, etc.); residual = AI-assessed risk; shows reduction arrow and explanation
- **Weighted Domain Chart**: groups gaps by DORA domain, applies Art.28 weights (Security Controls 25%, ICT Governance 20%, Incident Management 20%, etc.), shows per-domain progress bar + overall weighted %
- **Formal Risk Decision**: compliance officer records Proceed / Proceed with Conditions / Reject with rationale + timestamp. Reject decision blocks the "Review Contract" CTA in Next Steps (enforced gate)
- Backend: `riskDecision` schema on Assessment + `PATCH /assessments/:id/risk-decision`

### Step 4 gap fixes — Contractual Requirements
- **Clause sign-off**: each of the 12 Art.30 clauses gets Accept / Reject / Waive buttons with optional note. Shows who signed it and when. Sign-off progress counter (X of 12)
- **Negotiation round indicator**: "Round N of M" badge in header when multiple CONTRACT_A30 assessments exist for the same workspace
- Backend: `clauseSignoffs` schema on Assessment + `PATCH /assessments/:id/clause-signoff`

### Next step — Vendor Risk Register (`/risk-register`)
- Portfolio table showing ALL vendors: Tier, Service, DORA Risk, Gaps (missing/partial), Q Score, Contract status, Cert expiry countdown, Next review date, 5-step compliance status
- 3 summary cards: Total vendors · High risk count · Fully compliant count
- Amber banner when certs expiring within 90 days
- "Export RoI (Excel)" button linking to Questionnaires page
- Added to sidebar nav as top item

## Test plan
- [ ] DORA assessment complete → Inherent/Residual panel shows tier-based inherent risk
- [ ] Weighted domain chart renders bars with correct % and weight labels
- [ ] Record "Reject" decision → Next Steps shows blocked card instead of contract review CTA
- [ ] CONTRACT_A30 → each clause has Accept/Reject/Waive buttons; clicking records sign-off with attribution
- [ ] Multiple CONTRACT_A30 for same workspace → "Round N of M" badge visible
- [ ] `/risk-register` → table shows all vendors; cert expiry <30d shows red; "Complete" badge for 5/5 steps
- [ ] Backend: 1099 tests pass; lint 0 errors; frontend build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)