### PR TITLE
fix(frontend): restore Ask AI as new conversation page

### DIFF
--- a/frontend/src/app/(dashboard)/chat/page.tsx
+++ b/frontend/src/app/(dashboard)/chat/page.tsx
@@ -1,13 +1,49 @@
 'use client';
 
-import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { Loader2, MessageSquarePlus } from 'lucide-react';
 
-// /chat redirects to /conversations (Q&A history and chat)
-export default function ChatRedirectPage() {
+import { ChatInterface } from '@/components/chat';
+import { useActiveWorkspace, useWorkspaceStore } from '@/lib/stores/workspace-store';
+import type { Conversation } from '@/types';
+
+// /chat — blank new conversation page.
+// ChatInterface creates the conversation on first send, then onConversationCreated
+// redirects the user to /conversations/<id> so the URL reflects the saved session.
+export default function NewChatPage() {
   const router = useRouter();
-  useEffect(() => {
-    router.replace('/conversations');
-  }, [router]);
-  return null;
+  const activeWorkspace = useActiveWorkspace();
+  const workspacesLoading = useWorkspaceStore((state) => state.isLoading);
+
+  const handleConversationCreated = (conversation: Conversation) => {
+    router.replace(`/conversations/${conversation.id}`);
+  };
+
+  if (workspacesLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!activeWorkspace) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">Select a workspace to start a conversation</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center border-b px-4 py-2">
+        <MessageSquarePlus className="h-4 w-4 mr-2 text-muted-foreground" />
+        <h1 className="text-sm font-medium">New Conversation</h1>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        <ChatInterface onConversationCreated={handleConversationCreated} />
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -92,7 +92,9 @@ export function Sidebar() {
       <ScrollArea className="flex-1 px-3">
         <nav className="flex flex-col gap-1 py-2">
           {visibleMainNav.map((item) => {
-            const isActive = pathname === item.href;
+            const isActive =
+            pathname === item.href ||
+            (item.href === '/conversations' && pathname.startsWith('/conversations/'));
             return (
               <Button
                 key={item.href}


### PR DESCRIPTION
## Summary

- **`/chat/page.tsx`**: replaced silent redirect with a proper new-chat page that renders `ChatInterface` with no pre-existing conversation. On the first message send, `ChatInterface` creates the conversation via API, then `onConversationCreated` replaces the URL with `/conversations/<id>` so the session is saved and the URL reflects the correct route.
- **`sidebar.tsx`**: History nav item now also highlights on `/conversations/<id>` routes (active state was previously limited to exact `/conversations` match).

## Root cause

`/chat` was a `useEffect → router.replace('/conversations')`. When the user was already on `/conversations`, the replace was a no-op — the URL didn't change, nothing was visible → "Ask AI does nothing".

## Test plan

- [ ] Click **Ask AI** from any page → blank chat interface appears with example questions
- [ ] Type a question → conversation is created → URL changes to `/conversations/<id>` → answer streams in
- [ ] Click **History** → conversation list page, new conversation appears
- [ ] Click a conversation card → chat interface opens with that conversation's history
- [ ] Sidebar **History** item is highlighted both on `/conversations` and `/conversations/<id>`
- [ ] **New Chat** button on History page also works correctly (calls `/chat`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)