### PR TITLE
feat(frontend): add quantified residual risk matrix for dora art. 28

### DIFF
--- a/frontend/src/app/(dashboard)/assessments/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/assessments/[id]/page.tsx
@@ -27,11 +27,13 @@ import { Separator } from '@/components/ui/separator';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { AssessmentProgressStepper } from '@/components/assessment/AssessmentProgressStepper';
 import { GapAnalysisTable } from '@/components/assessment/GapAnalysisTable';
-import { InherentResidualPanel, WeightedDomainChart, FormalRiskDecision } from '@/components/assessment/RiskScoringPanel';
+import { ResidualRiskMatrix, WeightedDomainChart, FormalRiskDecision } from '@/components/assessment/RiskScoringPanel';
 import { Art30ClauseScorecardWithSignoff, NegotiationRoundBadge } from '@/components/assessment/ClauseSignoffPanel';
 import { assessmentsApi } from '@/lib/api/assessments';
 import { workspacesApi } from '@/lib/api/workspaces';
+import { questionnairesApi } from '@/lib/api/questionnaires';
 import type { Assessment, OverallRisk } from '@/lib/api/assessments';
+import type { VendorQuestionnaire } from '@/lib/api/questionnaires';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -233,6 +235,19 @@ export default function AssessmentDetailPage() {
     enabled: !!assessment?.workspaceId && assessment?.framework === 'CONTRACT_A30',
   });
 
