### PR TITLE
test(coverage): add missing tests for risk-decision, org controller and frontend panels

### DIFF
--- a/backend/tests/integrationtest/risk-decision.integration.test.js
+++ b/backend/tests/integrationtest/risk-decision.integration.test.js
@@ -1,0 +1,487 @@
+/**
+ * Integration Tests — Risk Decision & Clause Sign-off endpoints
+ *
+ *  PATCH /api/v1/assessments/:id/risk-decision
+ *  PATCH /api/v1/assessments/:id/clause-signoff
+ *
+ * Uses MongoMemoryServer + real auth/workspace middleware.
+ * All external services (Qdrant, queue, email) are mocked.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import supertest from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_ACCESS_SECRET = 'test-access-secret-key-that-is-at-least-32-characters-long';
+process.env.JWT_REFRESH_SECRET = 'test-refresh-secret-key-that-is-at-least-32-characters-long';
+process.env.JWT_ACCESS_EXPIRY = '15m';
+process.env.JWT_REFRESH_EXPIRY = '7d';
+process.env.ENCRYPTION_KEY = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+
+// ---------------------------------------------------------------------------
+// External service mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../config/redis.js', () => ({
+  redisConnection: {
+    get: vi.fn().mockResolvedValue(null),
+    setex: vi.fn().mockResolvedValue('OK'),
+    set: vi.fn().mockResolvedValue('OK'),
+    del: vi.fn().mockResolvedValue(1),
+    keys: vi.fn().mockResolvedValue([]),
+    incr: vi.fn().mockResolvedValue(1),
+    expire: vi.fn().mockResolvedValue(1),
+    ping: vi.fn().mockResolvedValue('PONG'),
+    quit: vi.fn().mockResolvedValue('OK'),
+  },
+}));
+
+vi.mock('../../config/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    stream: { write: vi.fn() },
+  },
+}));
+
+vi.mock('../../services/emailService.js', () => ({
+  emailService: {
+    sendEmail: () => Promise.resolve({ success: true }),
+    sendEmailVerification: () => Promise.resolve({ success: true }),
+    sendPasswordResetEmail: () => Promise.resolve({ success: true }),
+    sendPasswordChanged: () => Promise.resolve({ success: true }),
+    sendWelcomeEmail: () => Promise.resolve({ success: true }),
+    sendOrganizationInvitation: () => Promise.resolve({ success: true }),
+  },
+  default: {
+    sendEmail: () => Promise.resolve({ success: true }),
+    sendEmailVerification: () => Promise.resolve({ success: true }),
+    sendPasswordResetEmail: () => Promise.resolve({ success: true }),
+    sendPasswordChanged: () => Promise.resolve({ success: true }),
+    sendWelcomeEmail: () => Promise.resolve({ success: true }),
+    sendOrganizationInvitation: () => Promise.resolve({ success: true }),
+  },
+}));
+
+vi.mock('../../services/authAuditService.js', () => ({
+  authAuditService: {
+    logRegisterSuccess: vi.fn().mockResolvedValue(true),
+    logLoginSuccess: vi.fn().mockResolvedValue(true),
+    logLoginFailed: vi.fn().mockResolvedValue(true),
+    logLoginBlockedLocked: vi.fn().mockResolvedValue(true),
+    logAccountLocked: vi.fn().mockResolvedValue(true),
+    detectBruteForce: vi.fn().mockResolvedValue({ blocked: false }),
+    logPasswordResetRequest: vi.fn().mockResolvedValue(true),
+    logPasswordResetSuccess: vi.fn().mockResolvedValue(true),
+    logLogout: vi.fn().mockResolvedValue(true),
+    logTokenRefresh: vi.fn().mockResolvedValue(true),
+    logEmailVerified: vi.fn().mockResolvedValue(true),
+  },
+}));
+
+vi.mock('../../config/queue.js', () => ({
+  assessmentQueue: { add: vi.fn().mockResolvedValue({ id: 'j1' }), on: vi.fn() },
+  notionSyncQueue: { add: vi.fn().mockResolvedValue({}), on: vi.fn() },
+  documentIndexQueue: { add: vi.fn().mockResolvedValue({}), on: vi.fn() },
+  memoryDecayQueue: { add: vi.fn().mockResolvedValue({}), on: vi.fn() },
+  monitoringQueue: { add: vi.fn().mockResolvedValue({}), on: vi.fn() },
+}));
+
+vi.mock('../../services/fileIngestionService.js', () => ({
+  ingestFile: vi.fn().mockResolvedValue({ chunkCount: 5, collectionName: 'col' }),
+  deleteAssessmentCollection: vi.fn().mockResolvedValue(undefined),
+  assessmentCollectionName: vi.fn((id) => `assessment_${id}`),
+  chunkText: vi.fn().mockReturnValue(['c1', 'c2']),
+  parseFile: vi.fn().mockResolvedValue('text'),
+  searchAssessmentChunks: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@qdrant/js-client-rest', () => ({
+  QdrantClient: vi.fn().mockImplementation(() => ({
+    getCollections: vi.fn().mockResolvedValue({ collections: [] }),
+    getCollection: vi.fn().mockResolvedValue({ name: 'documents', vectors_count: 0 }),
+    createCollection: vi.fn().mockResolvedValue({}),
+    upsert: vi.fn().mockResolvedValue({}),
+    search: vi.fn().mockResolvedValue([]),
+    deleteCollection: vi.fn().mockResolvedValue({}),
+  })),
+}));
+
+vi.mock('../../config/vectorStore.js', () => ({
+  getVectorStore: vi
+    .fn()
+    .mockResolvedValue({ client: { getCollection: vi.fn().mockResolvedValue({}) } }),
+}));
+
+vi.mock('../../config/llm.js', () => ({
+  llm: { invoke: vi.fn().mockResolvedValue('test') },
+}));
+
+vi.mock('../../config/embeddings.js', () => ({
+  embeddings: {
+    embedQuery: vi.fn().mockResolvedValue([0.1, 0.2]),
+    embedDocuments: vi.fn().mockResolvedValue([[0.1, 0.2]]),
+  },
+}));
+
+vi.mock('@notionhq/client', () => ({
+  Client: vi
+    .fn()
+    .mockImplementation(() => ({ search: vi.fn().mockResolvedValue({ results: [] }) })),
+}));
+
+// ---------------------------------------------------------------------------
+// App (AFTER mocks)
+// ---------------------------------------------------------------------------
+
+import app from '../../app.js';
+
+const AUTH_BASE = '/api/v1/auth';
+const ASSESSMENT_BASE = '/api/v1/assessments';
+
+const makePdfBuffer = () =>
+  Buffer.from('%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\ntrailer\n<< /Root 1 0 R >>');
+
+async function createAndLoginUser(request, userData) {
+  await request.post(`${AUTH_BASE}/register`).send(userData);
+  const User = mongoose.model('User');
+  await User.updateOne(
+    { email: userData.email },
+    { $set: { isEmailVerified: true, isActive: true } }
+  );
+  const loginRes = await request
+    .post(`${AUTH_BASE}/login`)
+    .send({ email: userData.email, password: userData.password });
+  const userDoc = await User.findOne({ email: userData.email });
+  return { token: loginRes.body.data.accessToken, userId: userDoc._id.toString() };
+}
+
+async function createWorkspaceForUser(userId) {
+  const Workspace = mongoose.model('Workspace');
+  const WorkspaceMember = mongoose.model('WorkspaceMember');
+  const workspace = await Workspace.create({ name: 'Risk WS', syncStatus: 'synced', userId });
+  await WorkspaceMember.create({
+    workspaceId: workspace._id,
+    userId,
+    role: 'owner',
+    status: 'active',
+    permissions: { canQuery: true, canManage: true, canInvite: true },
+  });
+  return workspace._id.toString();
+}
+
+async function createCompleteAssessment(request, token, workspaceId, framework = 'DORA') {
+  const res = await request
+    .post(ASSESSMENT_BASE)
+    .set('Authorization', `Bearer ${token}`)
+    .field('name', 'Q1 Test')
+    .field('vendorName', 'Acme Corp')
+    .field('workspaceId', workspaceId)
+    .field('framework', framework)
+    .attach('files', makePdfBuffer(), { filename: 'policy.pdf', contentType: 'application/pdf' });
+  return res.body.data.assessment._id;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Risk Decision & Clause Sign-off Integration Tests', () => {
+  let request;
+  let mongoServer;
+  let user1Token;
+  let user1Id;
+  let user2Token;
+  let workspaceId;
+
+  const user1 = { email: 'rd-user1@example.com', password: 'ValidPassword123!', name: 'RD User1' };
+  const user2 = { email: 'rd-user2@example.com', password: 'ValidPassword123!', name: 'RD User2' };
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create({ instance: { launchTimeout: 60000 } });
+    const mongoUri = mongoServer.getUri();
+    process.env.MONGODB_URI = mongoUri;
+    await mongoose.connect(mongoUri);
+
+    request = supertest(app);
+    const u1 = await createAndLoginUser(request, user1);
+    user1Token = u1.token;
+    user1Id = u1.userId;
+
+    const u2 = await createAndLoginUser(request, user2);
+    user2Token = u2.token;
+
+    workspaceId = await createWorkspaceForUser(user1Id);
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  beforeEach(async () => {
+    await mongoose.model('Assessment').deleteMany({});
+    vi.clearAllMocks();
+  });
+
+  // ==========================================================================
+  // PATCH /assessments/:id/risk-decision
+  // ==========================================================================
+
+  describe('PATCH /assessments/:id/risk-decision', () => {
+    it('requires authentication', async () => {
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/000000000000000000000001/risk-decision`)
+        .send({ decision: 'proceed' });
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 400 for invalid decision value', async () => {
+      const assessmentId = await createCompleteAssessment(request, user1Token, workspaceId);
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/risk-decision`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ decision: 'approve' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 for non-existent assessment', async () => {
+      const fakeId = new mongoose.Types.ObjectId().toString();
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${fakeId}/risk-decision`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ decision: 'proceed' });
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 403 when user has no access to assessment workspace', async () => {
+      const assessmentId = await createCompleteAssessment(request, user1Token, workspaceId);
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/risk-decision`)
+        .set('Authorization', `Bearer ${user2Token}`)
+        .send({ decision: 'proceed' });
+      expect(res.status).toBe(403);
+    });
+
+    it('records proceed decision and returns 200', async () => {
+      const assessmentId = await createCompleteAssessment(request, user1Token, workspaceId);
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/risk-decision`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ decision: 'proceed', rationale: 'All controls verified' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.riskDecision.decision).toBe('proceed');
+      expect(res.body.data.riskDecision.rationale).toBe('All controls verified');
+    });
+
+    it('records reject decision', async () => {
+      const assessmentId = await createCompleteAssessment(request, user1Token, workspaceId);
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/risk-decision`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ decision: 'reject', rationale: 'Too risky' });
+      expect(res.status).toBe(200);
+      expect(res.body.data.riskDecision.decision).toBe('reject');
+    });
+
+    it('records conditional decision', async () => {
+      const assessmentId = await createCompleteAssessment(request, user1Token, workspaceId);
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/risk-decision`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ decision: 'conditional' });
+      expect(res.status).toBe(200);
+      expect(res.body.data.riskDecision.decision).toBe('conditional');
+    });
+
+    it('overwrites a previous decision when called again', async () => {
+      const assessmentId = await createCompleteAssessment(request, user1Token, workspaceId);
+      await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/risk-decision`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ decision: 'proceed' });
+
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/risk-decision`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ decision: 'reject', rationale: 'Changed mind' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.riskDecision.decision).toBe('reject');
+    });
+
+    it('persists the decision so GET /assessments/:id returns it', async () => {
+      const assessmentId = await createCompleteAssessment(request, user1Token, workspaceId);
+      await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/risk-decision`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ decision: 'conditional', rationale: 'Subject to cert renewal' });
+
+      const getRes = await request
+        .get(`${ASSESSMENT_BASE}/${assessmentId}`)
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(getRes.status).toBe(200);
+      expect(getRes.body.data.assessment.riskDecision.decision).toBe('conditional');
+    });
+  });
+
+  // ==========================================================================
+  // PATCH /assessments/:id/clause-signoff
+  // ==========================================================================
+
+  describe('PATCH /assessments/:id/clause-signoff', () => {
+    it('requires authentication', async () => {
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/000000000000000000000001/clause-signoff`)
+        .send({ clauseRef: 'Art.30(1)', status: 'accepted' });
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 400 when clauseRef is missing', async () => {
+      const assessmentId = await createCompleteAssessment(
+        request,
+        user1Token,
+        workspaceId,
+        'CONTRACT_A30'
+      );
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/clause-signoff`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ status: 'accepted' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for invalid status value', async () => {
+      const assessmentId = await createCompleteAssessment(
+        request,
+        user1Token,
+        workspaceId,
+        'CONTRACT_A30'
+      );
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/clause-signoff`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ clauseRef: 'Art.30(1)', status: 'approved' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when assessment is not CONTRACT_A30 framework', async () => {
+      const assessmentId = await createCompleteAssessment(request, user1Token, workspaceId, 'DORA');
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/clause-signoff`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ clauseRef: 'Art.30(1)', status: 'accepted' });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/CONTRACT_A30/);
+    });
+
+    it('returns 403 when user has no access to workspace', async () => {
+      const assessmentId = await createCompleteAssessment(
+        request,
+        user1Token,
+        workspaceId,
+        'CONTRACT_A30'
+      );
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/clause-signoff`)
+        .set('Authorization', `Bearer ${user2Token}`)
+        .send({ clauseRef: 'Art.30(1)', status: 'accepted' });
+      expect(res.status).toBe(403);
+    });
+
+    it('adds a new clause signoff and returns 200', async () => {
+      const assessmentId = await createCompleteAssessment(
+        request,
+        user1Token,
+        workspaceId,
+        'CONTRACT_A30'
+      );
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/clause-signoff`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ clauseRef: 'Art.30(1)', status: 'accepted', note: 'Verified by legal' });
+
+      expect(res.status).toBe(200);
+      const signoffs = res.body.data.clauseSignoffs;
+      expect(signoffs).toHaveLength(1);
+      expect(signoffs[0].clauseRef).toBe('Art.30(1)');
+      expect(signoffs[0].status).toBe('accepted');
+      expect(signoffs[0].note).toBe('Verified by legal');
+    });
+
+    it('accepts waived status', async () => {
+      const assessmentId = await createCompleteAssessment(
+        request,
+        user1Token,
+        workspaceId,
+        'CONTRACT_A30'
+      );
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/clause-signoff`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ clauseRef: 'Art.30(2)', status: 'waived' });
+      expect(res.status).toBe(200);
+      expect(res.body.data.clauseSignoffs[0].status).toBe('waived');
+    });
+
+    it('upserts: calling again for same clauseRef replaces the previous signoff', async () => {
+      const assessmentId = await createCompleteAssessment(
+        request,
+        user1Token,
+        workspaceId,
+        'CONTRACT_A30'
+      );
+
+      await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/clause-signoff`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ clauseRef: 'Art.30(1)', status: 'rejected', note: 'initial' });
+
+      const res = await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/clause-signoff`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ clauseRef: 'Art.30(1)', status: 'accepted', note: 'updated after negotiation' });
+
+      expect(res.status).toBe(200);
+      const signoffs = res.body.data.clauseSignoffs;
+      // Must still be exactly 1 signoff for Art.30(1)
+      const art30 = signoffs.filter((s) => s.clauseRef === 'Art.30(1)');
+      expect(art30).toHaveLength(1);
+      expect(art30[0].status).toBe('accepted');
+      expect(art30[0].note).toBe('updated after negotiation');
+    });
+
+    it('accumulates multiple distinct clause signoffs', async () => {
+      const assessmentId = await createCompleteAssessment(
+        request,
+        user1Token,
+        workspaceId,
+        'CONTRACT_A30'
+      );
+
+      await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/clause-signoff`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ clauseRef: 'Art.30(1)', status: 'accepted' });
+
+      await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/clause-signoff`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ clauseRef: 'Art.30(2)', status: 'waived' });
+
+      const getRes = await request
+        .get(`${ASSESSMENT_BASE}/${assessmentId}`)
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      const signoffs = getRes.body.data.assessment.clauseSignoffs;
+      expect(signoffs).toHaveLength(2);
+      expect(signoffs.map((s) => s.clauseRef).sort()).toEqual(['Art.30(1)', 'Art.30(2)']);
+    });
+  });
+});

--- a/backend/tests/unittest/organization-controller.unit.test.js
+++ b/backend/tests/unittest/organization-controller.unit.test.js
@@ -1,0 +1,433 @@
+/**
+ * Unit Tests — Organization Controller
+ *
+ * Tests: createOrganization, getMyOrganization, inviteMember,
+ *        getMembers, removeMember, getInviteInfo
+ *
+ * All DB / email / logger dependencies are mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+
+process.env.NODE_ENV = 'test';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../config/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../utils/index.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    catchAsync: (fn) => async (req, res, next) => {
+      try {
+        await fn(req, res, next);
+      } catch (err) {
+        next(err);
+      }
+    },
+  };
+});
+
+vi.mock('../../services/emailService.js', () => ({
+  emailService: {
+    sendOrganizationInvitation: vi.fn().mockResolvedValue({ success: true }),
+  },
+}));
+
+vi.mock('../../utils/security/fieldEncryption.js', () => ({
+  safeDecrypt: vi.fn((v) => v),
+  safeEncrypt: vi.fn((v) => v),
+}));
+
+const ORG_OID = new mongoose.Types.ObjectId('cccccccccccccccccccccccc');
+const USER_OID = new mongoose.Types.ObjectId('dddddddddddddddddddddddd');
+const MBR_OID = new mongoose.Types.ObjectId('eeeeeeeeeeeeeeeeeeeeeeee');
+
+const mockOrg = {
+  _id: ORG_OID,
+  name: 'HDI Global SE',
+  industry: 'insurance',
+  country: 'Germany',
+};
+
+const mockUser = {
+  _id: USER_OID,
+  email: 'alice@hdi.de',
+  name: 'Alice',
+};
+
+const mockActiveMembership = {
+  _id: MBR_OID,
+  organizationId: ORG_OID,
+  userId: USER_OID,
+  email: 'alice@hdi.de',
+  role: 'org_admin',
+  status: 'active',
+  joinedAt: new Date(),
+  populate: vi.fn().mockReturnThis(),
+};
+
+vi.mock('../../models/Organization.js', () => ({
+  Organization: {
+    create: vi.fn(),
+    findById: vi.fn(),
+  },
+}));
+
+vi.mock('../../models/OrganizationMember.js', () => ({
+  OrganizationMember: {
+    findOne: vi.fn(),
+    find: vi.fn(),
+    findById: vi.fn(),
+    findByIdAndUpdate: vi.fn(),
+    create: vi.fn(),
+    countDocuments: vi.fn(),
+    createInvite: vi.fn(),
+    findByToken: vi.fn(),
+    activate: vi.fn(),
+  },
+}));
+
+vi.mock('../../models/User.js', () => ({
+  User: {
+    findById: vi.fn(),
+    findByIdAndUpdate: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Subject imports (AFTER mocks)
+// ---------------------------------------------------------------------------
+
+import {
+  createOrganization,
+  getMyOrganization,
+  inviteMember,
+  getMembers,
+  removeMember,
+  getInviteInfo,
+} from '../../controllers/organizationController.js';
+import { Organization } from '../../models/Organization.js';
+import { OrganizationMember } from '../../models/OrganizationMember.js';
+import { User } from '../../models/User.js';
+import { emailService } from '../../services/emailService.js';
+import { safeDecrypt } from '../../utils/security/fieldEncryption.js';
+
+// ---------------------------------------------------------------------------
+// Shared beforeEach — clear all mocks then restore pass-through utilities
+// so vi.clearAllMocks() doesn't strip implementations used by the controller
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  safeDecrypt.mockImplementation((v) => v);
+  emailService.sendOrganizationInvitation.mockResolvedValue({ success: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: minimal req/res/next
+// ---------------------------------------------------------------------------
+
+function makeCtx(body = {}, params = {}, query = {}) {
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  };
+  const req = {
+    user: { userId: USER_OID.toString(), email: 'alice@hdi.de', name: 'Alice' },
+    body,
+    params,
+    query,
+  };
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+// ---------------------------------------------------------------------------
+// createOrganization
+// ---------------------------------------------------------------------------
+
+describe('createOrganization', () => {
+  it('returns 400 when name is missing', async () => {
+    const { req, res, next } = makeCtx({ industry: 'banking' });
+    await createOrganization(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 409 when user already belongs to an org', async () => {
+    OrganizationMember.findOne.mockResolvedValue(mockActiveMembership);
+    const { req, res, next } = makeCtx({ name: 'HDI Global SE' });
+    await createOrganization(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(409);
+  });
+
+  it('creates org, member and updates user, returns 201', async () => {
+    OrganizationMember.findOne.mockResolvedValue(null);
+    Organization.create.mockResolvedValue(mockOrg);
+    User.findById.mockResolvedValue(mockUser);
+    OrganizationMember.create.mockResolvedValue({});
+    User.findByIdAndUpdate.mockResolvedValue({});
+
+    const { req, res, next } = makeCtx({
+      name: 'HDI Global SE',
+      industry: 'insurance',
+      country: 'Germany',
+    });
+    await createOrganization(req, res, next);
+
+    expect(Organization.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'HDI Global SE', industry: 'insurance' })
+    );
+    expect(OrganizationMember.create).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'org_admin', status: 'active' })
+    );
+    expect(User.findByIdAndUpdate).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('returns org object in response', async () => {
+    OrganizationMember.findOne.mockResolvedValue(null);
+    Organization.create.mockResolvedValue(mockOrg);
+    User.findById.mockResolvedValue(mockUser);
+    OrganizationMember.create.mockResolvedValue({});
+    User.findByIdAndUpdate.mockResolvedValue({});
+
+    const { req, res, next } = makeCtx({ name: 'HDI Global SE' });
+    await createOrganization(req, res, next);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.data.organization.name).toBe('HDI Global SE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMyOrganization
+// ---------------------------------------------------------------------------
+
+describe('getMyOrganization', () => {
+  it('returns organization: null when user has no membership', async () => {
+    OrganizationMember.findOne.mockReturnValue({
+      populate: vi.fn().mockResolvedValue(null),
+    });
+    const { req, res, next } = makeCtx();
+    await getMyOrganization(req, res, next);
+    const body = res.json.mock.calls[0][0];
+    expect(body.data.organization).toBeNull();
+    expect(body.data.role).toBeNull();
+  });
+
+  it('returns org details and role when membership exists', async () => {
+    const populated = {
+      ...mockActiveMembership,
+      organizationId: { _id: ORG_OID, name: 'HDI', industry: 'insurance', country: 'DE' },
+    };
+    OrganizationMember.findOne.mockReturnValue({
+      populate: vi.fn().mockResolvedValue(populated),
+    });
+
+    const { req, res, next } = makeCtx();
+    await getMyOrganization(req, res, next);
+    const body = res.json.mock.calls[0][0];
+    expect(body.data.organization.name).toBe('HDI');
+    expect(body.data.role).toBe('org_admin');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inviteMember
+// ---------------------------------------------------------------------------
+
+describe('inviteMember', () => {
+  it('returns 400 when email is missing', async () => {
+    const { req, res, next } = makeCtx({ role: 'analyst' });
+    await inviteMember(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 for invalid role', async () => {
+    const { req, res, next } = makeCtx({ email: 'bob@hdi.de', role: 'superuser' });
+    await inviteMember(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 403 when caller is not an org member', async () => {
+    OrganizationMember.findOne.mockResolvedValue(null);
+    const { req, res, next } = makeCtx({ email: 'bob@hdi.de', role: 'analyst' });
+    await inviteMember(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('returns 403 when caller is not org_admin', async () => {
+    OrganizationMember.findOne.mockResolvedValue({ ...mockActiveMembership, role: 'analyst' });
+    const { req, res, next } = makeCtx({ email: 'bob@hdi.de', role: 'viewer' });
+    await inviteMember(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('returns 409 when email is already an active member', async () => {
+    OrganizationMember.findOne
+      .mockResolvedValueOnce(mockActiveMembership) // caller lookup
+      .mockResolvedValueOnce({ email: 'bob@hdi.de', status: 'active' }); // existing check
+
+    const { req, res, next } = makeCtx({ email: 'bob@hdi.de', role: 'analyst' });
+    await inviteMember(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(409);
+  });
+
+  it('creates invite and returns 201', async () => {
+    const newMember = { _id: MBR_OID, email: 'bob@hdi.de', role: 'analyst', status: 'pending' };
+
+    OrganizationMember.findOne
+      .mockResolvedValueOnce(mockActiveMembership)
+      .mockResolvedValueOnce(null);
+
+    OrganizationMember.createInvite.mockResolvedValue({ member: newMember, rawToken: 'tok123' });
+    Organization.findById.mockResolvedValue(mockOrg);
+    User.findById.mockReturnValue({ select: vi.fn().mockResolvedValue(mockUser) });
+
+    const { req, res, next } = makeCtx({ email: 'bob@hdi.de', role: 'analyst' });
+    await inviteMember(req, res, next);
+
+    expect(OrganizationMember.createInvite).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.data.member.email).toBe('bob@hdi.de');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMembers
+// ---------------------------------------------------------------------------
+
+describe('getMembers', () => {
+  it('returns 403 when caller has no membership', async () => {
+    OrganizationMember.findOne.mockResolvedValue(null);
+    const { req, res, next } = makeCtx();
+    await getMembers(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('returns member list with id, email, role, status', async () => {
+    OrganizationMember.findOne.mockResolvedValue(mockActiveMembership);
+    OrganizationMember.find.mockReturnValue({
+      populate: vi.fn().mockResolvedValue([
+        {
+          _id: MBR_OID,
+          email: 'alice@hdi.de',
+          role: 'org_admin',
+          status: 'active',
+          joinedAt: new Date(),
+          userId: { _id: USER_OID, name: 'Alice', email: 'alice@hdi.de' },
+        },
+      ]),
+    });
+
+    const { req, res, next } = makeCtx();
+    await getMembers(req, res, next);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.data.members).toHaveLength(1);
+    expect(body.data.members[0].email).toBe('alice@hdi.de');
+    expect(body.data.members[0].role).toBe('org_admin');
+    expect(body.data.members[0].user.name).toBe('Alice');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeMember
+// ---------------------------------------------------------------------------
+
+describe('removeMember', () => {
+  it('returns 403 when caller is not org_admin', async () => {
+    OrganizationMember.findOne.mockResolvedValue({ ...mockActiveMembership, role: 'analyst' });
+    const { req, res, next } = makeCtx({}, { memberId: MBR_OID.toString() });
+    await removeMember(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('returns 404 when target member not found', async () => {
+    OrganizationMember.findOne.mockResolvedValue(mockActiveMembership);
+    OrganizationMember.findById.mockResolvedValue(null);
+    const { req, res, next } = makeCtx({}, { memberId: MBR_OID.toString() });
+    await removeMember(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 400 when attempting to remove the only org admin', async () => {
+    const callerMembership = { ...mockActiveMembership, userId: USER_OID.toString() };
+    OrganizationMember.findOne.mockResolvedValue(callerMembership);
+    OrganizationMember.findById.mockResolvedValue({
+      ...callerMembership,
+      userId: USER_OID.toString(),
+    });
+    OrganizationMember.countDocuments.mockResolvedValue(1); // only one admin
+
+    const { req, res, next } = makeCtx({}, { memberId: MBR_OID.toString() });
+    await removeMember(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('revokes membership and returns 200', async () => {
+    const targetOID = new mongoose.Types.ObjectId('ffffffffffffffffffffffff');
+    OrganizationMember.findOne.mockResolvedValue(mockActiveMembership);
+    OrganizationMember.findById.mockResolvedValue({
+      _id: targetOID,
+      organizationId: ORG_OID,
+      userId: new mongoose.Types.ObjectId('111111111111111111111111'),
+    });
+    OrganizationMember.findByIdAndUpdate.mockResolvedValue({});
+
+    const { req, res, next } = makeCtx({}, { memberId: targetOID.toString() });
+    await removeMember(req, res, next);
+
+    expect(OrganizationMember.findByIdAndUpdate).toHaveBeenCalledWith(targetOID.toString(), {
+      status: 'revoked',
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getInviteInfo (public endpoint)
+// ---------------------------------------------------------------------------
+
+describe('getInviteInfo', () => {
+  it('returns 400 when token is missing', async () => {
+    const { req, res, next } = makeCtx({}, {}, {});
+    await getInviteInfo(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 404 when token is invalid/expired', async () => {
+    OrganizationMember.findByToken.mockResolvedValue(null);
+    const { req, res, next } = makeCtx({}, {}, { token: 'badtoken' });
+    await getInviteInfo(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns invite info when token is valid', async () => {
+    OrganizationMember.findByToken.mockResolvedValue({
+      organizationId: ORG_OID,
+      role: 'analyst',
+      email: 'bob@hdi.de',
+      invitedBy: USER_OID,
+    });
+    Organization.findById.mockResolvedValue(mockOrg);
+    User.findById.mockReturnValue({ select: vi.fn().mockResolvedValue(mockUser) });
+
+    const { req, res, next } = makeCtx({}, {}, { token: 'validtoken' });
+    await getInviteInfo(req, res, next);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.data.organizationName).toBe('HDI Global SE');
+    expect(body.data.role).toBe('analyst');
+    expect(body.data.email).toBe('bob@hdi.de');
+  });
+});

--- a/backend/tests/unittest/risk-decision.unit.test.js
+++ b/backend/tests/unittest/risk-decision.unit.test.js
@@ -1,0 +1,318 @@
+/**
+ * Unit Tests — setRiskDecision + setClauseSignoff controller handlers
+ *
+ * All DB/Redis/queue dependencies are mocked.
+ * catchAsync is unwrapped so async errors propagate to next().
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+
+process.env.NODE_ENV = 'test';
+
+// ---------------------------------------------------------------------------
+// Mocks (must be before subject imports)
+// ---------------------------------------------------------------------------
+
+vi.mock('../../config/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../utils/index.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    catchAsync: (fn) => async (req, res, next) => {
+      try {
+        await fn(req, res, next);
+      } catch (err) {
+        next(err);
+      }
+    },
+  };
+});
+
+vi.mock('../../config/queue.js', () => ({
+  assessmentQueue: { add: vi.fn().mockResolvedValue({ id: 'j1' }) },
+}));
+
+vi.mock('../../middleware/fileUpload.js', () => ({
+  handleFileUpload: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../services/reportGenerator.js', () => ({
+  generateReport: vi.fn().mockResolvedValue(Buffer.from('docx')),
+}));
+
+vi.mock('../../services/fileIngestionService.js', () => ({
+  assessmentCollectionName: vi.fn((id) => `assessment_${id}`),
+  deleteAssessmentCollection: vi.fn().mockResolvedValue(undefined),
+  ingestFile: vi.fn().mockResolvedValue({ chunkCount: 5 }),
+  searchAssessmentChunks: vi.fn().mockResolvedValue([]),
+  chunkText: vi.fn().mockReturnValue([]),
+  parseFile: vi.fn().mockResolvedValue('text'),
+}));
+
+// ---------------------------------------------------------------------------
+// Shared mock assessment document factory
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_OID = new mongoose.Types.ObjectId('bbbbbbbbbbbbbbbbbbbbbbbb');
+const ASSESSMENT_OID = new mongoose.Types.ObjectId('aaaaaaaaaaaaaaaaaaaaaaaa');
+
+function makeMockAssessment(overrides = {}) {
+  return {
+    _id: ASSESSMENT_OID,
+    workspaceId: WORKSPACE_OID,
+    name: 'DORA Q1',
+    vendorName: 'Acme',
+    framework: 'DORA',
+    status: 'complete',
+    riskDecision: null,
+    clauseSignoffs: [],
+    save: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+vi.mock('../../models/Assessment.js', () => ({
+  Assessment: {
+    create: vi.fn(),
+    find: vi.fn(),
+    findById: vi.fn(),
+    findByIdAndDelete: vi.fn(),
+    countDocuments: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Subject imports
+// ---------------------------------------------------------------------------
+
+import { setRiskDecision, setClauseSignoff } from '../../controllers/assessmentController.js';
+import { Assessment } from '../../models/Assessment.js';
+
+// ---------------------------------------------------------------------------
+// Request/response factory
+// ---------------------------------------------------------------------------
+
+function makeReqRes(bodyOverrides = {}, paramOverrides = {}) {
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  };
+  const req = {
+    user: { userId: 'user-abc', name: 'Alice', email: 'alice@example.com' },
+    authorizedWorkspaces: [{ _id: WORKSPACE_OID }],
+    body: bodyOverrides,
+    params: { id: ASSESSMENT_OID.toString(), ...paramOverrides },
+    query: {},
+  };
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+// ---------------------------------------------------------------------------
+// setRiskDecision
+// ---------------------------------------------------------------------------
+
+describe('setRiskDecision', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 400 for an invalid decision value', async () => {
+    const { req, res, next } = makeReqRes({ decision: 'approve' });
+    await setRiskDecision(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('calls next(AppError 404) when assessment not found', async () => {
+    Assessment.findById.mockResolvedValue(null);
+    const { req, res, next } = makeReqRes({ decision: 'proceed' });
+    await setRiskDecision(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 404 }));
+  });
+
+  it('calls next(AppError 403) when workspace is not authorized', async () => {
+    const otherWorkspace = new mongoose.Types.ObjectId('cccccccccccccccccccccccc');
+    Assessment.findById.mockResolvedValue(makeMockAssessment({ workspaceId: otherWorkspace }));
+    const { req, res, next } = makeReqRes({ decision: 'proceed' });
+    await setRiskDecision(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+  });
+
+  it('saves proceed decision and returns 200', async () => {
+    const mockDoc = makeMockAssessment();
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({ decision: 'proceed', rationale: 'All good' });
+    await setRiskDecision(req, res, next);
+    expect(mockDoc.save).toHaveBeenCalled();
+    expect(mockDoc.riskDecision.decision).toBe('proceed');
+    expect(mockDoc.riskDecision.rationale).toBe('All good');
+    expect(mockDoc.riskDecision.setBy).toBe('user-abc');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('saves conditional decision correctly', async () => {
+    const mockDoc = makeMockAssessment();
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({
+      decision: 'conditional',
+      rationale: 'Needs improvement',
+    });
+    await setRiskDecision(req, res, next);
+    expect(mockDoc.riskDecision.decision).toBe('conditional');
+  });
+
+  it('saves reject decision correctly', async () => {
+    const mockDoc = makeMockAssessment();
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({ decision: 'reject', rationale: 'Too risky' });
+    await setRiskDecision(req, res, next);
+    expect(mockDoc.riskDecision.decision).toBe('reject');
+  });
+
+  it('stores user name in setByName', async () => {
+    const mockDoc = makeMockAssessment();
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({ decision: 'proceed' });
+    await setRiskDecision(req, res, next);
+    expect(mockDoc.riskDecision.setByName).toBe('Alice');
+  });
+
+  it('falls back to email when name is not present', async () => {
+    const mockDoc = makeMockAssessment();
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({ decision: 'proceed' });
+    req.user.name = undefined;
+    await setRiskDecision(req, res, next);
+    expect(mockDoc.riskDecision.setByName).toBe('alice@example.com');
+  });
+
+  it('trims whitespace from rationale', async () => {
+    const mockDoc = makeMockAssessment();
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({ decision: 'proceed', rationale: '  trimmed  ' });
+    await setRiskDecision(req, res, next);
+    expect(mockDoc.riskDecision.rationale).toBe('trimmed');
+  });
+
+  it('allows empty rationale', async () => {
+    const mockDoc = makeMockAssessment();
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({ decision: 'proceed' });
+    await setRiskDecision(req, res, next);
+    expect(mockDoc.riskDecision.rationale).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setClauseSignoff
+// ---------------------------------------------------------------------------
+
+describe('setClauseSignoff', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 400 when clauseRef is missing', async () => {
+    const { req, res, next } = makeReqRes({ status: 'accepted' });
+    await setClauseSignoff(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 for an invalid status value', async () => {
+    const { req, res, next } = makeReqRes({ clauseRef: 'Art.30(1)', status: 'approved' });
+    await setClauseSignoff(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('calls next(AppError 404) when assessment not found', async () => {
+    Assessment.findById.mockResolvedValue(null);
+    const { req, res, next } = makeReqRes({ clauseRef: 'Art.30(1)', status: 'accepted' });
+    await setClauseSignoff(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 404 }));
+  });
+
+  it('returns 400 when framework is not CONTRACT_A30', async () => {
+    const mockDoc = makeMockAssessment({ framework: 'DORA' });
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({ clauseRef: 'Art.30(1)', status: 'accepted' });
+    await setClauseSignoff(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('pushes a new signoff and returns 200', async () => {
+    const mockDoc = makeMockAssessment({ framework: 'CONTRACT_A30', clauseSignoffs: [] });
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({
+      clauseRef: 'Art.30(1)',
+      status: 'accepted',
+      note: 'OK',
+    });
+    await setClauseSignoff(req, res, next);
+    expect(mockDoc.clauseSignoffs).toHaveLength(1);
+    expect(mockDoc.clauseSignoffs[0].clauseRef).toBe('Art.30(1)');
+    expect(mockDoc.clauseSignoffs[0].status).toBe('accepted');
+    expect(mockDoc.clauseSignoffs[0].note).toBe('OK');
+    expect(mockDoc.save).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('upserts existing signoff for the same clauseRef', async () => {
+    const existing = {
+      clauseRef: 'Art.30(1)',
+      status: 'rejected',
+      signedBy: 'user-old',
+      signedByName: 'Old User',
+      note: 'old note',
+    };
+    const mockDoc = makeMockAssessment({
+      framework: 'CONTRACT_A30',
+      clauseSignoffs: [existing],
+    });
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({
+      clauseRef: 'Art.30(1)',
+      status: 'waived',
+      note: 'waived now',
+    });
+    await setClauseSignoff(req, res, next);
+    // Should still have exactly 1 signoff (upserted, not appended)
+    expect(mockDoc.clauseSignoffs).toHaveLength(1);
+    expect(mockDoc.clauseSignoffs[0].status).toBe('waived');
+    expect(mockDoc.clauseSignoffs[0].note).toBe('waived now');
+  });
+
+  it('stores signedBy and signedByName from the authenticated user', async () => {
+    const mockDoc = makeMockAssessment({ framework: 'CONTRACT_A30', clauseSignoffs: [] });
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({ clauseRef: 'Art.30(2)', status: 'accepted' });
+    await setClauseSignoff(req, res, next);
+    expect(mockDoc.clauseSignoffs[0].signedBy).toBe('user-abc');
+    expect(mockDoc.clauseSignoffs[0].signedByName).toBe('Alice');
+  });
+
+  it('accepts rejected status', async () => {
+    const mockDoc = makeMockAssessment({ framework: 'CONTRACT_A30', clauseSignoffs: [] });
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({ clauseRef: 'Art.30(3)', status: 'rejected' });
+    await setClauseSignoff(req, res, next);
+    expect(mockDoc.clauseSignoffs[0].status).toBe('rejected');
+  });
+
+  it('accepts waived status', async () => {
+    const mockDoc = makeMockAssessment({ framework: 'CONTRACT_A30', clauseSignoffs: [] });
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({ clauseRef: 'Art.30(4)', status: 'waived' });
+    await setClauseSignoff(req, res, next);
+    expect(mockDoc.clauseSignoffs[0].status).toBe('waived');
+  });
+
+  it('returns the updated clauseSignoffs array in the response', async () => {
+    const mockDoc = makeMockAssessment({ framework: 'CONTRACT_A30', clauseSignoffs: [] });
+    Assessment.findById.mockResolvedValue(mockDoc);
+    const { req, res, next } = makeReqRes({ clauseRef: 'Art.30(1)', status: 'accepted' });
+    await setClauseSignoff(req, res, next);
+    const jsonCall = res.json.mock.calls[0][0];
+    expect(jsonCall).toBeDefined();
+    expect(jsonCall.data.clauseSignoffs).toBeDefined();
+  });
+});

--- a/frontend/src/tests/organizations-api.test.ts
+++ b/frontend/src/tests/organizations-api.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Frontend Tests — organizationsApi client
+ *
+ * Covers: create, getMe, getInviteInfo, invite, acceptInvite,
+ *         getMembers, removeMember
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { OrgMember, OrganizationData } from '@/lib/api/organizations';
+
+// ---------------------------------------------------------------------------
+// Mock apiClient BEFORE importing organizationsApi
+// ---------------------------------------------------------------------------
+const { mockGet, mockPost, mockDelete } = vi.hoisted(() => ({
+  mockGet:    vi.fn(),
+  mockPost:   vi.fn(),
+  mockDelete: vi.fn(),
+}));
+
+vi.mock('@/lib/api/client', () => ({
+  default: { get: mockGet, post: mockPost, delete: mockDelete },
+}));
+
+import { organizationsApi } from '@/lib/api/organizations';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockOrg: OrganizationData = {
+  id:       'org-001',
+  name:     'HDI Global SE',
+  industry: 'insurance',
+  country:  'Germany',
+};
+
+const mockMember: OrgMember = {
+  id:     'mbr-001',
+  email:  'alice@hdi.de',
+  role:   'org_admin',
+  status: 'active',
+  joinedAt: '2026-01-01T00:00:00.000Z',
+  user: { id: 'user-001', name: 'Alice', email: 'alice@hdi.de' },
+};
+
+const pendingMember: OrgMember = {
+  id:     'mbr-002',
+  email:  'bob@hdi.de',
+  role:   'analyst',
+  status: 'pending',
+  user:   null,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('organizationsApi', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // -------------------------------------------------------------------------
+  // create
+  // -------------------------------------------------------------------------
+  describe('create()', () => {
+    it('calls POST /organizations with org data', async () => {
+      mockPost.mockResolvedValue({ data: { status: 'success', data: { organization: mockOrg } } });
+      await organizationsApi.create({ name: 'HDI Global SE', industry: 'insurance', country: 'Germany' });
+      expect(mockPost).toHaveBeenCalledWith('/organizations', {
+        name: 'HDI Global SE', industry: 'insurance', country: 'Germany',
+      });
+    });
+
+    it('returns the created organization', async () => {
+      mockPost.mockResolvedValue({ data: { status: 'success', data: { organization: mockOrg } } });
+      const result = await organizationsApi.create({ name: 'HDI Global SE', industry: 'insurance', country: 'Germany' });
+      expect(result.data.organization.name).toBe('HDI Global SE');
+      expect(result.data.organization.industry).toBe('insurance');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getMe
+  // -------------------------------------------------------------------------
+  describe('getMe()', () => {
+    it('calls GET /organizations/me', async () => {
+      mockGet.mockResolvedValue({ data: { status: 'success', data: { organization: mockOrg, role: 'org_admin' } } });
+      await organizationsApi.getMe();
+      expect(mockGet).toHaveBeenCalledWith('/organizations/me');
+    });
+
+    it('returns organization and role', async () => {
+      mockGet.mockResolvedValue({ data: { status: 'success', data: { organization: mockOrg, role: 'analyst' } } });
+      const result = await organizationsApi.getMe();
+      expect(result.data.organization.id).toBe('org-001');
+      expect(result.data.role).toBe('analyst');
+    });
+
+    it('returns null organization when user has no org', async () => {
+      mockGet.mockResolvedValue({ data: { status: 'success', data: { organization: null, role: null } } });
+      const result = await organizationsApi.getMe();
+      expect(result.data.organization).toBeNull();
+      expect(result.data.role).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getInviteInfo
+  // -------------------------------------------------------------------------
+  describe('getInviteInfo()', () => {
+    it('calls GET /organizations/invite-info with encoded token', async () => {
+      mockGet.mockResolvedValue({
+        data: { status: 'success', data: { organizationName: 'HDI Global SE', inviterName: 'Alice', role: 'analyst', email: 'bob@hdi.de' } },
+      });
+      await organizationsApi.getInviteInfo('tok123');
+      expect(mockGet).toHaveBeenCalledWith('/organizations/invite-info?token=tok123');
+    });
+
+    it('returns invite metadata', async () => {
+      mockGet.mockResolvedValue({
+        data: { status: 'success', data: { organizationName: 'HDI Global SE', inviterName: 'Alice', role: 'viewer', email: 'bob@hdi.de' } },
+      });
+      const result = await organizationsApi.getInviteInfo('tok123');
+      expect(result.data.organizationName).toBe('HDI Global SE');
+      expect(result.data.role).toBe('viewer');
+      expect(result.data.email).toBe('bob@hdi.de');
+    });
+
+    it('URL-encodes special characters in token', async () => {
+      mockGet.mockResolvedValue({ data: { status: 'success', data: {} } });
+      await organizationsApi.getInviteInfo('a+b/c=d');
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining(encodeURIComponent('a+b/c=d'))
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // invite
+  // -------------------------------------------------------------------------
+  describe('invite()', () => {
+    it('calls POST /organizations/invite with email and role', async () => {
+      mockPost.mockResolvedValue({ data: { status: 'success', data: { member: pendingMember } } });
+      await organizationsApi.invite({ email: 'bob@hdi.de', role: 'analyst' });
+      expect(mockPost).toHaveBeenCalledWith('/organizations/invite', { email: 'bob@hdi.de', role: 'analyst' });
+    });
+
+    it('returns the pending member', async () => {
+      mockPost.mockResolvedValue({ data: { status: 'success', data: { member: pendingMember } } });
+      const result = await organizationsApi.invite({ email: 'bob@hdi.de', role: 'analyst' });
+      expect(result.data.member.status).toBe('pending');
+      expect(result.data.member.role).toBe('analyst');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // acceptInvite
+  // -------------------------------------------------------------------------
+  describe('acceptInvite()', () => {
+    it('calls POST /organizations/accept-invite with token in body', async () => {
+      mockPost.mockResolvedValue({ data: { status: 'success' } });
+      await organizationsApi.acceptInvite('tok456');
+      expect(mockPost).toHaveBeenCalledWith('/organizations/accept-invite', { token: 'tok456' });
+    });
+
+    it('returns the response data', async () => {
+      mockPost.mockResolvedValue({ data: { status: 'success' } });
+      const result = await organizationsApi.acceptInvite('tok456');
+      expect(result.status).toBe('success');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getMembers
+  // -------------------------------------------------------------------------
+  describe('getMembers()', () => {
+    it('calls GET /organizations/members', async () => {
+      mockGet.mockResolvedValue({ data: { status: 'success', data: { members: [mockMember] } } });
+      await organizationsApi.getMembers();
+      expect(mockGet).toHaveBeenCalledWith('/organizations/members');
+    });
+
+    it('returns member list with user details', async () => {
+      mockGet.mockResolvedValue({
+        data: { status: 'success', data: { members: [mockMember, pendingMember] } },
+      });
+      const result = await organizationsApi.getMembers();
+      expect(result.data.members).toHaveLength(2);
+      expect(result.data.members[0].user?.name).toBe('Alice');
+      expect(result.data.members[1].status).toBe('pending');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // removeMember
+  // -------------------------------------------------------------------------
+  describe('removeMember()', () => {
+    it('calls DELETE /organizations/members/:memberId', async () => {
+      mockDelete.mockResolvedValue({ data: { status: 'success' } });
+      await organizationsApi.removeMember('mbr-001');
+      expect(mockDelete).toHaveBeenCalledWith('/organizations/members/mbr-001');
+    });
+
+    it('returns success response', async () => {
+      mockDelete.mockResolvedValue({ data: { status: 'success' } });
+      const result = await organizationsApi.removeMember('mbr-002');
+      expect(result.status).toBe('success');
+    });
+  });
+});

--- a/frontend/src/tests/risk-scoring-panel.test.tsx
+++ b/frontend/src/tests/risk-scoring-panel.test.tsx
@@ -1,0 +1,300 @@
+/**
+ * Frontend Tests — RiskScoringPanel components
+ *
+ * Covers:
+ *  - InherentResidualPanel: inherent risk derivation, arrow direction, residual display
+ *  - WeightedDomainChart: domain grouping, score calculation, overall weighted %
+ *  - FormalRiskDecision: existing decision display, button rendering, mutation trigger
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import type { Assessment } from '@/lib/api/assessments';
+import type { WorkspaceWithMembership } from '@/types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+  useQueryClient: vi.fn(() => ({ invalidateQueries: vi.fn() })),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/api/assessments', () => ({
+  assessmentsApi: {
+    setRiskDecision: vi.fn().mockResolvedValue({ status: 'success' }),
+  },
+}));
+
+import { InherentResidualPanel, WeightedDomainChart, FormalRiskDecision } from '@/components/assessment/RiskScoringPanel';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeAssessment(overrides: Partial<Assessment> = {}): Assessment {
+  return {
+    _id: 'aaa111',
+    workspaceId: 'ws-001',
+    name: 'Q1 DORA',
+    vendorName: 'Acme',
+    framework: 'DORA',
+    status: 'complete',
+    statusMessage: '',
+    documents: [],
+    createdBy: 'user-001',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    results: {
+      gaps: [],
+      overallRisk: 'Medium',
+      summary: 'Test summary',
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      domainsAnalyzed: [],
+    },
+    riskDecision: null,
+    clauseSignoffs: [],
+    ...overrides,
+  };
+}
+
+function makeWorkspace(overrides: Partial<WorkspaceWithMembership> = {}): WorkspaceWithMembership {
+  return {
+    id: 'ws-001',
+    name: 'Test Vendor',
+    vendorTier: 'important',
+    serviceType: 'cloud',
+    myRole: 'owner',
+    permissions: { canQuery: true, canViewSources: true, canInvite: true },
+    ...overrides,
+  } as WorkspaceWithMembership;
+}
+
+// ---------------------------------------------------------------------------
+// InherentResidualPanel
+// ---------------------------------------------------------------------------
+
+describe('InherentResidualPanel', () => {
+  it('renders nothing when residualRisk is missing', () => {
+    const assessment = makeAssessment({ results: undefined });
+    const { container } = render(
+      <InherentResidualPanel assessment={assessment} workspace={makeWorkspace()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders inherent and residual risk boxes', () => {
+    render(<InherentResidualPanel assessment={makeAssessment()} workspace={makeWorkspace()} />);
+    expect(screen.getByText('Inherent risk')).toBeDefined();
+    expect(screen.getByText('Residual risk')).toBeDefined();
+  });
+
+  it('shows High inherent risk for critical tier vendors', () => {
+    const workspace = makeWorkspace({ vendorTier: 'critical' });
+    render(<InherentResidualPanel assessment={makeAssessment()} workspace={workspace} />);
+    // Both boxes rendered — inherent should show High
+    const allHighTexts = screen.getAllByText('High');
+    expect(allHighTexts.length).toBeGreaterThan(0);
+  });
+
+  it('shows Medium inherent risk for important tier with non-critical service', () => {
+    const workspace = makeWorkspace({ vendorTier: 'important', serviceType: 'hr' });
+    render(<InherentResidualPanel assessment={makeAssessment()} workspace={workspace} />);
+    const allMedium = screen.getAllByText('Medium');
+    expect(allMedium.length).toBeGreaterThan(0);
+  });
+
+  it('shows Low inherent risk for standard tier', () => {
+    const workspace = makeWorkspace({ vendorTier: 'standard', serviceType: 'hr' });
+    render(<InherentResidualPanel assessment={makeAssessment()} workspace={workspace} />);
+    // Inherent should be Low, residual Medium (from assessment)
+    expect(screen.getByText('Low')).toBeDefined();
+    expect(screen.getByText('Medium')).toBeDefined();
+  });
+
+  it('shows "reduced by controls" when residual < inherent', () => {
+    // critical tier = inherent High, residual Low
+    const assessment = makeAssessment({ results: { gaps: [], overallRisk: 'Low', generatedAt: '', domainsAnalyzed: [] } });
+    const workspace = makeWorkspace({ vendorTier: 'critical' });
+    render(<InherentResidualPanel assessment={assessment} workspace={workspace} />);
+    expect(screen.getByText('reduced by controls')).toBeDefined();
+  });
+
+  it('shows "elevated by gaps" when residual > inherent', () => {
+    // standard tier = inherent Low, residual High
+    const assessment = makeAssessment({ results: { gaps: [], overallRisk: 'High', generatedAt: '', domainsAnalyzed: [] } });
+    const workspace = makeWorkspace({ vendorTier: 'standard', serviceType: 'hr' });
+    render(<InherentResidualPanel assessment={assessment} workspace={workspace} />);
+    expect(screen.getByText('elevated by gaps')).toBeDefined();
+  });
+
+  it('shows "unchanged" when residual equals inherent', () => {
+    // important + cloud = inherent High, residual High
+    const assessment = makeAssessment({ results: { gaps: [], overallRisk: 'High', generatedAt: '', domainsAnalyzed: [] } });
+    const workspace = makeWorkspace({ vendorTier: 'important', serviceType: 'cloud' });
+    render(<InherentResidualPanel assessment={assessment} workspace={workspace} />);
+    expect(screen.getByText('unchanged')).toBeDefined();
+  });
+
+  it('shows vendor tier and service type classification text', () => {
+    render(<InherentResidualPanel assessment={makeAssessment()} workspace={makeWorkspace()} />);
+    expect(screen.getAllByText(/important/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/cloud/).length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WeightedDomainChart
+// ---------------------------------------------------------------------------
+
+describe('WeightedDomainChart', () => {
+  it('renders nothing when gaps array is empty', () => {
+    const assessment = makeAssessment({ results: { gaps: [], overallRisk: 'Low', generatedAt: '', domainsAnalyzed: [] } });
+    const { container } = render(<WeightedDomainChart assessment={assessment} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders domain rows for gaps with domains', () => {
+    const assessment = makeAssessment({
+      results: {
+        overallRisk: 'Medium', generatedAt: '', domainsAnalyzed: [],
+        gaps: [
+          { article: 'Art.28(1)', domain: 'Security Controls', requirement: 'req1', gapLevel: 'covered', vendorCoverage: '', recommendation: '', sourceChunks: [] },
+          { article: 'Art.28(2)', domain: 'Security Controls', requirement: 'req2', gapLevel: 'missing', vendorCoverage: '', recommendation: '', sourceChunks: [] },
+          { article: 'Art.28(3)', domain: 'ICT Governance',   requirement: 'req3', gapLevel: 'partial',  vendorCoverage: '', recommendation: '', sourceChunks: [] },
+        ],
+      },
+    });
+    render(<WeightedDomainChart assessment={assessment} />);
+    expect(screen.getByText('Security Controls')).toBeDefined();
+    expect(screen.getByText('ICT Governance')).toBeDefined();
+  });
+
+  it('shows a weighted overall % score', () => {
+    const assessment = makeAssessment({
+      results: {
+        overallRisk: 'Medium', generatedAt: '', domainsAnalyzed: [],
+        gaps: [
+          { article: 'Art.28(1)', domain: 'Security Controls', requirement: 'req1', gapLevel: 'covered', vendorCoverage: '', recommendation: '', sourceChunks: [] },
+        ],
+      },
+    });
+    render(<WeightedDomainChart assessment={assessment} />);
+    expect(screen.getByText(/weighted/)).toBeDefined();
+  });
+
+  it('shows covered/partial/missing counts per domain', () => {
+    const assessment = makeAssessment({
+      results: {
+        overallRisk: 'Medium', generatedAt: '', domainsAnalyzed: [],
+        gaps: [
+          { article: 'Art.28(1)', domain: 'Security Controls', requirement: 'r1', gapLevel: 'covered', vendorCoverage: '', recommendation: '', sourceChunks: [] },
+          { article: 'Art.28(2)', domain: 'Security Controls', requirement: 'r2', gapLevel: 'partial',  vendorCoverage: '', recommendation: '', sourceChunks: [] },
+          { article: 'Art.28(3)', domain: 'Security Controls', requirement: 'r3', gapLevel: 'missing',  vendorCoverage: '', recommendation: '', sourceChunks: [] },
+        ],
+      },
+    });
+    render(<WeightedDomainChart assessment={assessment} />);
+    // Each count rendered as "N ✓", "N ~", "N ✗"
+    expect(screen.getByText('1 ✓')).toBeDefined();
+    expect(screen.getByText('1 ~')).toBeDefined();
+    expect(screen.getByText('1 ✗')).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FormalRiskDecision
+// ---------------------------------------------------------------------------
+
+describe('FormalRiskDecision', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows "No formal decision" text when riskDecision is null', () => {
+    render(<FormalRiskDecision assessment={makeAssessment()} assessmentId="aaa111" />);
+    expect(screen.getByText(/No formal decision/)).toBeDefined();
+  });
+
+  it('renders three decision buttons', () => {
+    render(<FormalRiskDecision assessment={makeAssessment()} assessmentId="aaa111" />);
+    expect(screen.getByText('Proceed')).toBeDefined();
+    expect(screen.getByText('Proceed with Conditions')).toBeDefined();
+    expect(screen.getByText('Reject')).toBeDefined();
+  });
+
+  it('shows existing decision when riskDecision is set', () => {
+    const assessment = makeAssessment({
+      riskDecision: {
+        decision: 'proceed',
+        setBy: 'user-001',
+        setByName: 'Alice',
+        rationale: 'All controls in place',
+        setAt: '2026-01-15T10:00:00.000Z',
+      },
+    });
+    render(<FormalRiskDecision assessment={assessment} assessmentId="aaa111" />);
+    // 'Proceed' appears as both the badge (existing decision) and the button — use getAllByText
+    expect(screen.getAllByText('Proceed').length).toBeGreaterThan(0);
+    expect(screen.getByText(/All controls in place/)).toBeDefined();
+    expect(screen.getByText(/Alice/)).toBeDefined();
+  });
+
+  it('shows rationale textarea after clicking a decision button', () => {
+    render(<FormalRiskDecision assessment={makeAssessment()} assessmentId="aaa111" />);
+    fireEvent.click(screen.getByText('Proceed'));
+    expect(screen.getByPlaceholderText(/Rationale/)).toBeDefined();
+    expect(screen.getByText('Confirm')).toBeDefined();
+    expect(screen.getByText('Cancel')).toBeDefined();
+  });
+
+  it('hides the textarea when cancel is clicked', () => {
+    render(<FormalRiskDecision assessment={makeAssessment()} assessmentId="aaa111" />);
+    fireEvent.click(screen.getByText('Proceed'));
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.queryByPlaceholderText(/Rationale/)).toBeNull();
+  });
+
+  it('calls mutation.mutate when Confirm is clicked', async () => {
+    const { useMutation } = vi.mocked(await import('@tanstack/react-query'));
+    const mockMutate = vi.fn();
+    (useMutation as ReturnType<typeof vi.fn>).mockReturnValue({ mutate: mockMutate, isPending: false });
+
+    render(<FormalRiskDecision assessment={makeAssessment()} assessmentId="aaa111" />);
+    fireEvent.click(screen.getByText('Reject'));
+    fireEvent.click(screen.getByText('Confirm'));
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ decision: 'reject' })
+    );
+  });
+
+  it('shows "Saving…" text while mutation is pending', async () => {
+    const { useMutation } = vi.mocked(await import('@tanstack/react-query'));
+    (useMutation as ReturnType<typeof vi.fn>).mockReturnValue({ mutate: vi.fn(), isPending: true });
+
+    render(<FormalRiskDecision assessment={makeAssessment()} assessmentId="aaa111" />);
+    fireEvent.click(screen.getByText('Proceed'));
+    expect(screen.getByText('Saving…')).toBeDefined();
+  });
+
+  it('shows "To change this decision" hint when decision already exists', () => {
+    const assessment = makeAssessment({
+      riskDecision: {
+        decision: 'conditional',
+        setBy: 'user-001',
+        setByName: 'Alice',
+        rationale: '',
+        setAt: '2026-01-15T10:00:00.000Z',
+      },
+    });
+    render(<FormalRiskDecision assessment={assessment} assessmentId="aaa111" />);
+    expect(screen.getByText(/To change this decision/)).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the missing test coverage for features shipped in recent PRs that lacked unit/integration tests.

### Backend — 46 new tests across 3 files

- **`risk-decision.unit.test.js`** (20 tests): Unit tests for `setRiskDecision` and `setClauseSignoff` controllers — valid/invalid decisions, 404/403 guards, rationale trimming, upsert behaviour for clause sign-offs, CONTRACT_A30 framework check
- **`organization-controller.unit.test.js`** (28 tests): Unit tests for all 6 org controller handlers — `createOrganization`, `getMyOrganization`, `inviteMember` (including auth guards and 409 conflict), `getMembers`, `removeMember` (including last-admin guard), `getInviteInfo`
- **`risk-decision.integration.test.js`** (18 tests): End-to-end integration tests using MongoMemoryServer + supertest against the real auth and workspace middleware stack

### Frontend — 37 new tests across 2 files

- **`organizations-api.test.ts`** (16 tests): API client tests for `create`, `getMe`, `getInviteInfo` (token URL-encoding), `invite`, `acceptInvite`, `getMembers`, `removeMember`
- **`risk-scoring-panel.test.tsx`** (21 tests): Component tests for `InherentResidualPanel` (inherent risk matrix, arrow direction labels), `WeightedDomainChart` (domain grouping, weighted score), `FormalRiskDecision` (decision buttons, rationale textarea, mutation trigger, pending state)

### Bug fixes found during testing

- Integration test was attaching files to field `'documents'` but multer uses field name `'files'`
- `vi.clearAllMocks()` stripped `safeDecrypt` identity implementation and `emailService.sendOrganizationInvitation` resolved promise — fixed with a module-level `beforeEach` that restores both after each clear

## Test plan

- [x] `npm --prefix backend test` → 47 test files, 1158 tests, 0 failures
- [x] `npm --prefix frontend run test:run` → 14 test files, 394 tests, 0 failures
- [x] Backend lint → 0 errors
- [x] Frontend lint → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)