### PR TITLE
docs: deep review — fix stale content across 8 files

### DIFF
--- a/docs/docs/api/overview.md
+++ b/docs/docs/api/overview.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # API Overview
 
-The RAG Platform provides a RESTful API for all operations. All endpoints are prefixed with `/api/v1`.
+Retrieva provides a RESTful API for all operations. All endpoints are prefixed with `/api/v1`.
 
 ## Base URL
 
@@ -104,8 +104,12 @@ X-Workspace-Id: 507f1f77bcf86cd799439011
 | POST | `/auth/register` | Register user |
 | POST | `/auth/login` | Login |
 | POST | `/auth/logout` | Logout |
-| POST | `/auth/refresh` | Refresh token |
+| POST | `/auth/refresh` | Refresh access token |
 | GET | `/auth/me` | Get current user |
+| POST | `/auth/forgot-password` | Request password reset email |
+| POST | `/auth/reset-password` | Reset password with token |
+| POST | `/auth/verify-email` | Verify email address with token |
+| POST | `/auth/resend-verification` | Resend email verification link |
 
 ### Notion
 
@@ -117,16 +121,50 @@ X-Workspace-Id: 507f1f77bcf86cd799439011
 | GET | `/notion/sync-status` | Get sync status |
 | GET | `/notion/workspaces` | List workspaces |
 
-### Workspaces
+### Workspaces (Vendor Registry)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/workspaces` | List user workspaces |
-| GET | `/workspaces/:id` | Get workspace |
-| PATCH | `/workspaces/:id` | Update workspace |
+| GET | `/workspaces` | List workspaces for the current user / org |
+| POST | `/workspaces` | Create a new vendor workspace |
+| GET | `/workspaces/:id` | Get workspace details |
+| PATCH | `/workspaces/:id` | Update vendor profile (tier, country, contracts, certs) |
 | DELETE | `/workspaces/:id` | Delete workspace |