+  // Latest completed questionnaire score for residual risk matrix (DORA only)
+  const { data: wsQuestionnaires } = useQuery({
+    queryKey: ['questionnaires', assessment?.workspaceId, 'risk'],
+    queryFn: async () => {
+      const res = await questionnairesApi.list({ workspaceId: assessment!.workspaceId });
+      return (res.data?.questionnaires ?? []) as VendorQuestionnaire[];
+    },
+    enabled: !!assessment?.workspaceId && assessment?.framework === 'DORA',
+  });
+  const latestCompletedQ = wsQuestionnaires
+    ?.filter((q) => q.status === 'complete')
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];
+
   const prevStatus = assessment?.status;
   useEffect(() => {
     if (prevStatus === 'complete') {
@@ -432,10 +447,14 @@ export default function AssessmentDetailPage() {
             ))}
           </div>
 
-          {/* ── DORA-specific panels (Step 3 fixes) ── */}
+          {/* ── DORA-specific panels ── */}
           {!isA30 && (
             <>
-              <InherentResidualPanel assessment={assessment} workspace={workspace ?? null} />
+              <ResidualRiskMatrix
+                assessment={assessment}
+                workspace={workspace ?? null}
+                qScore={latestCompletedQ?.overallScore ?? null}
+              />
               <WeightedDomainChart assessment={assessment} />
             </>
           )}

--- a/frontend/src/app/(dashboard)/risk-register/page.tsx
+++ b/frontend/src/app/(dashboard)/risk-register/page.tsx
@@ -39,6 +39,8 @@ import { useWorkspaceStore } from '@/lib/stores/workspace-store';
 import { assessmentsApi } from '@/lib/api/assessments';
 import { questionnairesApi } from '@/lib/api/questionnaires';
 import { workspacesApi } from '@/lib/api/workspaces';
+import { buildRiskMatrix } from '@/lib/risk-scoring';
+import type { RiskMatrixResult } from '@/lib/risk-scoring';
 import type { Assessment, OverallRisk } from '@/lib/api/assessments';
 import type { VendorQuestionnaire } from '@/lib/api/questionnaires';
 import type { WorkspaceWithMembership } from '@/types';
@@ -85,6 +87,21 @@ function CertChip({ days }: { days: number | null }) {
   return <span className="text-xs font-medium text-green-600">{days}d</span>;
 }
 
+function RiskScoreChip({ m }: { m: RiskMatrixResult }) {
+  if (!m.hasData && m.inherentScore <= 25)
+    return <span className="text-muted-foreground text-xs">—</span>;
+  const color = m.residualRisk === 'High'
+    ? 'text-destructive'
+    : m.residualRisk === 'Medium'
+    ? 'text-amber-600'
+    : 'text-green-600';
+  return (
+    <span className={`text-xs font-bold tabular-nums ${color}`}>
+      {m.residualScore}<span className="text-muted-foreground font-normal">/100</span>
+    </span>
+  );
+}
+
 // ── Risk register row data builder ────────────────────────────────────────────
 
 interface RegisterRow {
@@ -96,6 +113,7 @@ interface RegisterRow {
   nearestCertDays:   number | null;
   contractDays:      number | null;
   reviewDays:        number | null;
+  riskMatrix:        RiskMatrixResult;
 }
 
 function buildRow(
@@ -131,6 +149,13 @@ function buildRow(
     .filter((d): d is number => d !== null);
   const nearestCertDays = certDays.length > 0 ? Math.min(...certDays) : null;
 
+  const riskMatrix = buildRiskMatrix(
+    workspace.vendorTier,
+    workspace.vendorFunctions,
+    latestDora?.results?.gaps ?? null,
+    latestQ?.status === 'complete' ? (latestQ.overallScore ?? null) : null,
+  );
+
   return {
     workspace,
     latestDora,
@@ -140,6 +165,7 @@ function buildRow(
     nearestCertDays,
     contractDays: daysFrom(workspace.contractEnd),
     reviewDays:   daysFrom(workspace.nextReviewDate),
+    riskMatrix,
   };
 }
 
@@ -248,6 +274,7 @@ export default function RiskRegisterPage() {
                 <TableHead>Tier</TableHead>
                 <TableHead>Service</TableHead>
                 <TableHead>DORA Risk</TableHead>
+                <TableHead>Risk Score</TableHead>
                 <TableHead>Gaps</TableHead>
                 <TableHead>Q Score</TableHead>
                 <TableHead>Contract</TableHead>
@@ -258,7 +285,7 @@ export default function RiskRegisterPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {rows.map(({ workspace, latestDora, latestA30, latestQ, stepsComplete, nearestCertDays, reviewDays }) => {
+              {rows.map(({ workspace, latestDora, latestA30, latestQ, stepsComplete, nearestCertDays, reviewDays, riskMatrix }) => {
                 const missing = latestDora?.results?.gaps.filter((g) => g.gapLevel === 'missing').length ?? null;
                 const partial = latestDora?.results?.gaps.filter((g) => g.gapLevel === 'partial').length ?? null;
                 const qScore  = latestQ?.status === 'complete' ? (latestQ.overallScore ?? null) : null;
@@ -285,6 +312,9 @@ export default function RiskRegisterPage() {
                     </TableCell>
                     <TableCell>
                       <RiskBadge risk={latestDora?.results?.overallRisk} />
+                    </TableCell>
+                    <TableCell>
+                      <RiskScoreChip m={riskMatrix} />
                     </TableCell>
                     <TableCell>
                       {latestDora ? (

--- a/frontend/src/components/assessment/RiskScoringPanel.tsx
+++ b/frontend/src/components/assessment/RiskScoringPanel.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 /**
- * RiskScoringPanel — Step 3 gap fixes
+ * RiskScoringPanel — DORA Art. 28(3) Quantified Risk Matrix
  *
- * Adds to DORA gap analysis reports:
- *  1. Inherent vs Residual risk panel
- *  2. Weighted DORA domain breakdown
- *  3. Formal risk decision (proceed / conditional / reject)
+ * Exports:
+ *  1. ResidualRiskMatrix   — Numeric inherent × residual scoring with heat map
+ *  2. WeightedDomainChart  — Weighted DORA domain breakdown bars
+ *  3. FormalRiskDecision   — Compliance decision (proceed / conditional / reject)
  */
 
 import { useState } from 'react';
@@ -17,10 +17,7 @@ import {
   CheckCircle2,
   AlertTriangle,
   XCircle,
-  ArrowRight,
   ShieldCheck,
-  TrendingDown,
-  Minus,
 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -30,35 +27,14 @@ import { Textarea } from '@/components/ui/textarea';
 import { assessmentsApi } from '@/lib/api/assessments';
 import type { Assessment, OverallRisk, RiskDecision, RiskDecisionValue } from '@/lib/api/assessments';
 import type { WorkspaceWithMembership } from '@/types';
+import {
+  DOMAIN_WEIGHTS,
+  FUNCTION_WEIGHT,
+  TIER_BASE,
+  buildRiskMatrix,
+} from '@/lib/risk-scoring';
 
-// ── Domain weights (DORA Art. 28–30) ──────────────────────────────────────────
-
-const DOMAIN_WEIGHTS: Record<string, number> = {
-  'ICT Governance':      0.20,
-  'Security Controls':   0.25,
-  'Incident Management': 0.20,
-  'Business Continuity': 0.15,
-  'Audit Rights':        0.05,
-  'Subcontracting':      0.05,
-  'Data Governance':     0.05,
-  'Exit Planning':       0.03,
-  'Regulatory History':  0.02,
-};
-
-// ── Inherent risk matrix ───────────────────────────────────────────────────────
-
-function computeInherentRisk(
-  vendorTier: string | null | undefined,
-  serviceType: string | null | undefined
-): OverallRisk {
-  const tier    = vendorTier  ?? 'standard';
-  const service = serviceType ?? 'other';
-
-  if (tier === 'critical') return 'High';
-  if (tier === 'important' && (service === 'cloud' || service === 'data' || service === 'network')) return 'High';
-  if (tier === 'important') return 'Medium';
-  return 'Low';
-}
+// ── Shared colour maps ─────────────────────────────────────────────────────────
 
 const RISK_COLOR: Record<OverallRisk, string> = {
   High:   'text-destructive',
@@ -72,67 +48,193 @@ const RISK_BG: Record<OverallRisk, string> = {
   Low:    'bg-green-50 border-green-200 dark:bg-green-950/20 dark:border-green-800',
 };
 
-// ── 1. Inherent vs Residual panel ─────────────────────────────────────────────
+// ── 1. Residual Risk Matrix ────────────────────────────────────────────────────
 
-export function InherentResidualPanel({
+export function ResidualRiskMatrix({
   assessment,
   workspace,
+  qScore = null,
 }: {
   assessment: Assessment;
   workspace: WorkspaceWithMembership | null;
+  qScore?: number | null;
 }) {
-  const residualRisk   = assessment.results?.overallRisk;
-  const inherentRisk   = computeInherentRisk(workspace?.vendorTier, workspace?.serviceType);
-  if (!residualRisk) return null;
+  const gaps = assessment.results?.gaps ?? null;
+  const m = buildRiskMatrix(
+    workspace?.vendorTier,
+    workspace?.vendorFunctions,
+    gaps,
+    qScore,
+  );
 
-  const riskOrder: Record<OverallRisk, number> = { Low: 0, Medium: 1, High: 2 };
-  const reduced = riskOrder[residualRisk] < riskOrder[inherentRisk];
-  const same    = residualRisk === inherentRisk;
+  // Effective DORA risk label from assessment (overrides computed when present)
+  const doraRisk = assessment.results?.overallRisk ?? m.residualRisk;
 
-  const ArrowIcon = reduced ? TrendingDown : same ? Minus : ArrowRight;
-  const arrowColor = reduced ? 'text-green-500' : same ? 'text-muted-foreground' : 'text-destructive';
+  // ── Heat-map grid (3×3) ──────────────────────────────────────────────────────
+  // Rows: inherent risk level  Col: control effectiveness bracket
+  const HEAT: OverallRisk[][] = [
+    //  ctrlLow      ctrlMed      ctrlHigh
+    ['High',   'High',   'Medium'],  // inherentHigh
+    ['Medium', 'Medium', 'Low'],     // inherentMedium
+    ['Low',    'Low',    'Low'],     // inherentLow
+  ];
+
+  const inherentRow = m.inherentRisk === 'High' ? 0 : m.inherentRisk === 'Medium' ? 1 : 2;
+  const ctrlCol     = m.controlEffectiveness < 33 ? 0 : m.controlEffectiveness <= 66 ? 1 : 2;
+
+  const activeFns = (workspace?.vendorFunctions ?? []);
+  const fnSum     = activeFns.reduce((s, fn) => s + (FUNCTION_WEIGHT[fn] ?? 0), 0);
+
+  const ctrlLabel =
+    m.controlEffectiveness >= 67 ? 'High (>66%)' :
+    m.controlEffectiveness >= 33 ? 'Medium (33–66%)' :
+    'Low (<33%)';
 
   return (
     <Card>
       <CardHeader className="pb-2">
         <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wide flex items-center gap-2">
           <ShieldCheck className="h-4 w-4" />
-          Risk Scoring
+          Residual Risk Matrix
+          <span className="ml-auto text-xs font-normal normal-case">DORA Art. 28(3)</span>
         </CardTitle>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-4">
+
+        {/* ── Top: three score tiles ── */}
         <div className="grid grid-cols-3 items-center gap-3">
-          {/* Inherent risk */}
-          <div className={`rounded-lg border p-3 text-center ${RISK_BG[inherentRisk]}`}>
-            <p className="text-xs text-muted-foreground mb-1">Inherent risk</p>
-            <p className={`text-lg font-bold ${RISK_COLOR[inherentRisk]}`}>{inherentRisk}</p>
-            <p className="text-xs text-muted-foreground mt-1">
-              {workspace?.vendorTier ?? 'unclassified'} · {workspace?.serviceType ?? 'unknown'}
+          {/* Inherent */}
+          <div className={`rounded-lg border p-3 text-center ${RISK_BG[m.inherentRisk]}`}>
+            <p className="text-xs text-muted-foreground mb-1">Inherent</p>
+            <p className={`text-2xl font-bold tabular-nums ${RISK_COLOR[m.inherentRisk]}`}>
+              {m.inherentScore}
+              <span className="text-sm font-normal text-muted-foreground">/100</span>
             </p>
+            <p className={`text-xs font-semibold mt-0.5 ${RISK_COLOR[m.inherentRisk]}`}>{m.inherentRisk}</p>
           </div>
-          {/* Arrow */}
-          <div className="flex flex-col items-center gap-1">
-            <ArrowIcon className={`h-6 w-6 ${arrowColor}`} />
-            <span className="text-xs text-muted-foreground">
-              {reduced ? 'reduced by controls' : same ? 'unchanged' : 'elevated by gaps'}
+
+          {/* Operator */}
+          <div className="flex flex-col items-center gap-1 text-muted-foreground">
+            <span className="text-lg">×</span>
+            <span className="text-xs text-center leading-tight">
+              {Math.round(m.residualFactor * 100)}%<br />remaining
             </span>
           </div>
-          {/* Residual risk */}
-          <div className={`rounded-lg border p-3 text-center ${RISK_BG[residualRisk]}`}>
-            <p className="text-xs text-muted-foreground mb-1">Residual risk</p>
-            <p className={`text-lg font-bold ${RISK_COLOR[residualRisk]}`}>{residualRisk}</p>
-            <p className="text-xs text-muted-foreground mt-1">after vendor controls</p>
+
+          {/* Residual */}
+          <div className={`rounded-lg border p-3 text-center ${RISK_BG[doraRisk]}`}>
+            <p className="text-xs text-muted-foreground mb-1">Residual</p>
+            <p className={`text-2xl font-bold tabular-nums ${RISK_COLOR[doraRisk]}`}>
+              {m.residualScore}
+              <span className="text-sm font-normal text-muted-foreground">/100</span>
+            </p>
+            <p className={`text-xs font-semibold mt-0.5 ${RISK_COLOR[doraRisk]}`}>{doraRisk}</p>
           </div>
         </div>
-        <p className="text-xs text-muted-foreground mt-3">
-          Inherent risk is derived from vendor classification ({workspace?.vendorTier ?? '—'}) and
-          service type ({workspace?.serviceType ?? '—'}) before any controls are applied. Residual
-          risk is the AI-assessed remaining risk after evaluating vendor documentation.
+
+        {/* ── Input breakdown ── */}
+        <div className="rounded-md bg-muted/40 border px-3 py-2.5 text-xs space-y-1.5">
+          <p className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">Input Breakdown</p>
+
+          {/* Tier row */}
+          <div className="flex justify-between">
+            <span>Tier ({workspace?.vendorTier ?? 'standard'})</span>
+            <span className="font-mono text-muted-foreground">base {TIER_BASE[workspace?.vendorTier ?? 'standard']}/100</span>
+          </div>
+
+          {/* Functions */}
+          {activeFns.length > 0 && (
+            <div className="flex justify-between">
+              <span>{activeFns.length} ICT function{activeFns.length !== 1 ? 's' : ''}</span>
+              <span className="font-mono text-muted-foreground">+{fnSum}</span>
+            </div>
+          )}
+
+          <div className="border-t pt-1 flex justify-between font-medium">
+            <span>Inherent score</span>
+            <span className={`font-mono ${RISK_COLOR[m.inherentRisk]}`}>{m.inherentScore}/100</span>
+          </div>
+
+          {/* Domain coverage */}
+          {m.domainCoverage !== null && (
+            <div className="flex justify-between">
+              <span>DORA gap coverage</span>
+              <span className="font-mono text-muted-foreground">{m.domainCoverage}%</span>
+            </div>
+          )}
+
+          {/* Q score */}
+          {m.qScore !== null && (
+            <div className="flex justify-between">
+              <span>Questionnaire score</span>
+              <span className="font-mono text-muted-foreground">{m.qScore}/100</span>
+            </div>
+          )}
+
+          <div className="border-t pt-1 flex justify-between font-medium">
+            <span>Control effectiveness</span>
+            <span className={`font-mono ${m.controlEffectiveness >= 67 ? 'text-green-600' : m.controlEffectiveness >= 33 ? 'text-amber-600' : 'text-destructive'}`}>
+              {m.controlEffectiveness}% · {ctrlLabel}
+            </span>
+          </div>
+
+          {!m.hasData && (
+            <p className="text-muted-foreground italic">
+              No questionnaire or DORA data yet — control effectiveness defaults to 0%.
+            </p>
+          )}
+        </div>
+
+        {/* ── 3×3 Heat map ── */}
+        <div>
+          <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1.5">Risk Matrix</p>
+          <div className="grid grid-cols-4 gap-1 text-[10px] text-center">
+            {/* Header row */}
+            <div />
+            {(['Low controls', 'Med controls', 'High controls'] as const).map((h) => (
+              <div key={h} className="text-muted-foreground font-medium py-0.5">{h}</div>
+            ))}
+            {/* Data rows */}
+            {(['High', 'Medium', 'Low'] as const).map((inhRisk, rIdx) => (
+              <>
+                <div key={`lbl-${inhRisk}`} className="text-muted-foreground font-medium flex items-center justify-end pr-1">{inhRisk}</div>
+                {[0, 1, 2].map((cIdx) => {
+                  const cell = HEAT[rIdx][cIdx];
+                  const isActive = rIdx === inherentRow && cIdx === ctrlCol;
+                  return (
+                    <div
+                      key={`${rIdx}-${cIdx}`}
+                      className={`rounded py-1.5 font-semibold transition-all
+                        ${cell === 'High'   ? 'bg-destructive/15 text-destructive' : ''}
+                        ${cell === 'Medium' ? 'bg-amber-100 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400' : ''}
+                        ${cell === 'Low'    ? 'bg-green-100 text-green-700 dark:bg-green-950/30 dark:text-green-400' : ''}
+                        ${isActive ? 'ring-2 ring-primary scale-105 shadow-sm' : 'opacity-60'}
+                      `}
+                    >
+                      {cell}
+                    </div>
+                  );
+                })}
+              </>
+            ))}
+          </div>
+        </div>
+
+        {/* ── Methodology footnote ── */}
+        <p className="text-[10px] text-muted-foreground leading-relaxed">
+          Inherent score = tier base + ICT function weights (DORA Art. 28). Control effectiveness
+          = Q-score × 40% + gap coverage × 60%. Residual factor floor: 15% (risk is never fully
+          eliminated). Formula is deterministic and auditable per Art. 28(3).
         </p>
       </CardContent>
     </Card>
   );
 }
+
+// ── Legacy alias — kept so any other import of InherentResidualPanel still works ─
+
+/** @deprecated Use ResidualRiskMatrix */
+export const InherentResidualPanel = ResidualRiskMatrix;
 
 // ── 2. Weighted domain breakdown ──────────────────────────────────────────────
 

--- a/frontend/src/lib/risk-scoring.ts
+++ b/frontend/src/lib/risk-scoring.ts
@@ -1,0 +1,167 @@
+/**
+ * risk-scoring.ts — DORA Art. 28(3) quantified risk scoring
+ *
+ * Formula:
+ *   inherentScore  = TIER_BASE[tier] + Σ FUNCTION_WEIGHT[fn]          [0–100]
+ *   domainCoverage = weighted DORA gap domain score                    [0–100]
+ *   controlEff     = qScore × 0.40 + domainCoverage × 0.60            [0–100]
+ *   residualFactor = max(0.15, 1 − controlEff/100)                    [0–1]
+ *   residualScore  = round(inherentScore × residualFactor)             [0–100]
+ *   riskLevel      = score ≥ 65 → High | 35–64 → Medium | < 35 → Low
+ */
+
+import type { Gap, OverallRisk } from '@/lib/api/assessments';
+import type { VendorTier, VendorFunction } from '@/types';
+
+// Re-export OverallRisk so callers can import from one place
+export type { OverallRisk };
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const TIER_BASE: Record<VendorTier, number> = {
+  critical:  80,
+  important: 55,
+  standard:  25,
+};
+
+export const FUNCTION_WEIGHT: Record<VendorFunction, number> = {
+  payment_processing:       8,
+  settlement_clearing:      8,
+  core_banking:             8,
+  risk_management:          4,
+  regulatory_reporting:     4,
+  fraud_detection:          4,
+  identity_access_management: 3,
+  network_infrastructure:   3,
+  data_storage:             2,
+  business_continuity:      2,
+};
+
+/** DORA domain weights (Art. 28–30) — same set as WeightedDomainChart */
+export const DOMAIN_WEIGHTS: Record<string, number> = {
+  'ICT Governance':      0.20,
+  'Security Controls':   0.25,
+  'Incident Management': 0.20,
+  'Business Continuity': 0.15,
+  'Audit Rights':        0.05,
+  'Subcontracting':      0.05,
+  'Data Governance':     0.05,
+  'Exit Planning':       0.03,
+  'Regulatory History':  0.02,
+};
+
+// ── Pure scoring functions ─────────────────────────────────────────────────────
+
+/** Sum tier base + function weights, capped at 100. */
+export function computeInherentScore(
+  tier: VendorTier | null | undefined,
+  functions: VendorFunction[] | null | undefined,
+): number {
+  const base = TIER_BASE[tier ?? 'standard'] ?? 25;
+  const fnSum = (functions ?? []).reduce(
+    (acc, fn) => acc + (FUNCTION_WEIGHT[fn] ?? 0),
+    0,
+  );
+  return Math.min(100, base + fnSum);
+}
+
+/**
+ * Weighted average DORA gap domain score (0–100).
+ * Returns null when there are no gaps to score.
+ */
+export function computeDomainCoverage(
+  gaps: Gap[] | null | undefined,
+): number | null {
+  if (!gaps || gaps.length === 0) return null;
+
+  const domainMap: Record<string, { covered: number; partial: number; missing: number }> = {};
+  for (const gap of gaps) {
+    const d = gap.domain ?? 'Unknown';
+    if (!domainMap[d]) domainMap[d] = { covered: 0, partial: 0, missing: 0 };
+    domainMap[d][gap.gapLevel]++;
+  }
+
+  let weightedSum = 0;
+  let totalWeight = 0;
+  for (const [domain, counts] of Object.entries(domainMap)) {
+    const total = counts.covered + counts.partial + counts.missing;
+    const score = total > 0 ? ((counts.covered + counts.partial * 0.5) / total) * 100 : 100;
+    const w = DOMAIN_WEIGHTS[domain] ?? 0;
+    weightedSum += score * w;
+    totalWeight += w;
+  }
+
+  return totalWeight > 0 ? Math.round(weightedSum / totalWeight) : null;
+}
+
+/**
+ * Control effectiveness: blended score of questionnaire + domain coverage.
+ * When either input is missing the other is weighted at 100%.
+ */
+export function computeControlEffectiveness(
+  qScore: number | null,
+  domainCoverage: number | null,
+): number {
+  if (qScore !== null && domainCoverage !== null) {
+    return Math.round(qScore * 0.40 + domainCoverage * 0.60);
+  }
+  if (qScore !== null) return qScore;
+  if (domainCoverage !== null) return domainCoverage;
+  return 0;
+}
+
+/** Residual factor — fraction of inherent risk remaining after controls.  Floor: 0.15. */
+export function computeResidualFactor(controlEffectiveness: number): number {
+  return Math.max(0.15, 1 - controlEffectiveness / 100);
+}
+
+/** Final residual score (rounded to nearest integer). */
+export function computeResidualScore(inherentScore: number, residualFactor: number): number {
+  return Math.round(inherentScore * residualFactor);
+}
+
+/** Map a 0–100 score to a qualitative risk level. */
+export function scoreToRisk(score: number): OverallRisk {
+  if (score >= 65) return 'High';
+  if (score >= 35) return 'Medium';
+  return 'Low';
+}
+
+// ── Composite result ───────────────────────────────────────────────────────────
+
+export interface RiskMatrixResult {
+  inherentScore:        number;
+  domainCoverage:       number | null;  // null = no DORA gap data
+  qScore:               number | null;  // null = no questionnaire
+  controlEffectiveness: number;         // 0–100
+  residualFactor:       number;         // 0–1 fraction remaining
+  residualScore:        number;
+  inherentRisk:         OverallRisk;
+  residualRisk:         OverallRisk;
+  hasData:              boolean;        // true if at least one control input is present
+}
+
+export function buildRiskMatrix(
+  tier:      VendorTier | null | undefined,
+  functions: VendorFunction[] | null | undefined,
+  gaps:      Gap[] | null | undefined,
+  qScore:    number | null,
+): RiskMatrixResult {
+  const inherentScore  = computeInherentScore(tier, functions);
+  const domainCoverage = computeDomainCoverage(gaps);
+  const controlEff     = computeControlEffectiveness(qScore, domainCoverage);
+  const residualFactor = computeResidualFactor(controlEff);
+  const residualScore  = computeResidualScore(inherentScore, residualFactor);
+
+  return {
+    inherentScore,
+    domainCoverage,
+    qScore,
+    controlEffectiveness: controlEff,
+    residualFactor,
+    residualScore,
+    inherentRisk:  scoreToRisk(inherentScore),
+    residualRisk:  scoreToRisk(residualScore),
+    hasData:       qScore !== null || domainCoverage !== null,
+  };
+}

--- a/frontend/src/tests/risk-scoring-panel.test.tsx
+++ b/frontend/src/tests/risk-scoring-panel.test.tsx
@@ -80,75 +80,70 @@ function makeWorkspace(overrides: Partial<WorkspaceWithMembership> = {}): Worksp
 }
 
 // ---------------------------------------------------------------------------
-// InherentResidualPanel
+// InherentResidualPanel (alias for ResidualRiskMatrix)
 // ---------------------------------------------------------------------------
 
 describe('InherentResidualPanel', () => {
-  it('renders nothing when residualRisk is missing', () => {
+  it('always renders the risk matrix card', () => {
+    // ResidualRiskMatrix always renders — no early return on missing results
     const assessment = makeAssessment({ results: undefined });
     const { container } = render(
       <InherentResidualPanel assessment={assessment} workspace={makeWorkspace()} />
     );
-    expect(container.firstChild).toBeNull();
+    expect(container.firstChild).not.toBeNull();
   });
 
-  it('renders inherent and residual risk boxes', () => {
+  it('renders inherent and residual score tiles', () => {
     render(<InherentResidualPanel assessment={makeAssessment()} workspace={makeWorkspace()} />);
-    expect(screen.getByText('Inherent risk')).toBeDefined();
-    expect(screen.getByText('Residual risk')).toBeDefined();
+    expect(screen.getByText('Inherent')).toBeDefined();
+    expect(screen.getByText('Residual')).toBeDefined();
   });
 
   it('shows High inherent risk for critical tier vendors', () => {
     const workspace = makeWorkspace({ vendorTier: 'critical' });
     render(<InherentResidualPanel assessment={makeAssessment()} workspace={workspace} />);
-    // Both boxes rendered — inherent should show High
+    // critical tier → inherentScore=80 → inherentRisk=High
     const allHighTexts = screen.getAllByText('High');
     expect(allHighTexts.length).toBeGreaterThan(0);
   });
 
   it('shows Medium inherent risk for important tier with non-critical service', () => {
-    const workspace = makeWorkspace({ vendorTier: 'important', serviceType: 'hr' });
+    const workspace = makeWorkspace({ vendorTier: 'important', serviceType: 'other' });
     render(<InherentResidualPanel assessment={makeAssessment()} workspace={workspace} />);
+    // important tier → inherentScore=55 → inherentRisk=Medium
     const allMedium = screen.getAllByText('Medium');
     expect(allMedium.length).toBeGreaterThan(0);
   });
 
   it('shows Low inherent risk for standard tier', () => {
-    const workspace = makeWorkspace({ vendorTier: 'standard', serviceType: 'hr' });
+    const workspace = makeWorkspace({ vendorTier: 'standard', serviceType: 'other' });
     render(<InherentResidualPanel assessment={makeAssessment()} workspace={workspace} />);
-    // Inherent should be Low, residual Medium (from assessment)
-    expect(screen.getByText('Low')).toBeDefined();
-    expect(screen.getByText('Medium')).toBeDefined();
+    // standard tier → inherentScore=25 → inherentRisk=Low
+    const allLow = screen.getAllByText('Low');
+    expect(allLow.length).toBeGreaterThan(0);
   });
 
-  it('shows "reduced by controls" when residual < inherent', () => {
-    // critical tier = inherent High, residual Low
-    const assessment = makeAssessment({ results: { gaps: [], overallRisk: 'Low', generatedAt: '', domainsAnalyzed: [] } });
+  it('shows numeric inherent score for critical tier vendor', () => {
     const workspace = makeWorkspace({ vendorTier: 'critical' });
-    render(<InherentResidualPanel assessment={assessment} workspace={workspace} />);
-    expect(screen.getByText('reduced by controls')).toBeDefined();
+    render(<InherentResidualPanel assessment={makeAssessment()} workspace={workspace} />);
+    // TIER_BASE[critical] = 80 — appears as "80/100" in both the tile and the breakdown
+    expect(screen.getAllByText(/80\/100/).length).toBeGreaterThan(0);
   });
 
-  it('shows "elevated by gaps" when residual > inherent', () => {
-    // standard tier = inherent Low, residual High
-    const assessment = makeAssessment({ results: { gaps: [], overallRisk: 'High', generatedAt: '', domainsAnalyzed: [] } });
-    const workspace = makeWorkspace({ vendorTier: 'standard', serviceType: 'hr' });
-    render(<InherentResidualPanel assessment={assessment} workspace={workspace} />);
-    expect(screen.getByText('elevated by gaps')).toBeDefined();
-  });
-
-  it('shows "unchanged" when residual equals inherent', () => {
-    // important + cloud = inherent High, residual High
-    const assessment = makeAssessment({ results: { gaps: [], overallRisk: 'High', generatedAt: '', domainsAnalyzed: [] } });
-    const workspace = makeWorkspace({ vendorTier: 'important', serviceType: 'cloud' });
-    render(<InherentResidualPanel assessment={assessment} workspace={workspace} />);
-    expect(screen.getByText('unchanged')).toBeDefined();
-  });
-
-  it('shows vendor tier and service type classification text', () => {
+  it('shows "remaining" text for the residual factor', () => {
     render(<InherentResidualPanel assessment={makeAssessment()} workspace={makeWorkspace()} />);
+    expect(screen.getByText(/remaining/)).toBeDefined();
+  });
+
+  it('shows methodology footnote', () => {
+    render(<InherentResidualPanel assessment={makeAssessment()} workspace={makeWorkspace()} />);
+    expect(screen.getByText(/Inherent score = tier base/)).toBeDefined();
+  });
+
+  it('shows vendor tier in input breakdown', () => {
+    render(<InherentResidualPanel assessment={makeAssessment()} workspace={makeWorkspace()} />);
+    // "Tier (important)" appears in the breakdown section
     expect(screen.getAllByText(/important/).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/cloud/).length).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Promotes the quantified DORA Art. 28(3) residual risk matrix feature from `dev` to `main` for production deployment.

### Changes included
- **`lib/risk-scoring.ts`** — pure deterministic scoring: `inherentScore = TIER_BASE + Σ FUNCTION_WEIGHT`, `controlEff = qScore × 40% + domainCoverage × 60%`, `residualFactor = max(0.15, 1 − controlEff/100)`
- **`ResidualRiskMatrix`** replaces qualitative `InherentResidualPanel` — numeric scores (0–100), 3×3 heat map, input breakdown, methodology footnote
- **Assessment detail page** — fetches latest completed Q score, passes to matrix
- **Risk register page** — "Risk Score" column with coloured N/100 chip

## Test plan

- [x] Backend lint — 0 errors
- [x] Frontend lint — 0 errors
- [x] Backend tests — 1131 tests passed
- [x] Frontend tests — 393 tests passed
- [x] `next build` — 31 routes, no errors
- [x] CI on feat→dev PR — all 6 checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)