### PR TITLE
feat(storage): DigitalOcean Spaces file storage with org-level isolation

### DIFF
--- a/backend/config/storage.js
+++ b/backend/config/storage.js
@@ -1,0 +1,104 @@
+/**
+ * DigitalOcean Spaces (S3-compatible) Storage
+ *
+ * Provides upload / download / delete helpers for persistent file storage.
+ * All keys are prefixed with organizations/{orgId}/... to enforce org-level isolation.
+ *
+ * Gracefully no-ops when Spaces env vars are not configured.
+ */
+
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+} from '@aws-sdk/client-s3';
+import logger from './logger.js';
+
+const {
+  DO_SPACES_KEY,
+  DO_SPACES_SECRET,
+  DO_SPACES_ENDPOINT,
+  DO_SPACES_BUCKET,
+  DO_SPACES_REGION = 'fra1',
+} = process.env;
+
+/**
+ * Returns true when all required Spaces env vars are present.
+ */
+export function isStorageConfigured() {
+  return !!(DO_SPACES_KEY && DO_SPACES_SECRET && DO_SPACES_ENDPOINT && DO_SPACES_BUCKET);
+}
+
+const s3 = isStorageConfigured()
+  ? new S3Client({
+      endpoint: DO_SPACES_ENDPOINT,
+      region: DO_SPACES_REGION,
+      credentials: {
+        accessKeyId: DO_SPACES_KEY,
+        secretAccessKey: DO_SPACES_SECRET,
+      },
+    })
+  : null;
+
+/**
+ * Build the Spaces object key for a data source file.
+ * organizations/{orgId}/workspaces/{wsId}/datasources/{dsId}/{fileName}
+ */
+export function buildDataSourceKey(orgId, workspaceId, dataSourceId, fileName) {
+  return `organizations/${orgId}/workspaces/${workspaceId}/datasources/${dataSourceId}/${fileName}`;
+}
+
+/**
+ * Build the Spaces object key for an assessment document.
+ * organizations/{orgId}/workspaces/{wsId}/assessments/{assessmentId}/{index}_{fileName}
+ */
+export function buildAssessmentFileKey(orgId, workspaceId, assessmentId, docIndex, fileName) {
+  return `organizations/${orgId}/workspaces/${workspaceId}/assessments/${assessmentId}/${docIndex}_${fileName}`;
+}
+
+/**
+ * Upload a buffer to Spaces.
+ * @param {string} key - Object key (path in bucket)
+ * @param {Buffer} buffer - File contents
+ * @param {string} mimeType - Content-Type header
+ * @returns {Promise<string>} The key that was uploaded
+ * @throws {Error} If storage is not configured or upload fails
+ */
+export async function uploadFile(key, buffer, mimeType = 'application/octet-stream') {
+  if (!s3) throw new Error('Storage not configured');
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: DO_SPACES_BUCKET,
+      Key: key,
+      Body: buffer,
+      ContentType: mimeType,
+      ACL: 'private',
+    })
+  );
+  logger.info('File uploaded to Spaces', { key });
+  return key;
+}
+
+/**
+ * Download a file from Spaces as a readable stream.
+ * Pipe the returned stream directly to an Express response.
+ * @param {string} key - Object key
+ * @returns {Promise<import('stream').Readable>} Node.js readable stream
+ * @throws {Error} If storage is not configured or object not found
+ */
+export async function downloadFileStream(key) {
+  if (!s3) throw new Error('Storage not configured');
+  const response = await s3.send(new GetObjectCommand({ Bucket: DO_SPACES_BUCKET, Key: key }));
+  return response.Body;
+}
+
+/**
+ * Delete a file from Spaces. No-op if storage is not configured.
+ * @param {string} key - Object key
+ */
+export async function deleteFile(key) {
+  if (!s3) return;
+  await s3.send(new DeleteObjectCommand({ Bucket: DO_SPACES_BUCKET, Key: key }));
+  logger.info('File deleted from Spaces', { key });
+}

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -88,6 +88,7 @@ export const authenticate = async (req, res, next) => {
       email: user.email,
       role: user.role,
       name: user.name,
+      organizationId: user.organizationId || null,
     };
 
     logger.debug('User authenticated', {

--- a/backend/models/Assessment.js
+++ b/backend/models/Assessment.js
@@ -54,6 +54,7 @@ const documentSchema = new mongoose.Schema(
       enum: ['uploading', 'indexed', 'failed'],
       default: 'uploading',
     },
+    storageKey: { type: String, default: null }, // DigitalOcean Spaces object key
   },
   { _id: false }
 );