-| POST | `/workspaces/:id/members` | Add member |
-| DELETE | `/workspaces/:id/members/:userId` | Remove member |
+| POST | `/workspaces/:id/members` | Add workspace member |
+| DELETE | `/workspaces/:id/members/:userId` | Remove workspace member |
+| GET | `/workspaces/roi-export` | Download EBA DORA Art. 28(3) RoI XLSX workbook |
+
+### Assessments
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/assessments` | List assessments for a workspace |
+| POST | `/assessments` | Create assessment and upload vendor documents |
+| GET | `/assessments/:id` | Get assessment details and gap results |
+| DELETE | `/assessments/:id` | Delete assessment |
+| GET | `/assessments/:id/report` | Download Word (.docx) compliance report |
+
+### Questionnaires
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/questionnaires` | List questionnaires for a workspace |
+| POST | `/questionnaires` | Create and send a vendor questionnaire |
+| GET | `/questionnaires/:id` | Get questionnaire with scoring results |
+| PATCH | `/questionnaires/:id` | Update questionnaire |
+| DELETE | `/questionnaires/:id` | Delete questionnaire |
+
+### Organizations
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/organizations` | Create a new organization (first-time onboarding) |
+| GET | `/organizations/me` | Get current user's organization |
+| PATCH | `/organizations/:id` | Update organization |
+| POST | `/organizations/:id/invite` | Invite a team member (sends email with `/join` link) |
+| GET | `/organizations/:id/members` | List organization members |
+| PATCH | `/organizations/:id/members/:memberId` | Change member role |
+| DELETE | `/organizations/:id/members/:memberId` | Revoke membership |
 
 ### Analytics
 
@@ -177,24 +215,14 @@ Returns service health status:
 
 ```json
 {
-  "status": "healthy",
-  "version": "1.0.0",
-  "timestamp": "2024-01-01T00:00:00.000Z",
-  "services": {
-    "mongodb": "connected",
-    "redis": "connected",
-    "qdrant": "connected",
-    "ollama": "connected"
+  "status": "success",
+  "message": "Service is healthy",
+  "data": {
+    "status": "up",
+    "timestamp": "2024-01-01T00:00:00.000Z",
+    "uptime": 123.456
   }
 }
-```
-
-## Swagger Documentation
-
-Interactive API documentation is available at:
-
-```
-http://localhost:3007/api-docs
 ```
 
 ## Rate Limiting

--- a/docs/docs/architecture/rag-pipeline.md
+++ b/docs/docs/architecture/rag-pipeline.md
@@ -160,12 +160,13 @@ const compressedDocs = await compressDocuments(documents, query, {
 ```javascript
 const ragPrompt = ChatPromptTemplate.fromMessages([
   ['system', `
-    You are an expert AI assistant with access to the user's Notion workspace.
+    You are an expert DORA compliance AI assistant. You have access to the organisation's
+    uploaded vendor ICT documentation, DORA regulatory articles, and completed gap assessments.
 
     CRITICAL INSTRUCTIONS:
     1. Use ONLY information from provided context
     2. ALWAYS cite sources using [Source N] format
-    3. If information not found, say so
+    3. If information not found, say so explicitly
     4. NEVER invent or hallucinate information
 
     CONTEXT:
@@ -274,14 +275,13 @@ Key environment variables:
 ```bash
 # Retrieval
 QDRANT_URL=http://localhost:6333
-QDRANT_COLLECTION=notion_documents
-RETRIEVAL_TOP_K=10
+QDRANT_COLLECTION_NAME=documents          # default collection for workspace knowledge base
 
-# LLM
-OLLAMA_BASE_URL=http://localhost:11434
-LLM_MODEL=llama3.2:latest
-LLM_TEMPERATURE=0.1
-LLM_MAX_TOKENS=2048
+# LLM (Azure OpenAI — production default)
+LLM_PROVIDER=azure_openai
+AZURE_OPENAI_LLM_DEPLOYMENT=gpt-4o-mini
+LLM_TEMPERATURE=0.3
+LLM_MAX_TOKENS=2000
 
 # Timeouts
 LLM_INVOKE_TIMEOUT=60000
@@ -291,6 +291,7 @@ LLM_STREAM_CHUNK_TIMEOUT=10000
 # Quality
 MIN_CONFIDENCE_THRESHOLD=0.4
 ENABLE_HALLUCINATION_BLOCKING=true
+GUARDRAIL_STRICT_HALLUCINATION_BLOCKING=true
 ```
 
 ## Error Handling

--- a/docs/docs/backend/models.md
+++ b/docs/docs/backend/models.md
@@ -12,58 +12,63 @@ Mongoose models define the data schema and provide an interface to MongoDB.
 // models/User.js
 
 const userSchema = new Schema({
-  email: {
-    type: String,
-    required: true,
-    unique: true,
-    lowercase: true,
-    trim: true,
+  email: { type: String, required: true, unique: true, lowercase: true, trim: true },
+  password: { type: String, required: true, select: false },
+  name: { type: String, required: true, trim: true },  // field-level AES-256-GCM encrypted
+  role: { type: String, enum: ['user', 'admin'], default: 'user' },
+  isActive: { type: Boolean, default: true },
+
+  // Multi-device session management (up to 5 active sessions per user)
+  refreshTokens: [{
+    tokenHash:  { type: String, required: true },  // SHA-256 of raw token
+    deviceInfo: { type: String, default: 'unknown' },
+    createdAt:  { type: Date, default: Date.now },
+    expiresAt:  { type: Date, required: true },
+  }],
+
+  lastLogin: Date,
+  loginAttempts: { type: Number, default: 0 },
+  lockUntil: Date,  // account locks for 2h after 5 failed attempts
+
+  // Email verification
+  isEmailVerified:            { type: Boolean, default: false },
+  emailVerificationToken:     { type: String, select: false },  // SHA-256 hash
+  emailVerificationExpires:   { type: Date, select: false },
+  emailVerificationLastSentAt: Date,
+
+  // Password reset
+  passwordResetToken:   { type: String, select: false },  // SHA-256 hash
+  passwordResetExpires: { type: Date, select: false },
+
+  // Per-channel, per-event notification preferences
+  notificationPreferences: {
+    inApp: { workspace_invitation: Boolean, sync_completed: Boolean, system_alert: Boolean, /* ... */ },
+    email: { workspace_invitation: Boolean, sync_failed: Boolean, system_alert: Boolean, /* ... */ },
   },
-  password: {
-    type: String,
-    required: true,
-    select: false,  // Don't include in queries by default
-  },
-  name: {
-    type: String,
-    required: true,
-    trim: true,
-  },
-  status: {
-    type: String,
-    enum: ['active', 'inactive', 'suspended'],
-    default: 'active',
-  },
-  role: {
-    type: String,
-    enum: ['user', 'admin'],
-    default: 'user',
-  },
-  refreshToken: {
-    type: String,
-    select: false,
-  },
-  lastLoginAt: Date,
-  createdAt: {
-    type: Date,
-    default: Date.now,
-  },
+
+  // Organization membership (null for legacy users — falls back to WorkspaceMember)
+  organizationId: { type: ObjectId, ref: 'Organization', default: null },
+}, { timestamps: true });
+
+// Virtual: account is locked
+userSchema.virtual('isLocked').get(function() {
+  return !!(this.lockUntil && this.lockUntil > Date.now());
 });
-
-// Password hashing
-userSchema.pre('save', async function(next) {
-  if (!this.isModified('password')) return next();
-  this.password = await bcrypt.hash(this.password, 12);
-  next();
-});
-
-// Password comparison
-userSchema.methods.comparePassword = async function(candidatePassword) {
-  return bcrypt.compare(candidatePassword, this.password);
-};
-
-export const User = model('User', userSchema);
 ```
+
+**Key methods:**
+
+| Method | Description |
+|--------|-------------|
+| `comparePassword(candidate)` | bcrypt compare |
+| `incLoginAttempts()` | Increment failed logins; locks after 5 |
+| `resetLoginAttempts()` | Clear count on successful login |
+| `addRefreshToken(hash, device, days)` | Add hashed token (max 5 sessions) |
+| `consumeRefreshToken(hash)` | Find + remove token (rotation) |
+| `clearAllRefreshTokens()` | Logout all devices |
+| `createPasswordResetToken()` | Returns raw token; stores SHA-256 hash |
+| `createEmailVerificationToken()` | Returns raw token; stores SHA-256 hash |
+| `verifyEmail(rawToken)` | Sets `isEmailVerified = true` |
 
 ## NotionWorkspace Model
 
@@ -179,10 +184,9 @@ export const NotionWorkspace = model('NotionWorkspace', notionWorkspaceSchema);
 
 const conversationSchema = new Schema({
   workspaceId: {
-    type: Schema.Types.ObjectId,
-    ref: 'NotionWorkspace',
-    required: true,
+    type: Schema.Types.Mixed,  // String or ObjectId — vendor workspace
     index: true,
+    default: 'default',
   },
   userId: {
     type: Schema.Types.ObjectId,
@@ -282,80 +286,73 @@ export const Message = model('Message', messageSchema);
 
 ## DocumentSource Model
 
+Tracks indexed documents from all data sources. The actual vectors are in Qdrant; this model stores metadata and sync state.
+
 ```javascript
 // models/DocumentSource.js
 
 const documentSourceSchema = new Schema({
-  workspaceId: {
-    type: String,
-    required: true,
-    index: true,
-  },
+  workspaceId: { type: String, required: true, index: true },
+
+  // Source type — covers all supported connectors
   sourceType: {
     type: String,
-    enum: ['notion', 'pdf', 'web'],
-    default: 'notion',
-  },
-  sourceId: {
-    type: String,
+    enum: ['file', 'pdf', 'docx', 'xlsx', 'url', 'confluence',
+           'gdrive', 'github', 'jira', 'slack', 'text', 'custom'],
     required: true,
   },
-  documentType: {
+  sourceId: { type: String, required: true },
+  documentType: { type: String, enum: ['page', 'database', 'file', 'folder'], required: true },
+
+  // Document classification for access control
+  classification: {
     type: String,
-    enum: ['page', 'database', 'file'],
-    default: 'page',
+    enum: ['public', 'internal', 'confidential', 'restricted'],
+    default: 'internal',
   },
-  title: {
-    type: String,
-    required: true,
-  },
+
+  title: { type: String, required: true },  // field-level AES-256-GCM encrypted
   url: String,
-  contentHash: {
-    type: String,
-    index: true,
-  },
+  parentId: String,
+  path: String,
+  contentHash: String,
+  lastModifiedInSource: Date,
+  lastSyncedAt: Date,
+
   syncStatus: {
     type: String,
-    enum: ['pending', 'indexed', 'error', 'deleted'],
+    enum: ['pending', 'synced', 'error', 'deleted'],
     default: 'pending',
   },
-  chunkCount: {
-    type: Number,
-    default: 0,
-  },
   vectorStoreIds: [String],
-  lastModifiedInSource: Date,
-  lastIndexedAt: Date,
-  metadata: {
-    author: String,
-    createdAt: Date,
-    properties: Schema.Types.Mixed,
-    parentId: String,
-    parentType: String,
-  },
-  error: {
-    message: String,
+  chunkCount: { type: Number, default: 0 },
+
+  // Embedding version tracking (for migration support)
+  embeddingMetadata: {
+    version: String,
+    provider: { type: String, enum: ['local', 'cloud'] },
+    model: String,
+    dimensions: Number,
     timestamp: Date,
-    retryCount: Number,
   },
-  createdAt: {
-    type: Date,
-    default: Date.now,
-  },
-});
+
+  metadata: { author: String, tags: [String], properties: Mixed, customFields: Mixed },
+
+  // Error log (max 10 entries, messages capped at 2000 chars)
+  errorLog: [{ timestamp: Date, error: String, retryCount: Number }],
+}, { timestamps: true });
 
 // Compound unique index
 documentSourceSchema.index({ workspaceId: 1, sourceId: 1 }, { unique: true });
-
-// Mark as deleted
-documentSourceSchema.methods.markAsDeleted = async function() {
-  this.syncStatus = 'deleted';
-  this.deletedAt = new Date();
-  return this.save();
-};
-
-export const DocumentSource = model('DocumentSource', documentSourceSchema);
 ```
+
+**Key methods:**
+
+| Method | Description |
+|--------|-------------|
+| `markAsSynced(vectorIds, chunkCount, embeddingMeta)` | Set `syncStatus = 'synced'` |
+| `markAsDeleted()` | Set `syncStatus = 'deleted'` |
+| `addError(error, retryCount)` | Append to error log (capped), set `syncStatus = 'error'` |
 
 ## SyncJob Model
 
@@ -461,7 +458,7 @@ export const SyncJob = model('SyncJob', syncJobSchema);
 const analyticsSchema = new Schema({
   workspaceId: {
     type: Schema.Types.ObjectId,
-    ref: 'NotionWorkspace',
+    ref: 'Workspace',
     required: true,
     index: true,
   },

--- a/docs/docs/backend/services.md
+++ b/docs/docs/backend/services.md
@@ -314,7 +314,7 @@ export const emailService = {
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `RESEND_API_KEY` | - | Resend API key (required for sending) |
-| `SMTP_FROM_NAME` | `RAG Platform` | Display name in "From" field |
+| `SMTP_FROM_NAME` | `Retrieva` | Display name in "From" field |
 | `RESEND_FROM_EMAIL` | `noreply@retrieva.online` | Sender address (must match verified domain) |
 | `EMAIL_SERVICE_URL` | - | When set, proxy to standalone email-service instead of calling Resend directly |
 

--- a/docs/docs/deployment/docker.md
+++ b/docs/docs/deployment/docker.md
@@ -102,8 +102,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - QDRANT_URL=http://qdrant:6333
-      - OLLAMA_BASE_URL=http://host.docker.internal:11434
       - RAGAS_SERVICE_URL=http://ragas-service:8001
+      # Azure OpenAI — set via .env file (not hardcoded here)
+      # LLM_PROVIDER=azure_openai, AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, etc.
     depends_on:
       mongodb:
         condition: service_healthy
@@ -126,8 +127,6 @@ services:
     container_name: rag-ragas
     ports:
       - "8001:8001"
-    environment:
-      - OLLAMA_BASE_URL=http://host.docker.internal:11434
     networks:
       - rag-network
     restart: unless-stopped

--- a/docs/docs/deployment/environment-variables.md
+++ b/docs/docs/deployment/environment-variables.md
@@ -189,7 +189,7 @@ Files are stored under `organizations/{orgId}/workspaces/{wsId}/...` enforcing o
 | Variable | Description |
 |----------|-------------|
 | `LANGSMITH_API_KEY` | LangSmith API key |
-| `LANGSMITH_PROJECT` | `rag-notion` - Project name |
+| `LANGSMITH_PROJECT` | `retrieva` - Project name |
 | `LANGSMITH_ENABLED` | `true` - Enable tracing |
 | `RAGAS_SERVICE_URL` | `http://localhost:8001` |
 | `RAGAS_TIMEOUT` | `60000` - Evaluation timeout |
@@ -206,7 +206,7 @@ Files are stored under `organizations/{orgId}/workspaces/{wsId}/...` enforcing o
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `RESEND_API_KEY` | - | Resend API key for sending emails |
-| `SMTP_FROM_NAME` | `RAG Platform` | Display name in the "From" field |
+| `SMTP_FROM_NAME` | `Retrieva` | Display name in the "From" field |
 | `RESEND_FROM_EMAIL` | `noreply@retrieva.online` | Sender email address (must match a verified Resend domain) |
 
 :::note
@@ -243,7 +243,7 @@ In docker-compose development all three microservice URLs are automatically set 
 |----------|---------|-------------|
 | `NEXT_PUBLIC_API_URL` | `http://localhost:3007/api/v1` | Backend API URL |
 | `NEXT_PUBLIC_WS_URL` | `http://localhost:3007` | WebSocket URL |
-| `NEXT_PUBLIC_APP_NAME` | `RAG Platform` | Application name |
+| `NEXT_PUBLIC_APP_NAME` | `Retrieva` | Application name |
 
 ## Environment File Template
 
@@ -283,7 +283,7 @@ DO_SPACES_REGION=fra1
 
 # Email (optional for local dev - emails will be skipped if not set)
 RESEND_API_KEY=
-SMTP_FROM_NAME=RAG Platform
+SMTP_FROM_NAME=Retrieva
 RESEND_FROM_EMAIL=noreply@yourdomain.com
 
 # Frontend
@@ -296,7 +296,7 @@ ALLOWED_ORIGINS=http://localhost:3000
 ```bash
 NEXT_PUBLIC_API_URL=http://localhost:3007/api/v1
 NEXT_PUBLIC_WS_URL=http://localhost:3007
-NEXT_PUBLIC_APP_NAME=RAG Platform
+NEXT_PUBLIC_APP_NAME=Retrieva
 ```
 
 ## Secret Generation

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -24,8 +24,8 @@ The platform was built across four delivery phases:
 
 | Phase | Feature | Status |
 |-------|---------|--------|
-| Phase 1 | RAG foundation — knowledge ingestion, vector search, AI copilot | ✅ Production |
-| Phase 2 | Multi-source ingestion — files, URLs, Notion, Confluence; DORA assessment UI | ✅ Production |
+| Phase 1 | DORA Copilot foundation — knowledge ingestion, vector search, conversational Q&A | ✅ Production |
+| Phase 2 | Multi-source ingestion (files, URLs, Confluence, Notion connector); DORA gap assessment UI | ✅ Production |
 | Phase 3 | Vendor questionnaires with LLM scoring | ✅ Production |
 | Phase 4 | Monitoring alerts + Register of Information export | ✅ Production |
 

--- a/docs/docs/security/overview.md
+++ b/docs/docs/security/overview.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Security Overview
 
-The RAG Platform implements multiple security layers to protect user data and ensure safe AI operations.
+Retrieva implements multiple security layers to protect user data and ensure safe AI operations.
 
 ## Security Architecture
 
@@ -113,7 +113,7 @@ The platform addresses the [OWASP Top 10 for LLM Applications](https://owasp.org
 
 ### Data Protection
 
-- AES-256 encryption for Notion tokens
+- AES-256-GCM encryption for sensitive tokens (OAuth access tokens, Notion credentials, API keys)
 - Tenant isolation at database level
 - Mandatory workspace filter on vector queries
 - No cross-tenant data access
@@ -185,7 +185,7 @@ Events logged:
 If you discover a security vulnerability:
 
 1. **Do not** disclose publicly
-2. Email security@example.com
+2. Email security@retrieva.online
 3. Include detailed reproduction steps
 4. Allow 90 days for remediation
 


### PR DESCRIPTION
## Summary

Deep review of all documentation to align with the current DORA compliance platform architecture. 8 files corrected across every major inaccuracy found.

### `architecture/rag-pipeline.md`
- System prompt was "access to the user's Notion workspace" → fixed to DORA compliance assistant
- Config block had `QDRANT_COLLECTION=notion_documents`, `OLLAMA_BASE_URL`, `LLM_MODEL=llama3.2:latest` — all wrong; replaced with correct Azure OpenAI / `QDRANT_COLLECTION_NAME` vars

### `api/overview.md`
- Product name "RAG Platform" → "Retrieva"
- Health check response showed `"ollama": "connected"` — removed (Ollama not used)
- Removed non-existent Swagger `/api-docs` section
- Added missing auth endpoints (forgot/reset password, email verification × 2)
- Added missing API tables: **Assessments**, **Questionnaires**, **Organizations**
- Added `POST /workspaces` (create) and `GET /workspaces/roi-export` to Workspaces table

### `backend/models.md`
- **User model**: was missing 10+ real fields — added `refreshTokens[]`, `isActive`, `loginAttempts`, `lockUntil`, `isEmailVerified`, email/password reset token fields, `notificationPreferences`, `organizationId`
- **DocumentSource**: `sourceType` enum was `['notion','pdf','web']` — fixed to actual enum with all 12 source types
- **Conversation**: `workspaceId` ref was `NotionWorkspace` → `Workspace` (Mixed type)
- **Analytics**: `workspaceId` ref was `NotionWorkspace` → `Workspace`

### `security/overview.md`
- "RAG Platform" → "Retrieva"
- "AES-256 encryption for Notion tokens" → broader description covering all sensitive tokens
- Security contact `security@example.com` → `security@retrieva.online`

### `deployment/docker.md`
- Removed `OLLAMA_BASE_URL=http://host.docker.internal:11434` from dev docker-compose example

### `deployment/environment-variables.md`
- All `SMTP_FROM_NAME` and `NEXT_PUBLIC_APP_NAME` defaults: "RAG Platform" → "Retrieva"
- `LANGSMITH_PROJECT` value: `rag-notion` → `retrieva`

### `backend/services.md`
- `SMTP_FROM_NAME` default: "RAG Platform" → "Retrieva"

### `intro.md`
- Phase 1/2 descriptions updated to reflect DORA product focus (not generic RAG)

## Test plan
- [ ] Docusaurus build passes ✅
- [ ] No broken links introduced
- [ ] All corrected content matches actual backend source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)