### PR TITLE
docs(storage): document spaces file storage and remove notion references

### DIFF
--- a/docs/docs/api/assessments.md
+++ b/docs/docs/api/assessments.md
@@ -43,7 +43,7 @@ Create a new assessment and start the ingestion + analysis pipeline.
       "vendorName": "Acme Cloud",
       "status": "indexing",
       "documents": [
-        { "fileName": "policy.pdf", "fileType": "application/pdf", "fileSize": 204800, "status": "uploading" }
+        { "fileName": "policy.pdf", "fileType": "application/pdf", "fileSize": 204800, "status": "uploading", "storageKey": "organizations/org-1/workspaces/ws-123/assessments/asmnt-1/0_policy.pdf" }
       ],
       "createdAt": "2025-06-01T10:00:00.000Z"
     }
@@ -116,6 +116,27 @@ Get a single assessment including full gap results.
   }
 }
 ```
+
+---
+
+### `GET /assessments/:id/files/:docIndex`
+
+Download an original uploaded vendor document by its zero-based index in `assessment.documents`.
+
+**Path parameters**
+
+| Name | Description |
+|------|-------------|
+| `id` | Assessment ID |
+| `docIndex` | Zero-based document index (e.g. `0` for the first uploaded file) |
+
+**Response `200`**
+
+- `Content-Type: application/octet-stream`
+- `Content-Disposition: attachment; filename="{original filename}"`
+- Body: raw file bytes (streamed from DigitalOcean Spaces)
+
+Returns `404` when the document's `storageKey` is `null` (Spaces not configured at upload time).
 
 ---
 

--- a/docs/docs/api/data-sources.md
+++ b/docs/docs/api/data-sources.md
@@ -81,6 +81,7 @@ Supported file types: **pdf**, **docx**, **xlsx**, **xls** (max 25 MB).
       "name": "DORA Compliance Guide",
       "sourceType": "file",
       "status": "pending",
+      "storageKey": "organizations/org-1/workspaces/ws-123/datasources/ds-abc123/document.pdf",
       "config": {
         "fileName": "document.pdf",
         "fileType": "pdf",
@@ -161,6 +162,26 @@ Requires `canTriggerSync` workspace permission.
 
 ---
 
+## Download the original file
+
+```http
+GET /api/v1/data-sources/:id/download
+```
+
+Streams the original uploaded file back to the client. Only available for `sourceType: file` data sources when DigitalOcean Spaces is configured and a `storageKey` was recorded on creation.
+
+Returns `404` when:
+- the data source does not exist
+- `storageKey` is `null` (Spaces not configured at upload time, or non-file source)
+
+### Response `200`
+
+- `Content-Type: application/octet-stream`
+- `Content-Disposition: attachment; filename="{original filename}"`
+- Body: raw file bytes (streamed directly from Spaces)
+
+---
+
 ## Delete a data source
 
 ```http
@@ -169,6 +190,7 @@ DELETE /api/v1/data-sources/:id
 
 1. Soft-deletes all related `DocumentSource` records (`syncStatus: 'deleted'`).
 2. Hard-deletes the `DataSource` document from MongoDB.
+3. If `storageKey` is set, deletes the file from DigitalOcean Spaces (non-blocking — a warning is logged on failure but the delete still succeeds).
 
 Qdrant vectors for soft-deleted records are pruned on the next document index pass.
 

--- a/docs/docs/backend/services.md
+++ b/docs/docs/backend/services.md
@@ -169,45 +169,27 @@ export async function retrieveAdditionalDocuments(queries, retriever, vectorStor
 }
 ```
 
-## Notion Services
+## Object Storage (`config/storage.js`)
 
-### Notion OAuth (`services/notionOAuth.js`)
-
-Handles Notion OAuth flow.
+Provides persistent file storage using **DigitalOcean Spaces** (S3-compatible). All objects are stored under an org-scoped key prefix to enforce multi-tenant isolation. The module degrades gracefully when Spaces env vars are absent — uploads are skipped and download endpoints return 404.
 
 ```javascript