--- a/backend/routes/assessmentRoutes.js
+++ b/backend/routes/assessmentRoutes.js
@@ -4,6 +4,7 @@ import {
   listAssessments,
   getAssessment,
   downloadReport,
+  downloadAssessmentFile,
   deleteAssessment,
   setRiskDecision,
   setClauseSignoff,
@@ -59,6 +60,13 @@ router.patch('/:id/risk-decision', authenticate, requireWorkspaceAccess, setRisk
  * @access Private — CONTRACT_A30 assessments only
  */
 router.patch('/:id/clause-signoff', authenticate, requireWorkspaceAccess, setClauseSignoff);
+
+/**
+ * @route  GET /api/v1/assessments/:id/files/:docIndex
+ * @desc   Download an original vendor document from DigitalOcean Spaces
+ * @access Private
+ */
+router.get('/:id/files/:docIndex', authenticate, requireWorkspaceAccess, downloadAssessmentFile);
 
 /**
  * @route  DELETE /api/v1/assessments/:id

--- a/backend/routes/dataSourceRoutes.js
+++ b/backend/routes/dataSourceRoutes.js
@@ -17,6 +17,7 @@ import {
   getOne,
   triggerSync,
   deleteSource,
+  downloadDataSourceFile,
 } from '../controllers/dataSourceController.js';
 
 const router = Router();
@@ -64,5 +65,12 @@ router.post('/:id/sync', triggerSync);
  * @access Private
  */
 router.delete('/:id', deleteSource);
+
+/**
+ * @route  GET /api/v1/data-sources/:id/download
+ * @desc   Download the original uploaded file from DigitalOcean Spaces
+ * @access Private
+ */
+router.get('/:id/download', downloadDataSourceFile);
 
 export default router;

--- a/backend/tests/unittest/authMiddleware.test.js
+++ b/backend/tests/unittest/authMiddleware.test.js
@@ -148,6 +148,7 @@ describe('Auth Middleware', () => {
         email: 'test@example.com',
         role: 'user',
         name: 'Test User',
+        organizationId: null,
       });
       expect(mockNext).toHaveBeenCalled();
     });

--- a/frontend/src/app/(dashboard)/assessments/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/assessments/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
   ChevronRight,
   Building2,
   FileSearch,
+  Download,
 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -358,6 +359,17 @@ export default function AssessmentDetailPage() {
               >
                 {doc.status}
               </Badge>
+              {doc.storageKey && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 shrink-0"
+                  title="Download document"
+                  onClick={() => assessmentsApi.downloadAssessmentFile(id, i, doc.fileName)}
+                >
+                  <Download className="h-3.5 w-3.5" />
+                </Button>
+              )}
             </li>
           ))}
         </ul>

--- a/frontend/src/components/sources/DataSourceCard.tsx
+++ b/frontend/src/components/sources/DataSourceCard.tsx
@@ -9,6 +9,7 @@ import {
   AlertCircle,
   RefreshCw,
   Trash2,
+  Download,
 } from 'lucide-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -149,6 +150,19 @@ export function DataSourceCard({ dataSource, workspaceId }: DataSourceCardProps)
               Sync
             </Button>
           </RequirePermission>
+
+          {dataSource.storageKey && dataSource.sourceType === 'file' && (
+            <Button
+              size="sm"
+              variant="ghost"
+              title="Download original file"
+              onClick={() =>
+                sourcesApi.downloadFile(dataSource._id, dataSource.config?.fileName ?? dataSource.name)
+              }
+            >
+              <Download className="h-3 w-3" />
+            </Button>
+          )}
 
           <RequirePermission permission="canTriggerSync">
             <Button

