### PR TITLE
fix(validators): remove dead notion workspace schemas

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,6 @@
         "@langchain/openai": "^1.2.1",
         "@langchain/qdrant": "^1.0.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@notionhq/client": "^2.3.0",
         "axios": "^1.13.2",
         "bcryptjs": "^3.0.3",
         "bullmq": "^5.66.4",
@@ -3015,19 +3014,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@notionhq/client": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.3.0.tgz",
-      "integrity": "sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node-fetch": "^2.5.10",
-        "node-fetch": "^2.6.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -4277,16 +4263,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/uuid": {
@@ -9011,48 +8987,6 @@
       "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
       "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
       "license": "MIT"
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/node-gyp-build-optional-packages": {
       "version": "5.2.2",

--- a/backend/validators/schemas.js
+++ b/backend/validators/schemas.js
@@ -85,26 +85,6 @@ export const updateConversationSchema = z.object({
     .optional(),
 });
 
-// Notion Workspace Schemas
-export const connectWorkspaceSchema = z.object({
-  accessToken: z.string().min(1, 'Access token is required'),
-  workspaceName: z
-    .string()
-    .min(1, 'Workspace name is required')
-    .max(100, 'Workspace name too long'),
-  workspaceIcon: z.string().optional(),
-  syncIntervalHours: z
-    .number()
-    .int()
-    .min(1)
-    .max(168, 'Sync interval too long (max 1 week)')
-    .default(6),
-});
-
-export const triggerSyncSchema = z.object({
-  fullSync: z.boolean().default(false),
-});
-
 // Analytics Schemas
 export const analyticsSummarySchema = z.object({
   startDate: z.string().datetime().optional(),


### PR DESCRIPTION
## Summary

- Remove `connectWorkspaceSchema` and `triggerSyncSchema` from `backend/validators/schemas.js` — these Notion-specific exports were never imported anywhere after the Notion integration was removed in #92
- Regenerate `package-lock.json` to drop the direct `@notionhq/client` entry (66 lines removed)

## Test plan

- [x] Backend lint: 0 errors
- [x] Frontend lint: 0 errors
- [x] Backend tests: 1131 tests passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)