### PR TITLE
docs: remove stale ragas and microservices references

### DIFF
--- a/docs/docs/architecture/rag-pipeline.md
+++ b/docs/docs/architecture/rag-pipeline.md
@@ -273,9 +273,9 @@ await cache.set(question, result, workspaceId, conversationId);
 Key environment variables:
 
 ```bash
-# Retrieval
+# Retrieval (Qdrant)
 QDRANT_URL=http://localhost:6333
-QDRANT_COLLECTION_NAME=documents          # default collection for workspace knowledge base
+QDRANT_COLLECTION_NAME=documents          # workspace knowledge base collection
 
 # LLM (Azure OpenAI — production default)
 LLM_PROVIDER=azure_openai
@@ -283,14 +283,20 @@ AZURE_OPENAI_LLM_DEPLOYMENT=gpt-4o-mini
 LLM_TEMPERATURE=0.3
 LLM_MAX_TOKENS=2000
 
+# Embeddings (Azure OpenAI — text-embedding-3-small, 1536 dims, Cosine)
+EMBEDDING_PROVIDER=azure
+AZURE_OPENAI_EMBEDDING_DEPLOYMENT=text-embedding-3-small
+EMBEDDING_MAX_CONCURRENCY=10              # parallel embedding API calls (S0 tier: 5-10 safe)
+EMBEDDING_BATCH_MAX_CHUNKS=50            # max chunks per batch request
+EMBEDDING_BATCH_MAX_TOKENS=8192          # max tokens per batch request
+EMBEDDING_CONTEXT_TOKENS=8192            # model context window (drives per-chunk truncation)
+
 # Timeouts
 LLM_INVOKE_TIMEOUT=60000
 LLM_STREAM_INITIAL_TIMEOUT=30000
 LLM_STREAM_CHUNK_TIMEOUT=10000
 
 # Quality
-MIN_CONFIDENCE_THRESHOLD=0.4
-ENABLE_HALLUCINATION_BLOCKING=true
 GUARDRAIL_STRICT_HALLUCINATION_BLOCKING=true
 ```
 

--- a/docs/docs/backend/configuration.md
+++ b/docs/docs/backend/configuration.md
@@ -122,23 +122,56 @@ export async function getJudgeLLM() {
 
 ### Embeddings (`config/embeddings.js`)
 
+The embeddings module wraps `AzureOpenAIEmbeddings` from `@langchain/openai` inside a custom `BatchedEmbeddings` class that adds automatic batching, text truncation, and metrics tracking.
+
+**Provider:** Azure OpenAI — `text-embedding-3-small` (1 536-dimension vectors, Cosine distance).
+Hybrid mode (`ENABLE_HYBRID_EMBEDDINGS`) is disabled; Azure is the only active provider.
+
 ```javascript
+// Simplified structure — actual class has ~350 lines
 import { AzureOpenAIEmbeddings } from '@langchain/openai';
 
-let embeddingsModel = null;
+const baseEmbeddings = new AzureOpenAIEmbeddings({
+  azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
+  azureOpenAIApiInstanceName: AZURE_OPENAI_INSTANCE_NAME, // extracted from AZURE_OPENAI_ENDPOINT
+  azureOpenAIApiDeploymentName: process.env.AZURE_OPENAI_EMBEDDING_DEPLOYMENT || 'text-embedding-3-small',
+  azureOpenAIApiVersion: process.env.AZURE_OPENAI_API_VERSION || '2024-02-15-preview',
+  maxConcurrency: parseInt(process.env.EMBEDDING_MAX_CONCURRENCY) || 10,
+});
 
-export async function getEmbeddings() {
-  if (embeddingsModel) return embeddingsModel;
+export const embeddings = new BatchedEmbeddings(baseEmbeddings, BATCH_CONFIG);
+```
 
-  embeddingsModel = new AzureOpenAIEmbeddings({
-    azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
-    azureOpenAIApiInstanceName: extractInstanceName(process.env.AZURE_OPENAI_ENDPOINT),
-    azureOpenAIApiDeploymentName: process.env.AZURE_OPENAI_EMBEDDING_DEPLOYMENT || 'text-embedding-3-small',
-    azureOpenAIApiVersion: process.env.AZURE_OPENAI_API_VERSION || '2024-02-15-preview',
-  });
+#### Batch Configuration
 
-  return embeddingsModel;
-}
+```javascript
+export const BATCH_CONFIG = {
+  maxChunks: parseInt(process.env.EMBEDDING_BATCH_MAX_CHUNKS) || 50,  // max chunks per API call
+  maxTokens: parseInt(process.env.EMBEDDING_BATCH_MAX_TOKENS) || 8192, // max tokens per batch
+  charsPerToken: 4,                                                     // estimation ratio
+};
+```
+
+Batches are split whenever either limit (`maxChunks` or `maxTokens`) would be exceeded. Each batch is sent as a single `embedDocuments()` call.
+
+#### Truncation & Retry
+
+Texts exceeding `maxCharsPerChunk` are truncated before embedding. If the API still returns a context-length error, the system retries with progressively shorter inputs:
+
+| Attempt | Text length |
+|---------|------------|
+| 1 | Full (truncated to `maxCharsPerChunk`) |
+| 2 | 50% of original |
+| 3 | 25% of original |
+| 4 | 10% of original (minimum 100 chars) |
+
+#### Metrics
+
+```javascript
+import { getEmbeddingMetrics } from './config/embeddings.js';
+
+const m = getEmbeddingMetrics();
+// { totalChunksEmbedded, totalBatches, chunksPerSecond, avgBatchLatencyMs, errors, truncations }
 ```
 
 ## Vector Store Configuration