--- a/frontend/src/lib/api/assessments.ts
+++ b/frontend/src/lib/api/assessments.ts
@@ -39,6 +39,7 @@ export interface AssessmentDocument {
   fileType: string;
   fileSize: number;
   status: 'uploading' | 'indexed' | 'failed';
+  storageKey?: string | null;
 }
 
 export interface Assessment {
@@ -164,5 +165,27 @@ export const assessmentsApi = {
       { clauseRef, status, note }
     );
     return response.data;
+  },
+
+  /**
+   * Download an original vendor document from DigitalOcean Spaces.
+   */
+  downloadAssessmentFile: async (
+    assessmentId: string,
+    docIndex: number,
+    fileName: string
+  ): Promise<void> => {
+    const response = await apiClient.get(
+      `/assessments/${assessmentId}/files/${docIndex}`,
+      { responseType: 'blob', timeout: 60_000 }
+    );
+    const url = window.URL.createObjectURL(new Blob([response.data]));
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', fileName);
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.URL.revokeObjectURL(url);
   },
 };

--- a/frontend/src/lib/api/sources.ts
+++ b/frontend/src/lib/api/sources.ts
@@ -37,6 +37,7 @@ export interface DataSource {
   lastSyncJobId?: string;
   stats: DataSourceStats;
   errorLog?: Array<{ timestamp: string; error: string }>;
+  storageKey?: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -151,5 +152,23 @@ export const sourcesApi = {
    */
   delete: async (id: string): Promise<void> => {
     await apiClient.delete(`/data-sources/${id}`);
+  },
+
+  /**
+   * Download the original uploaded file from DigitalOcean Spaces.
+   */
+  downloadFile: async (id: string, fileName: string): Promise<void> => {
+    const response = await apiClient.get(`/data-sources/${id}/download`, {
+      responseType: 'blob',
+      timeout: 60_000,
+    });
+    const url = window.URL.createObjectURL(new Blob([response.data]));
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', fileName);
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.URL.revokeObjectURL(url);
   },
 };


### PR DESCRIPTION
## Summary

- **New** `backend/config/storage.js`: S3-compatible client wrapping `@aws-sdk/client-s3` with key-builder helpers and upload/download/delete functions; gracefully no-ops when env vars are absent (`isStorageConfigured()`)
- **Auth middleware**: `organizationId` now included in `req.user` (read from existing `User.organizationId` field)
- **Data sources**: original file uploaded to Spaces on create (`organizations/{orgId}/workspaces/{wsId}/datasources/{dsId}/{file}`); deleted from Spaces on data-source delete; new `GET /data-sources/:id/download` endpoint streams file back through backend proxy (no pre-signed URLs)
- **Assessments**: each vendor doc uploaded to Spaces after assessment creation; `storageKey` field added to `Assessment.documents` subdoc; new `GET /assessments/:id/files/:docIndex` endpoint streams file back
- **Frontend**: `storageKey` field added to `DataSource` and `AssessmentDocument` types; Download button added to `DataSourceCard` (shown only when `storageKey` is set); Download button per document in assessment detail page; blob-download helpers added to `sourcesApi` and `assessmentsApi`

## Security model

- Key path prefix `organizations/{orgId}/...` enforces org-level isolation at the storage layer
- Download endpoints verify workspace membership via existing `requireWorkspaceAccess` middleware
- Files are served via backend proxy — no pre-signed URLs exposed to client
- Bucket ACL is `private` — no public access

## Graceful degradation

When `DO_SPACES_KEY` / `DO_SPACES_SECRET` / `DO_SPACES_ENDPOINT` / `DO_SPACES_BUCKET` are unset:
- `isStorageConfigured()` returns `false`; upload is skipped silently; `storageKey` stays `null`
- Download button hidden in UI (guarded by `storageKey` truthy check)
- Download endpoints return 404

## Test plan

- [ ] Upload a PDF data source → DB record has `storageKey` field populated
- [ ] Click Download on DataSourceCard → file downloads with original filename
- [ ] Delete a data source with `storageKey` → file removed from Spaces (verify in DO console)
- [ ] Run an assessment with PDF uploads → `assessment.documents[i].storageKey` populated
- [ ] Click Download button on assessment detail page → file downloads
- [ ] Remove Spaces env vars → upload succeeds (text extracted), `storageKey = null`, no Download button
- [ ] Access `GET /api/v1/datasources/:id/download` with user from different workspace → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)