### PR TITLE
feat(frontend): pricing page — week 3

### DIFF
--- a/frontend/src/app/contact/page.tsx
+++ b/frontend/src/app/contact/page.tsx
@@ -1,0 +1,82 @@
+import Link from 'next/link';
+import { ArrowLeft, Mail, ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ThemeToggle } from '@/components/theme/theme-toggle';
+
+export default function ContactPage() {
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      {/* Header */}
+      <header className="border-b">
+        <div className="container mx-auto px-4 h-16 flex items-center justify-between">
+          <Link href="/" className="flex items-center gap-2">
+            <ShieldCheck className="h-6 w-6 text-primary" />
+            <span className="font-bold text-xl">Retrieva</span>
+          </Link>
+          <div className="flex items-center gap-4">
+            <ThemeToggle />
+            <Link href="/pricing">
+              <Button variant="ghost">Pricing</Button>
+            </Link>
+            <Link href="/login">
+              <Button variant="ghost">Sign In</Button>
+            </Link>
+            <Link href="/register">
+              <Button>Get Started</Button>
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="flex-1 container mx-auto px-4 py-16 max-w-xl">
+        <Link
+          href="/pricing"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-8"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to pricing
+        </Link>
+
+        <div className="text-center">
+          <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-primary/10 text-primary mb-6">
+            <Mail className="h-7 w-7" />
+          </div>
+
+          <h1 className="text-3xl font-bold mb-4">Talk to Sales</h1>
+          <p className="text-muted-foreground max-w-sm mx-auto mb-8">
+            Interested in Enterprise? Tell us about your organisation and we&apos;ll get back to you
+            within one business day.
+          </p>
+
+          <a
+            href="mailto:sales@retrieva.online?subject=Enterprise%20inquiry%20%E2%80%94%20Retrieva"
+          >
+            <Button size="lg" className="gap-2 mb-3">
+              <Mail className="h-4 w-4" />
+              Email Sales
+            </Button>
+          </a>
+
+          <p className="text-sm text-muted-foreground mb-6">sales@retrieva.online</p>
+
+          <p className="text-sm text-muted-foreground">
+            We typically respond within 1 business day.
+          </p>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t py-8">
+        <div className="container mx-auto px-4 text-center text-muted-foreground text-sm">
+          <p>
+            &copy; {new Date().getFullYear()} Retrieva.{' '}
+            <span className="opacity-60">
+              Built for DORA (Regulation EU 2022/2554) compliance.
+            </span>
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -21,6 +21,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { useAuthStore } from '@/lib/stores/auth-store';
 import { ThemeToggle } from '@/components/theme/theme-toggle';
+import { PricingSection } from '@/components/marketing/pricing-section';
 
 export default function LandingPage() {
   const router = useRouter();
@@ -57,6 +58,9 @@ export default function LandingPage() {
           </div>
           <div className="flex items-center gap-4">
             <ThemeToggle />
+            <Link href="/pricing">
+              <Button variant="ghost">Pricing</Button>
+            </Link>
             <Link href="/login">
               <Button variant="ghost">Sign In</Button>
             </Link>
@@ -230,6 +234,9 @@ export default function LandingPage() {
           </div>
         </div>
       </section>
+
+      {/* Pricing */}
+      <PricingSection />
 
       {/* CTA */}
       <section className="container mx-auto px-4 py-24 text-center">

--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import Link from 'next/link';
+import { ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ThemeToggle } from '@/components/theme/theme-toggle';
+import { PricingSection } from '@/components/marketing/pricing-section';
+
+const FAQ_ITEMS = [
+  {
+    question: 'Can I change plans later?',
+    answer: 'Yes, you can upgrade or downgrade your plan at any time from your billing settings. Changes take effect immediately.',
+  },
+  {
+    question: 'What happens after the trial?',
+    answer: "At the end of your 20-day trial you'll be prompted to add a payment method to continue. We never auto-charge — your data stays safe until you decide.",
+  },
+  {
+    question: 'Is there an annual discount?',
+    answer: 'Yes — all paid plans are 20% cheaper when billed annually. You can switch between monthly and annual billing at any time from your billing settings.',
+  },
+  {
+    question: 'How does the Enterprise POC work?',
+    answer: 'Contact our sales team and we will scope a proof-of-concept tailored to your organisation. No commitment required — the POC is designed to validate fit before you sign.',
+  },
+];
+
+export default function PricingPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Header */}
+      <header className="border-b">
+        <div className="container mx-auto px-4 h-16 flex items-center justify-between">
+          <Link href="/" className="flex items-center gap-2">
+            <ShieldCheck className="h-6 w-6 text-primary" />
+            <span className="font-bold text-xl">Retrieva</span>
+          </Link>
+          <div className="flex items-center gap-4">
+            <ThemeToggle />
+            <Link href="/pricing">
+              <Button variant="ghost" className="font-semibold">
+                Pricing
+              </Button>
+            </Link>
+            <Link href="/login">
+              <Button variant="ghost">Sign In</Button>
+            </Link>
+            <Link href="/register">
+              <Button>Get Started</Button>
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      {/* Pricing section */}
+      <PricingSection />
+
+      {/* FAQ */}
+      <section className="container mx-auto px-4 py-16 max-w-3xl">
+        <h2 className="text-2xl font-bold text-center mb-8">Frequently asked questions</h2>
+        <div className="space-y-2">
+          {FAQ_ITEMS.map((item) => (
+            <details
+              key={item.question}
+              className="group border rounded-lg overflow-hidden"
+            >
+              <summary className="flex items-center justify-between px-5 py-4 cursor-pointer font-medium select-none list-none">
+                {item.question}
+                <span className="text-muted-foreground transition-transform group-open:rotate-180 ml-4 shrink-0">
+                  ▾
+                </span>
+              </summary>
+              <div className="px-5 pb-4 text-sm text-muted-foreground leading-relaxed">
+                {item.answer}
+              </div>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="border-t py-8">
+        <div className="container mx-auto px-4 text-center text-muted-foreground text-sm">
+          <p>
+            &copy; {new Date().getFullYear()} Retrieva.{' '}
+            <span className="opacity-60">
+              Built for DORA (Regulation EU 2022/2554) compliance.
+            </span>
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/components/marketing/pricing-section.tsx
+++ b/frontend/src/components/marketing/pricing-section.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { Check } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+type Billing = 'monthly' | 'annual';
+
+interface Plan {
+  name: string;
+  monthly: string;
+  annual: string;
+  monthlyRaw: number | null;
+  annualRaw: number | null;
+  vendors: string;
+  members: string;
+  dataSources: string;
+  support: string;
+  trial: string;
+  highlighted: boolean;
+  badge?: string;
+  ctaLabel: string;
+  ctaHref: string;
+}
+
+const PLANS: Plan[] = [
+  {
+    name: 'Starter',
+    monthly: '€199',
+    annual: '€159',
+    monthlyRaw: 199,
+    annualRaw: 159,
+    vendors: 'Up to 10',
+    members: '3',
+    dataSources: 'File, URL',
+    support: 'Email',
+    trial: '20 days',
+    highlighted: false,
+    ctaLabel: 'Start free trial',
+    ctaHref: '/register',
+  },
+  {
+    name: 'Professional',
+    monthly: '€499',
+    annual: '€399',
+    monthlyRaw: 499,
+    annualRaw: 399,
+    vendors: 'Up to 50',
+    members: '10',
+    dataSources: 'File, URL, Confluence',
+    support: 'Priority email',
+    trial: '20 days',
+    highlighted: true,
+    badge: 'Most Popular',
+    ctaLabel: 'Start free trial',
+    ctaHref: '/register',
+  },
+  {
+    name: 'Business',
+    monthly: '€999',
+    annual: '€799',
+    monthlyRaw: 999,
+    annualRaw: 799,
+    vendors: 'Up to 150',
+    members: '30',
+    dataSources: 'All sources',
+    support: 'Slack + SLA',
+    trial: '20 days',
+    highlighted: false,
+    ctaLabel: 'Start free trial',
+    ctaHref: '/register',
+  },
+  {
+    name: 'Enterprise',
+    monthly: 'Custom',
+    annual: 'Custom',
+    monthlyRaw: null,
+    annualRaw: null,
+    vendors: 'Unlimited',
+    members: 'Unlimited',
+    dataSources: 'All + custom',
+    support: 'Dedicated CSM',
+    trial: 'POC',
+    highlighted: false,
+    ctaLabel: 'Contact Sales',
+    ctaHref: '/contact',
+  },
+];
+
+interface FeatureRowProps {
+  label: string;
+  value: string | React.ReactNode;
+}
+
+function FeatureRow({ label, value }: FeatureRowProps) {
+  return (
+    <div className="flex justify-between items-center py-2 border-b border-border/50 last:border-0">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="text-xs font-medium text-right max-w-[55%]">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+const checkMark = <Check className="h-4 w-4 text-green-500 ml-auto" />;
+
+export function PricingSection() {
+  const [billing, setBilling] = useState<Billing>('monthly');
+
+  return (
+    <section className="container mx-auto px-4 py-24">
+      <div className="text-center mb-12">
+        <h2 className="text-3xl font-bold mb-4">Simple, transparent pricing</h2>
+        <p className="text-muted-foreground max-w-2xl mx-auto mb-8">
+          20-day free trial on all plans. No credit card required to start.
+        </p>
+
+        {/* Billing toggle */}
+        <div className="inline-flex items-center rounded-full border p-1 bg-muted/50">
+          <button
+            onClick={() => setBilling('monthly')}
+            className={`px-4 py-1.5 rounded-full text-sm font-medium transition-all ${
+              billing === 'monthly'
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Monthly
+          </button>
+          <button
+            onClick={() => setBilling('annual')}
+            className={`px-4 py-1.5 rounded-full text-sm font-medium transition-all flex items-center gap-1.5 ${
+              billing === 'annual'
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Annual
+            <span className="text-xs font-semibold text-green-500 bg-green-500/10 px-1.5 py-0.5 rounded-full">
+              -20%
+            </span>
+          </button>
+        </div>
+      </div>
+
+      {/* 4-card grid */}
+      <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+        {PLANS.map((plan, index) => (
+          <motion.div
+            key={plan.name}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.4, delay: index * 0.1 }}
+            className={`relative rounded-xl p-6 flex flex-col ${
+              plan.highlighted
+                ? 'ring-2 ring-primary bg-card shadow-lg'
+                : 'border bg-card'
+            }`}
+          >
+            {/* Most Popular badge */}
+            {plan.badge && (
+              <span className="absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-1 rounded-full text-xs font-semibold bg-primary text-primary-foreground whitespace-nowrap">
+                {plan.badge}
+              </span>
+            )}
+
+            {/* Plan name */}
+            <h3 className="font-semibold text-lg mb-1">{plan.name}</h3>
+
+            {/* Price */}
+            <div className="mb-6">
+              {plan.monthlyRaw === null ? (
+                <div className="text-4xl font-bold">Custom</div>
+              ) : (
+                <>
+                  <div className="text-4xl font-bold">
+                    {billing === 'monthly' ? plan.monthly : plan.annual}
+                    <span className="text-base font-normal text-muted-foreground">/mo</span>
+                  </div>
+                  {billing === 'annual' && (
+                    <p className="text-xs text-muted-foreground mt-1">billed annually</p>
+                  )}
+                </>
+              )}
+            </div>
+
+            {/* Feature rows */}
+            <div className="flex-1 space-y-0">
+              <FeatureRow label="Vendors managed" value={plan.vendors} />
+              <FeatureRow label="Team members" value={plan.members} />
+              <FeatureRow label="DORA gap assessments" value="Unlimited" />
+              <FeatureRow label="Vendor questionnaires" value="Unlimited" />
+              <FeatureRow label="AI Copilot queries" value="Unlimited" />
+              <FeatureRow label="Data sources" value={plan.dataSources} />
+              <FeatureRow label="EBA Excel export" value={checkMark} />
+              <FeatureRow label="Cert/contract alerts" value={checkMark} />
+              <FeatureRow label="Support" value={plan.support} />
+              <FeatureRow label="Free trial" value={plan.trial} />
+            </div>
+
+            {/* CTA */}
+            <Link href={plan.ctaHref} className="mt-6">
+              <Button
+                size="lg"
+                variant={plan.highlighted ? 'default' : 'outline'}
+                className="w-full"
+              >
+                {plan.ctaLabel}
+              </Button>
+            </Link>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `/pricing` standalone public route with 4-plan grid (Starter / Professional / Business / Enterprise)
- Monthly/annual billing toggle with −20% annual badge; prices update live
- Professional card highlighted with `ring-2 ring-primary` and "Most Popular" badge
- Add `/contact` page for Enterprise → "Talk to Sales" with `mailto:` CTA
- Insert `<PricingSection />` on landing page between How It Works and CTA
- Add "Pricing" nav link to landing page header

## Test plan

- [ ] Backend lint — 0 errors ✅
- [ ] Frontend lint — 0 errors ✅
- [ ] 1131 backend tests — 0 failures ✅
- [ ] `next build` (26/26 routes) — no errors ✅
- [ ] Landing page: "Pricing" appears in nav; pricing section visible between How It Works and CTA
- [ ] `/pricing`: full page renders; toggle switches prices; "Most Popular" badge on Professional
- [ ] Annual toggle: Starter €159/mo, Professional €399/mo, Business €799/mo, Enterprise "Custom"
- [ ] Enterprise "Contact Sales" → `/contact`; all other CTAs → `/register`
- [ ] `/contact`: "Talk to Sales" page with mailto button → `sales@retrieva.online`

🤖 Generated with [Claude Code](https://claude.com/claude-code)