### PR TITLE
fix(backend): use vectorStore.similaritySearch to fix TenantIsolationError

### DIFF
--- a/backend/services/rag.js
+++ b/backend/services/rag.js
@@ -542,7 +542,7 @@ class RAGService {
     }
 
     // Direct vector store retrieval
-    const rawDocs = await this.retriever.invoke(searchQuery, { filter: qdrantFilter });
+    const rawDocs = await this.vectorStore.similaritySearch(searchQuery, 15, qdrantFilter);
     const rerankedDocs = rerankDocuments(rawDocs, searchQuery, 15);
 
     const retrieval = {


### PR DESCRIPTION
## Summary

- Production RAG queries were failing with HTTP 500 / `TenantIsolationError: Retriever invoked without workspace filter`
- Root cause: `this.retriever` was created at startup without a workspace filter; the tenant isolation wrapper checked for a filter set at creation time, not call time, so `this.retriever.invoke(query, { filter })` always threw
- Fix: replace the broken one-liner with `this.vectorStore.similaritySearch(searchQuery, 15, qdrantFilter)`, which routes through the already-correct validation path in `tenantIsolation.js`

## Files changed

| File | Change |
|------|--------|
| `backend/services/rag.js:545` | `this.retriever.invoke(...)` → `this.vectorStore.similaritySearch(searchQuery, 15, qdrantFilter)` |

## Test plan

- [x] Pre-PR gate: backend lint ✅, frontend lint ✅, 1131 backend tests ✅
- [ ] Deploy to production → trigger RAG query via UI → expect 200, no `TenantIsolationError` in logs
- [ ] LangSmith: `rag-answer-generation` trace appears in `retrieva-production` project

🤖 Generated with [Claude Code](https://claude.com/claude-code)