@@ -156,7 +189,7 @@ const qdrantClient = new QdrantClient({
 
 export async function getVectorStore(documents = []) {
   const embeddings = await getEmbeddings();
-  const collectionName = process.env.QDRANT_COLLECTION || 'notion_documents';
+  const collectionName = process.env.QDRANT_COLLECTION_NAME || 'documents';
 
   // Ensure collection exists
   const collections = await qdrantClient.getCollections();
@@ -316,19 +349,18 @@ LOG_LEVEL=info
 # ===========================================
 # MongoDB
 # ===========================================
-MONGODB_URI=mongodb://localhost:27017/rag
+MONGODB_URI=mongodb://localhost:27017/enterprise_rag
 
 # ===========================================
 # Redis
 # ===========================================
-REDIS_HOST=localhost
-REDIS_PORT=6378
+REDIS_URL=redis://localhost:6378
 
 # ===========================================
 # Qdrant Vector Store
 # ===========================================
 QDRANT_URL=http://localhost:6333
-QDRANT_COLLECTION=notion_documents
+QDRANT_COLLECTION_NAME=documents
 
 # ===========================================
 # Azure OpenAI
@@ -345,6 +377,14 @@ LLM_MAX_TOKENS=2000
 JUDGE_LLM_MODEL=gpt-4o-mini
 
 # ===========================================
+# Embedding Batching (optional — defaults shown)
+# ===========================================
+EMBEDDING_MAX_CONCURRENCY=10          # parallel API calls (S0 tier: 5-10 safe)
+EMBEDDING_BATCH_MAX_CHUNKS=50         # max chunks per batch request
+EMBEDDING_BATCH_MAX_TOKENS=8192       # max tokens per batch request
+EMBEDDING_CONTEXT_TOKENS=8192         # model context window (for per-chunk truncation)
+
+# ===========================================
 # LLM Timeouts
 # ===========================================
 LLM_INVOKE_TIMEOUT=60000
@@ -354,33 +394,21 @@ LLM_STREAM_CHUNK_TIMEOUT=10000
 # ===========================================
 # JWT Authentication
 # ===========================================
-JWT_SECRET=your-super-secret-jwt-key-change-in-production
-JWT_REFRESH_SECRET=your-super-secret-refresh-key-change-in-production
-JWT_EXPIRES_IN=15m
-JWT_REFRESH_EXPIRES_IN=7d
-
-# ===========================================
-# Notion OAuth
-# ===========================================
-NOTION_CLIENT_ID=your-notion-client-id
-NOTION_CLIENT_SECRET=your-notion-client-secret
-NOTION_REDIRECT_URI=http://localhost:3007/api/v1/notion/callback
+JWT_ACCESS_SECRET=             # generate: openssl rand -base64 48
+JWT_REFRESH_SECRET=            # generate: openssl rand -base64 48
+JWT_ACCESS_EXPIRY=15m
+JWT_REFRESH_EXPIRY=7d
 
 # ===========================================
 # Encryption
 # ===========================================
-ENCRYPTION_KEY=32-byte-hex-key-for-token-encryption
+ENCRYPTION_KEY=                # generate: openssl rand -hex 32
 
 # ===========================================
 # CORS
 # ===========================================
-CORS_ORIGIN=http://localhost:3000
-
-# ===========================================
-# Rate Limiting
-# ===========================================
-RATE_LIMIT_WINDOW_MS=60000
-RATE_LIMIT_MAX=100
+FRONTEND_URL=http://localhost:3000
+ALLOWED_ORIGINS=http://localhost:3000
 
 # ===========================================
 # Chunking Configuration
@@ -392,15 +420,14 @@ MAX_LIST_ITEMS=15
 # ===========================================
 # Sync Configuration
 # ===========================================
-BATCH_SIZE=30
 STALE_JOB_TIMEOUT_HOURS=2
 MAX_SYNC_RECOVERY_ATTEMPTS=2
+SYNC_PROGRESS_TIMEOUT_MINUTES=30
 
 # ===========================================
 # Quality Guardrails
 # ===========================================
-MIN_CONFIDENCE_THRESHOLD=0.4
-STRICT_HALLUCINATION_MODE=false
+GUARDRAIL_STRICT_HALLUCINATION_BLOCKING=true
 ENABLE_CODE_FILTER=true
 
 # ===========================================
@@ -408,7 +435,8 @@ ENABLE_CODE_FILTER=true
 # ===========================================
 LOG_RETRIEVAL_TRACE=false
 LANGSMITH_API_KEY=your-langsmith-key
-LANGSMITH_PROJECT=rag-platform
+LANGSMITH_PROJECT=retrieva
+LANGSMITH_ENABLED=true
 ```
 
 ## Configuration Validation

--- a/docs/docs/backend/services.md
+++ b/docs/docs/backend/services.md
@@ -293,7 +293,7 @@ export function tenantIsolationPlugin(schema) {
 
 ### Email Service (`services/emailService.js`)
 
-Sends transactional emails via the **Resend HTTP API**. In **microservice mode** (`EMAIL_SERVICE_URL` is set), this file proxies HTTP calls to the standalone `email-service` (port 3008). When the env var is unset, it calls the Resend HTTP API directly in-process.
+Sends transactional emails via the **Resend HTTP API** directly in-process. The env var `EMAIL_SERVICE_URL` exists as a future extension point that would delegate to a standalone service — it is **not set in production**; all email sending happens inside the backend process.
 
 ```javascript
 export const emailService = {
@@ -324,9 +324,7 @@ If `RESEND_API_KEY` is not set, the service logs a warning and skips sending. Th
 
 ### Notification Service (`services/notificationService.js`)
 
-Dual-channel delivery: **WebSocket** (real-time) + **email** (important events).
-
-In **microservice mode** (`NOTIFICATION_SERVICE_URL` is set), this file is a thin HTTP proxy to the standalone `notification-service` (port 3009) which owns the Notification MongoDB collection and Redis pub/sub publishing. When unset, in-process logic is used (no docker-compose required for local dev).
+Dual-channel delivery: **WebSocket** (real-time) + **email** (important events). Runs entirely in-process. The env var `NOTIFICATION_SERVICE_URL` exists as a future extension point — it is **not set in production**.
 
 ```javascript
 export const notificationService = {
@@ -351,21 +349,34 @@ User preferences are checked per notification type and channel (`inApp`, `email`
 
 ### Real-Time / Presence Service
 
-Socket.io real-time communication and user presence tracking. Like email and notifications, this follows the **strangler fig** pattern.
+Socket.io runs **embedded in the backend process** (port 3007). There is no separate realtime service deployed.
 
-**`services/socketService.js`** — When `REALTIME_SERVICE_URL` is set, the monolith publishes events to Redis channels instead of maintaining a Socket.io server. When unset, the full Socket.io server runs in-process (same as before the extraction).
+**`services/socketService.js`** — maintains the in-process Socket.io server and emits events directly to connected rooms.
 
-**`services/presenceService.js`** — When `REALTIME_SERVICE_URL` is set, all write operations are no-ops (the `realtime-service` owns presence state) and reads query Redis hashes directly. When unset, an in-memory Map is used.
+**`services/presenceService.js`** — tracks online users in an in-memory Map. The env var `REALTIME_SERVICE_URL` is a future extension point (would delegate to Redis pub/sub) but is **not set in production**.
 
-| Function | Remote mode | Local mode |
-|----------|-------------|------------|
-| `emitToUser()` | Publishes to `realtime:user:{userId}` Redis channel | Emits directly via Socket.io |
-| `emitToWorkspace()` | Publishes to `realtime:workspace:{id}` Redis channel | Emits to Socket.io room |
-| `isUserOnline()` | Reads `presence:user:{userId}` Redis HASH (async) | Checks in-memory Map (sync) |
-| `userConnected()` | no-op | Updates in-memory Map |
-| `getWorkspacePresence()` | Reads `presence:workspace:{id}:members` Redis HASH | Reads in-memory Map |
+| Function | Description |
+|----------|-------------|
+| `emitToUser(userId, event, data)` | Emit to a specific user's socket room |
+| `emitToWorkspace(workspaceId, event, data)` | Emit to all sockets in a workspace room |
+| `isUserOnline(userId)` | Check in-memory presence Map |
+| `userConnected(userId)` | Register user connection |
+| `getWorkspacePresence(workspaceId)` | List online members of a workspace |
 
-**Analytics socket events** (`analytics:subscribe`, `analytics:get`) are no-ops in the standalone `realtime-service` — the `liveAnalyticsService` remains in the monolith and is only available in local mode.
+### Billing Service (`services/stripeService.js`)
+
+Manages Stripe customer portal sessions and subscription state.
+
+| Function | Description |
+|----------|-------------|
+| `createBillingPortalSession(userId)` | Create a Stripe Customer Portal session URL for self-serve plan management |
+| `handleWebhookEvent(event)` | Process Stripe webhook events (subscription updated, payment failed, etc.) |
+
+**Configuration env vars:** `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`.
+
+The `POST /api/v1/billing/webhook` route uses raw body parsing (before JSON middleware) to preserve the Stripe webhook signature for verification.
+
+---
 
 ## Service Dependencies
 

--- a/docs/docs/backend/workers.md
+++ b/docs/docs/backend/workers.md
@@ -116,14 +116,25 @@ MONITORING_INTERVAL_HOURS=24   # How often the job runs (default: 24)
 
 ## Queue Configuration (`config/queue.js`)
 
+Six queues are defined. The first four have active workers; the last two use scheduled repeatable jobs:
+
 ```javascript
-export const assessmentQueue    = new Queue('assessmentJobs',    { ... });
-export const documentIndexQueue = new Queue('documentIndex',     { ... });
-export const questionnaireQueue = new Queue('questionnaireJobs', { ... });
-export const monitoringQueue    = new Queue('monitoringJobs',    { ... });
+export const assessmentQueue    = new Queue('assessmentJobs',    { ... }); // assessmentWorker
+export const documentIndexQueue = new Queue('documentIndex',     { ... }); // documentIndexWorker
+export const questionnaireQueue = new Queue('questionnaireJobs', { ... }); // questionnaireWorker
+export const monitoringQueue    = new Queue('monitoringJobs',    { ... }); // monitoringWorker (scheduled)
+export const dataSourceSyncQueue = new Queue('dataSourceSync',   { ... }); // enqueued by dataSourceController
+export const memoryDecayQueue   = new Queue('memoryDecay',       { ... }); // scheduled repeatable job
 ```
 
-All queues use exponential backoff and Redis for persistence. `scheduleMonitoringJob()` registers the 24-hour repeatable job on startup (mirrors `scheduleMemoryDecayJob()`).
+All queues use exponential backoff and Redis for persistence.
+
+- `scheduleMonitoringJob()` — registers the 24-hour compliance alert repeatable job on startup
+- `scheduleMemoryDecayJob()` — registers the 24-hour memory decay repeatable job on startup
+
+:::note
+`dataSourceSyncQueue` jobs are enqueued by `POST /api/v1/data-sources/:id/sync` but are processed inline by the same worker flow as document indexing. The queue provides retry and backoff resilience for multi-source ingestion (file, URL, Confluence).
+:::
 
 ## Dead Letter Queue
 

--- a/docs/docs/deployment/ci-cd.md
+++ b/docs/docs/deployment/ci-cd.md
@@ -15,13 +15,13 @@ Push/PR to main/dev/staging
 ┌─────────────────────────────────────────────────────────────────┐
 │                     CI Workflow (ci.yml)                         │
 │                                                                 │
-│  ┌──────────────┐  ┌──────────────┐  ┌───────────────────────┐ │
-│  │ Backend Tests │  │Frontend Tests│  │ RAGAS Service Tests   │ │
-│  │  (Node.js)   │  │  (Next.js)   │  │     (Python)          │ │
-│  │ + Lint        │  │ + Lint       │  │ + Lint                │ │
-│  │ + MongoDB     │  │ + Vitest     │  │ + Pytest              │ │
-│  │ + Redis       │  │              │  │                       │ │
-│  └──────────────┘  └──────────────┘  └───────────────────────┘ │
+│  ┌──────────────┐  ┌──────────────┐                             │
+│  │ Backend Tests │  │Frontend Tests│                             │
+│  │  (Node.js)   │  │  (Next.js)   │                             │
+│  │ + Lint        │  │ + Lint       │                             │
+│  │ + MongoDB     │  │ + Vitest     │                             │
+│  │ + Redis       │  │              │                             │
+│  └──────────────┘  └──────────────┘                             │
 │  ┌──────────────┐  ┌──────────────┐  ┌───────────────────────┐ │
 │  │   Security   │  │Secret Scanning│  │    SAST (Semgrep)    │ │
 │  │    Audit     │  │  (Gitleaks)  │  │  nodejs/js/owasp/     │ │
@@ -29,8 +29,8 @@ Push/PR to main/dev/staging
 │  └──────────────┘  └──────────────┘  └───────────────────────┘ │
 │  ┌─────────────────────────────────┐  ┌────────────────────────┐│
 │  │    Trivy Filesystem Scan         │  │  Docker Build Check   │ │
-│  │  backend / frontend / ragas     │  │  backend / frontend   │ │
-│  │  HIGH+CRITICAL, ignore-unfixed  │  │  ragas-service        │ │
+│  │  backend / frontend             │  │  backend / frontend   │ │
+│  │  HIGH+CRITICAL, ignore-unfixed  │  │                       │ │
 │  └─────────────────────────────────┘  └────────────────────────┘│
 │                           │                                     │
 │                    CI Success Gate                               │
@@ -66,11 +66,10 @@ Push/PR to main/dev/staging
 | `backend-test` | Lint + run Vitest tests | MongoDB 7.0, Redis 7 |
 | `frontend-test` | Lint + run Vitest tests | None |
 | `backend-security` | `npm audit --audit-level=high --omit=dev` — fails on HIGH/CRITICAL production CVEs | None |
-| `ragas-test` | Flake8 lint + Pytest | None |
 | `secret-scan` | [Gitleaks](https://github.com/gitleaks/gitleaks) scans full git history for committed secrets | None |
 | `sast` | [Semgrep](https://semgrep.dev) static analysis with `p/nodejs`, `p/javascript`, `p/secrets`, `p/owasp-top-ten` rulesets | None |
-| `trivy-scan` | [Trivy](https://trivy.dev) filesystem scan for HIGH/CRITICAL CVEs with fixes available (3-way matrix: backend, frontend, ragas-service) | None |
-| `docker-build` | Build Docker images (no push) for backend, frontend, ragas-service | None |
+| `trivy-scan` | [Trivy](https://trivy.dev) filesystem scan for HIGH/CRITICAL CVEs with fixes available (2-way matrix: backend, frontend) | None |
+| `docker-build` | Build Docker images (no push) for backend and frontend | None |
 | `ci-success` | Gate job — fails if any of the above jobs failed | None |
 
 ### Security Scan Configuration
@@ -116,7 +115,7 @@ env:
 ### Steps
 
 1. **Run CI** — calls the CI workflow as a reusable workflow
-2. **Build & Push** — builds Docker images for `backend`, `frontend`, and `ragas-service`, then pushes to GHCR
+2. **Build & Push** — builds Docker images for `backend` and `frontend`, then pushes to GHCR
 3. **Deploy via SSH** — connects to the production droplet and runs the deployment script:
    - Pull latest code and decrypt secrets (SOPS)
    - Tag current `:latest` images as `:rollback` (pre-deploy safety net)
@@ -132,7 +131,6 @@ Images are pushed to GitHub Container Registry (GHCR):
 ```
 ghcr.io/andreliar/retrieva/backend
 ghcr.io/andreliar/retrieva/frontend
-ghcr.io/andreliar/retrieva/ragas-service
 ```
 
 **Tagging strategy:**
@@ -161,9 +159,8 @@ Production secrets are encrypted at rest using **SOPS** with **age** encryption.
 
 | File | Contents |
 |------|----------|
-| `backend/.env.production.enc` | Main backend secrets (DB URIs, API keys, JWT secrets, etc.) |
+| `backend/.env.production.enc` | Main backend secrets (DB URIs, API keys, JWT secrets, Stripe keys, etc.) |
 | `backend/.env.resend.production.enc` | Email service secrets (`RESEND_API_KEY`, `RESEND_FROM_EMAIL`) |
-| `ragas-service/.env.production.enc` | RAGAS service secrets |
 
 ### Decryption During Deployment
 
@@ -210,19 +207,19 @@ Never commit plaintext `.env` files. Only `.enc` (encrypted) files belong in the
                    │  Nginx  │  (TLS termination, reverse proxy)
                    └────┬────┘
                         │
-          ┌─────────────┼─────────────┐
-          │             │             │
-     ┌────▼────┐  ┌─────▼────┐  ┌────▼────────┐
-     │Frontend │  │ Backend  │  │RAGAS Service │
-     │ :3000   │  │  :3007   │  │   :8001      │
-     └─────────┘  └────┬─────┘  └──────────────┘
-                       │
-          ┌────────────┼────────────┐
-          │            │            │
-     ┌────▼────┐ ┌─────▼───┐ ┌─────▼───┐
-     │MongoDB  │ │  Redis  │ │ Qdrant  │
-     │ :27017  │ │  :6379  │ │  :6333  │
-     └─────────┘ └─────────┘ └─────────┘
+               ┌────────┴────────┐
+               │                 │
+          ┌────▼────┐      ┌─────▼────┐
+          │Frontend │      │ Backend  │
+          │ :3000   │      │  :3007   │
+          └─────────┘      └────┬─────┘
+                                │
+               ┌────────────────┼────────────┐
+               │                │            │
+          ┌────▼────┐    ┌──────▼──┐  ┌──────▼──┐
+          │MongoDB  │    │  Redis  │  │ Qdrant  │
+          │ Atlas   │    │  :6379  │  │  :6333  │
+          └─────────┘    └─────────┘  └─────────┘
 ```
 
 All services run on a single **DigitalOcean droplet** via `docker-compose.production.yml`.
@@ -265,9 +262,8 @@ The backend `/health` endpoint returns service status including database connect
 Before pulling new images, the CD pipeline tags the current `:latest` images as `:rollback`:
 
 ```bash
-docker tag ghcr.io/andreliar/retrieva/backend:latest   ghcr.io/andreliar/retrieva/backend:rollback
-docker tag ghcr.io/andreliar/retrieva/frontend:latest   ghcr.io/andreliar/retrieva/frontend:rollback
-docker tag ghcr.io/andreliar/retrieva/ragas-service:latest ghcr.io/andreliar/retrieva/ragas-service:rollback
+docker tag ghcr.io/andreliar/retrieva/backend:latest  ghcr.io/andreliar/retrieva/backend:rollback
+docker tag ghcr.io/andreliar/retrieva/frontend:latest ghcr.io/andreliar/retrieva/frontend:rollback
 ```
 
 If health checks fail after deployment, the pipeline automatically:
@@ -286,7 +282,7 @@ ssh deploy@<DEPLOY_HOST>
 cd /opt/rag
 
 # Option 1: Use rollback images (if still available)
-for svc in backend frontend ragas-service; do
+for svc in backend frontend; do
   docker tag "ghcr.io/andreliar/retrieva/${svc}:rollback" "ghcr.io/andreliar/retrieva/${svc}:latest"
 done
 docker compose -f docker-compose.production.yml up -d --remove-orphans

--- a/docs/docs/deployment/docker.md
+++ b/docs/docs/deployment/docker.md
@@ -15,22 +15,14 @@ Container-based deployment using Docker and Docker Compose.
 │                      Docker Compose Stack (Development)                        │
 ├──────────────────────────────────────────────────────────────────────────────┤
 │                                                                                │
-│  ┌─────────────┐  ┌─────────────┐  ┌──────────────┐  ┌──────────────┐       │
-│  │   Backend   │  │   Frontend  │  │ RAGAS Service│  │ MinIO (S3)   │       │
-│  │  Port: 3007 │  │  Port: 3000 │  │  Port: 8001  │  │  Port: 9000  │       │
-│  └──────┬──────┘  └─────────────┘  └──────────────┘  └──────────────┘       │
+│  ┌─────────────┐  ┌─────────────┐                                             │
+│  │   Backend   │  │   Frontend  │                                             │
+│  │  Port: 3007 │  │  Port: 3000 │                                             │
+│  └──────┬──────┘  └─────────────┘                                             │
 │         │                                                                      │
 │  ┌──────┴──────────────────────────────────────────────────────────┐          │
-│  │                        Microservices                             │          │
-│  │  ┌──────────────┐  ┌──────────────────┐  ┌──────────────────┐  │          │
-│  │  │ email-service│  │notification-svc  │  │  realtime-svc    │  │          │
-│  │  │  Port: 3008  │  │   Port: 3009     │  │   Port: 3010     │  │          │
-│  │  └──────────────┘  └──────────────────┘  └──────────────────┘  │          │
-│  └─────────────────────────────────────────────────────────────────┘          │
-│                                                                                │
-│  ┌────────────────────────────────────────────────────────────────┐           │
-│  │                         rag-network                             │           │
-│  └──────────────┬──────────────────────────────────────┬──────────┘           │
+│  │                         rag-network                              │          │
+│  └──────────────┬──────────────────────────────────────┬───────────┘          │
 │                 │                                        │                     │
 │  ┌──────────────┴──┐  ┌────────────┐          ┌────────┴────┐                │
 │  │    MongoDB      │  │   Redis    │          │   Qdrant    │                │
@@ -47,11 +39,11 @@ Container-based deployment using Docker and Docker Compose.
 │                    Docker Compose Stack (Production)                      │
 ├─────────────────────────────────────────────────────────────────────────┤
 │                                                                          │
-│   ┌──────────────┐     ┌──────────────┐     ┌──────────────┐           │
-│   │   Frontend   │     │   Backend    │     │ RAGAS Service│           │
-│   │  (Next.js)   │     │  (Node.js)   │     │   (Python)   │           │
-│   │  Port: 3000  │     │  Port: 3007  │     │  Port: 8001  │           │
-│   └──────────────┘     └──────┬───────┘     └──────────────┘           │
+│   ┌──────────────┐     ┌──────────────┐                                 │
+│   │   Frontend   │     │   Backend    │                                 │
+│   │  (Next.js)   │     │  (Node.js)   │                                 │
+│   │  Port: 3000  │     │  Port: 3007  │                                 │
+│   └──────────────┘     └──────┬───────┘                                 │
 │                               │                                          │
 │                  ┌────────────┼────────────┐                             │
 │                  │            │            │                             │
@@ -102,7 +94,6 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - QDRANT_URL=http://qdrant:6333
-      - RAGAS_SERVICE_URL=http://ragas-service:8001
       # Azure OpenAI — set via .env file (not hardcoded here)
       # LLM_PROVIDER=azure_openai, AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, etc.
     depends_on:
@@ -115,18 +106,6 @@ services:
     volumes:
       - ./backend:/app
       - /app/node_modules
-    networks:
-      - rag-network
-    restart: unless-stopped
-
-  # RAGAS Evaluation Service (Python)
-  ragas-service:
-    build:
-      context: ./ragas-service
-      dockerfile: Dockerfile
-    container_name: rag-ragas
-    ports:
-      - "8001:8001"
     networks:
       - rag-network
     restart: unless-stopped
@@ -302,36 +281,18 @@ docker-compose build backend
 docker-compose build --no-cache backend
 ```
 
-## Microservices
+## Monolith Architecture Note
 
-Phase 1–2 extractions add three lightweight services alongside the monolith. Each uses the same `strangler fig` pattern — the monolith automatically falls back to its built-in in-process logic when the corresponding `*_SERVICE_URL` env var is **not** set.
+The backend is a **single Node.js process** (port 3007). Email, notifications, and real-time communication are all handled in-process:
 
-| Service | Port | Env var | Fallback |
-|---------|------|---------|---------|
-| `email-service` | 3008 | `EMAIL_SERVICE_URL` | In-process Resend HTTP calls |
-| `notification-service` | 3009 | `NOTIFICATION_SERVICE_URL` | In-process DB + socket delivery |
-| `realtime-service` | 3010 | `REALTIME_SERVICE_URL` | In-process Socket.io server |
+| Capability | How it runs |
+|------------|------------|
+| Email | `services/emailService.js` calls Resend HTTP API directly |
+| Notifications | `services/notificationService.js` uses MongoDB + Socket.io |
+| Real-time / Presence | Socket.io server embedded in the backend Express process |
+| Background jobs | 4 BullMQ workers running in the same process (`assessmentWorker`, `documentIndexWorker`, `questionnaireWorker`, `monitoringWorker`) |
 
-### Redis pub/sub channels (realtime-service)
-
-When `REALTIME_SERVICE_URL` is set, the monolith publishes socket events to Redis instead of emitting directly. The realtime-service subscribes and forwards them to connected clients.
-
-| Channel | Direction | Purpose |
-|---------|-----------|---------|
-| `realtime:user:{userId}` | monolith → realtime-svc | Emit to a specific user |
-| `realtime:workspace:{workspaceId}` | monolith → realtime-svc | Emit to a workspace room |
-| `realtime:query:{queryId}` | monolith → realtime-svc | Emit to a query room |
-| `realtime:broadcast` | monolith → realtime-svc | Broadcast to all connected sockets |
-
-### Redis presence keys (realtime-service → monolith reads)
-
-The realtime-service writes presence state to Redis hashes; the monolith presenceService reads them for query decisions (e.g. whether to email a notification).
-
-| Key | Type | Fields |
-|-----|------|--------|
-| `presence:user:{userId}` | HASH | `status`, `lastSeen`, `name`, `email`, `connections` — expires 600 s |
-| `presence:workspace:{workspaceId}:members` | HASH | `{userId}` → JSON presence data |
-| `presence:typing:{workspaceId}:{conversationId}` | HASH | `{userId}` → JSON typing data — expires 30 s |
+The codebase includes conditional env vars (`EMAIL_SERVICE_URL`, `NOTIFICATION_SERVICE_URL`, `REALTIME_SERVICE_URL`) that would delegate these concerns to separate services — these are **not deployed** but act as future extension points. Leave them unset in both development and production.
 
 ## Health Checks
 
@@ -351,14 +312,6 @@ docker exec rag-redis redis-cli ping
 
 ```bash
 curl http://localhost:3007/health
-```
-
-### Microservices
-
-```bash
-curl http://localhost:3008/health   # email-service
-curl http://localhost:3009/health   # notification-service
-curl http://localhost:3010/health   # realtime-service
 ```
 
 ### Qdrant
@@ -509,7 +462,6 @@ In production, all five services have compose-level healthchecks in `docker-comp
 |---------|---------|----------|---------|---------|--------------|
 | Backend | `wget --spider http://localhost:3007/health` | 10s | 5s | 5 | 30s |
 | Frontend | `wget --spider http://127.0.0.1:3000` | 10s | 5s | 3 | 20s |
-| RAGAS | `curl -f http://localhost:8001/health` | 10s | 5s | 3 | 20s |
 | Redis | `redis-cli -a $REDIS_PASSWORD ping` | 10s | 5s | 5 | — |
 | Qdrant | `bash -c ':>/dev/tcp/0.0.0.0/6333'` | 10s | 5s | 5 | 30s |
 

--- a/docs/docs/deployment/environment-variables.md
+++ b/docs/docs/deployment/environment-variables.md
@@ -213,22 +213,20 @@ Files are stored under `organizations/{orgId}/workspaces/{wsId}/...` enforcing o
 The email service uses the **Resend HTTP API** over HTTPS (port 443). No SMTP ports (25, 465, 587) are needed — this is important because DigitalOcean blocks outbound SMTP traffic.
 :::
 
-### Microservice URLs
+### Optional Microservice Extension Points
 
-These variables enable the standalone microservice mode. When **unset**, the monolith falls back to its built-in in-process implementation so local dev works without Docker.
+The following env vars are **not set in production** and are not required for development. They exist as future extension points — when set, each corresponding service is delegated to a standalone process instead of running in-process in the backend.
 
-| Variable | Dev value | Description |
-|----------|-----------|-------------|
-| `EMAIL_SERVICE_URL` | `http://localhost:3008` | Email microservice (port 3008). Leave unset to use in-process Resend sending. |
-| `NOTIFICATION_SERVICE_URL` | `http://localhost:3009` | Notification microservice (port 3009). Leave unset to use in-process notification logic. |
-| `REALTIME_SERVICE_URL` | `http://localhost:3010` | Realtime/presence microservice (port 3010). When set, Socket.io is delegated to this service and the monolith publishes events via Redis pub/sub. Clients should set `NEXT_PUBLIC_WS_URL` to this URL. |
-| `INTERNAL_API_KEY` | - | Shared secret sent as `X-Internal-Api-Key` header on service-to-service calls. Optional; leave blank in local dev. |
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EMAIL_SERVICE_URL` | unset | When set, email is proxied to a standalone email service instead of calling Resend directly in-process. |
+| `NOTIFICATION_SERVICE_URL` | unset | When set, notifications are proxied to a standalone notification service instead of in-process delivery. |
+| `REALTIME_SERVICE_URL` | unset | When set, Socket.io events are published via Redis pub/sub to a standalone realtime service. |
+| `INTERNAL_API_KEY` | unset | Shared secret for `X-Internal-Api-Key` headers on service-to-service calls (only relevant if any `*_SERVICE_URL` is set). |
 | `INTERNAL_REQUEST_TIMEOUT_MS` | `10000` | Timeout (ms) for internal HTTP calls between services. |
-| `SERVICE_NAME` | `monolith` | Identifies this service in `X-Service-Name` headers on internal calls. |
+| `SERVICE_NAME` | `monolith` | Identifies this service in `X-Service-Name` request headers. |
 
-:::tip
-In docker-compose development all three microservice URLs are automatically set to their container names (e.g. `http://notification-service:3009`). See [Docker Deployment](./docker) for the full compose setup.
-:::
+**Leave all of these unset** in development and production — the backend handles email, notifications, and real-time fully in-process.
 
 ### Logging
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -89,7 +89,7 @@ A BullMQ repeatable job runs every 24 hours and sends email alerts to workspace 
 | Real-Time | Socket.io |
 | Frontend | Next.js 16, React 19, TypeScript |
 | UI Components | shadcn/ui, Tailwind CSS |
-| Monitoring | LangSmith, RAGAS |
+| Monitoring | LangSmith |
 | Export | xlsx (XLSX workbook generation) |
 
 ## Architecture Overview


### PR DESCRIPTION
## Summary

- Remove all references to the non-existent `ragas-service` (Python) from CI/CD diagrams, job definitions, Docker image builds, rollback scripts, and SOPS secrets table
- Remove `MinIO` and the three microservice boxes (email:3008, notification:3009, realtime:3010) from Docker Compose diagrams — these do not run in either dev or production
- Rewrite the `docker.md` microservices section: email, notifications, and real-time all run **in-process** in the backend; the `*_SERVICE_URL` env vars are undeployed future extension points
- Clarify `environment-variables.md` microservice URLs section with the same framing
- Add missing `dataSourceSyncQueue` and `memoryDecayQueue` to the workers queue reference
- Add missing `stripeService.js` to the services reference
- Update `configuration.md` embeddings section: document the real `BatchedEmbeddings` class, batch config, truncation/retry strategy, and metrics API
- Remove `RAGAS` from the tech stack monitoring row in `intro.md`

## Test plan

- [x] `npm --prefix backend run lint` — 0 errors
- [x] `npm --prefix frontend run lint` — 0 errors
- [x] `npm --prefix backend test` — 1131 tests passed
- [x] Frontend tests — 393 tests passed
- [x] `cd docs && npm run build` — Docusaurus build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)