-export const notionOAuth = {
-  getAuthorizationUrl(state) {
-    // Generate OAuth URL
-  },
+// Key builders
+buildDataSourceKey(orgId, workspaceId, dataSourceId, fileName)
+// → organizations/{orgId}/workspaces/{wsId}/datasources/{dsId}/{fileName}
 
-  async exchangeCode(code) {
-    // Exchange code for access token
-  },
-
-  async refreshToken(refreshToken) {
-    // Refresh access token
-  },
-};
+buildAssessmentFileKey(orgId, workspaceId, assessmentId, docIndex, fileName)
+// → organizations/{orgId}/workspaces/{wsId}/assessments/{assessmentId}/{index}_{fileName}
 ```
 
-### Notion Transformer (`services/notionTransformer.js`)
+| Export | Description |
+|--------|-------------|
+| `isStorageConfigured()` | Returns `true` when all four `DO_SPACES_*` env vars are set |
+| `uploadFile(key, buffer, mimeType)` | Uploads a buffer to Spaces, returns the key |
+| `downloadFileStream(key)` | Returns a readable stream — pipe directly to Express `res` |
+| `deleteFile(key)` | Deletes an object; no-op when storage is not configured |
 
-Transforms Notion blocks to text/markdown.
-
-```javascript
-export const transformBlocksToText = (blocks, indentLevel = 0) => {
-  // Convert Notion blocks to markdown
-};
-
-export const groupBlocksSemantically = (blocks) => {
-  // Group blocks for semantic chunking
-};
-
-export const extractPageMetadata = (properties) => {
-  // Extract metadata from Notion properties
-};
-```
+**Configuration env vars:** `DO_SPACES_KEY`, `DO_SPACES_SECRET`, `DO_SPACES_ENDPOINT`, `DO_SPACES_BUCKET`, `DO_SPACES_REGION` (default: `fra1`).
 
 ## Memory Services
 

--- a/docs/docs/deployment/environment-variables.md
+++ b/docs/docs/deployment/environment-variables.md
@@ -92,15 +92,19 @@ Generate encryption key:
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```
 
-### Notion Integration
+### Object Storage (DigitalOcean Spaces)
 
-| Variable | Description |
-|----------|-------------|
-| `NOTION_CLIENT_ID` | OAuth client ID |
-| `NOTION_CLIENT_SECRET` | OAuth client secret |
-| `NOTION_REDIRECT_URI` | OAuth callback URL |
-| `NOTION_WEBHOOK_SECRET` | Webhook signature verification |
-| `NOTION_API_RATE_LIMIT` | `2` - API calls per second |
+Persistent file storage for uploaded data source files and assessment documents. All variables are optional — when unset the upload step is silently skipped and download buttons are hidden in the UI.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DO_SPACES_KEY` | - | Spaces access key ID |
+| `DO_SPACES_SECRET` | - | Spaces secret access key |
+| `DO_SPACES_ENDPOINT` | - | Spaces endpoint URL (e.g. `https://fra1.digitaloceanspaces.com`) |
+| `DO_SPACES_BUCKET` | - | Bucket name |
+| `DO_SPACES_REGION` | `fra1` | Bucket region |
+
+Files are stored under `organizations/{orgId}/workspaces/{wsId}/...` enforcing org-level isolation. Files are served via a backend proxy — no pre-signed URLs are exposed to clients.
 
 ### RAG Configuration
 
@@ -163,15 +167,6 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 | `STALE_JOB_TIMEOUT_HOURS` | `2` | Hours before job is stale |
 | `MAX_SYNC_RECOVERY_ATTEMPTS` | `2` | Max recovery attempts |
 | `SYNC_PROGRESS_TIMEOUT_MINUTES` | `30` | Minutes without progress |
-
-### Token Health Monitoring
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `NOTION_TOKEN_MONITOR_ENABLED` | `true` | Enable token monitoring |
-| `TOKEN_CHECK_INTERVAL_HOURS` | `6` | Check frequency |
-| `NOTION_AUTO_RECONNECT` | `false` | Auto reconnection |
-| `NOTION_TOKEN_EMAIL_NOTIFICATIONS` | `true` | Email on token expiry |
 
 ### Guardrails
 
@@ -279,10 +274,12 @@ JWT_REFRESH_SECRET=
 # Encryption (REQUIRED - generate with: openssl rand -hex 32)
 ENCRYPTION_KEY=
 
-# Notion OAuth
-NOTION_CLIENT_ID=
-NOTION_CLIENT_SECRET=
-NOTION_REDIRECT_URI=http://localhost:3007/api/v1/notion/callback
+# Object Storage (DigitalOcean Spaces) — optional, files stored in-memory only when unset
+DO_SPACES_KEY=
+DO_SPACES_SECRET=
+DO_SPACES_ENDPOINT=https://fra1.digitaloceanspaces.com
+DO_SPACES_BUCKET=
+DO_SPACES_REGION=fra1
 
 # Email (optional for local dev - emails will be skipped if not set)
 RESEND_API_KEY=
@@ -316,8 +313,6 @@ echo "JWT_REFRESH_SECRET=$(openssl rand -base64 48)"
 # Encryption Key (32-byte hex)
 echo "ENCRYPTION_KEY=$(openssl rand -hex 32)"
 
-# Notion Webhook Secret
-echo "NOTION_WEBHOOK_SECRET=$(openssl rand -base64 32)"
 ```
 
 ## Environment-Specific Configurations


### PR DESCRIPTION
## Summary

- **`environment-variables.md`** — Replace removed Notion sections with new `DO_SPACES_*` object storage table and updated `.env.example` snippet
- **`backend/services.md`** — Replace dead Notion Services section with Object Storage module docs
- **`api/data-sources.md`** — Document `GET /:id/download`; update delete to mention Spaces cleanup; add `storageKey` to response example
- **`api/assessments.md`** — Document `GET /:id/files/:docIndex`; add `storageKey` to documents example

## Test plan

- [x] Docs-only change — no code modified
- [x] CI will run on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)