### PR TITLE
feat(backend): auto-schedule reassessment review on risk decision

### DIFF
--- a/backend/controllers/assessmentController.js
+++ b/backend/controllers/assessmentController.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import { Assessment } from '../models/Assessment.js';
-import { assessmentQueue } from '../config/queue.js';
+import { Workspace } from '../models/Workspace.js';
+import { assessmentQueue, monitoringQueue } from '../config/queue.js';
 import { handleFileUpload } from '../middleware/fileUpload.js';
 import { generateReport } from '../services/reportGenerator.js';
 import { catchAsync, sendSuccess, sendError, AppError } from '../utils/index.js';
@@ -302,6 +303,42 @@ export const setRiskDecision = catchAsync(async (req, res) => {
     decision,
     userId: req.user.userId,
   });
+
+  // Auto-schedule reassessment review (proceed + conditional only)
+  if (decision === 'proceed' || decision === 'conditional') {
+    try {
+      const nextReviewDate = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+      await Workspace.findByIdAndUpdate(assessment.workspaceId, { nextReviewDate });
+
+      // Delay = nextReviewDate − 30 days − now  (≈ 335 days)
+      const delayMs = Math.max(0, nextReviewDate.getTime() - 30 * 24 * 60 * 60 * 1000 - Date.now());
+      const jobId = `review-reminder-${assessment.workspaceId}`;
+
+      // Remove any existing reminder so re-recording resets the clock
+      const existing = await monitoringQueue.getJob(jobId);
+      if (existing) await existing.remove();
+
+      await monitoringQueue.add(
+        'review-reminder',
+        { workspaceId: assessment.workspaceId.toString() },
+        { jobId, delay: delayMs }
+      );
+
+      logger.info('Review reminder scheduled', {
+        service: 'assessment-controller',
+        workspaceId: assessment.workspaceId,
+        nextReviewDate,
+        delayDays: Math.round(delayMs / 86_400_000),
+      });
+    } catch (err) {
+      // Non-critical — a Redis issue must not block the decision response
+      logger.warn('Failed to schedule review reminder (non-critical)', {
+        service: 'assessment-controller',
+        workspaceId: assessment.workspaceId,
+        error: err.message,
+      });
+    }
+  }
 
   sendSuccess(res, 200, 'Risk decision recorded', { riskDecision: assessment.riskDecision });
 });

--- a/backend/services/alertMonitorService.js
+++ b/backend/services/alertMonitorService.js
@@ -234,6 +234,35 @@ async function checkAssessmentOverdue() {
 }
 
 // ---------------------------------------------------------------------------
+// Exported function — called by monitoringWorker for delayed review-reminder jobs
+// ---------------------------------------------------------------------------
+
+/**
+ * Sends a 30-day review reminder to all workspace owners.
+ * Called by monitoringWorker when the delayed 'review-reminder' job fires.
+ */
+export async function sendReviewReminderAlert(workspaceId) {
+  const workspace = await Workspace.findById(workspaceId);
+  if (!workspace) {
+    logger.warn('Review reminder: workspace not found', { service: 'alertMonitor', workspaceId });
+    return;
+  }
+
+  const details = {
+    reviewDate: workspace.nextReviewDate
+      ? workspace.nextReviewDate.toLocaleDateString('en-GB', {
+          day: 'numeric',
+          month: 'long',
+          year: 'numeric',
+        })
+      : 'soon',
+  };
+
+  await sendAlertToOwners(workspace, 'review-due-30', details);
+  logger.info('Review reminder sent', { service: 'alertMonitor', workspaceId });
+}
+
+// ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
 

--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -122,6 +122,7 @@ function buildMonitoringAlertHtml({ toName, workspaceName, alertType, details })
     'contract-renewal-60': `The ICT service contract with vendor <strong>${workspaceName}</strong> is due for renewal on <strong>${details.contractEnd}</strong> (60 days from now). Schedule a review with your legal team.`,
     'annual-review-overdue': `The scheduled annual DORA vendor review for <strong>${workspaceName}</strong> was due on <strong>${details.reviewDate}</strong> and has not been completed. Please schedule this review to maintain compliance.`,
     'assessment-overdue-12mo': `No DORA gap assessment has been run for vendor <strong>${workspaceName}</strong> in over 12 months. The last assessment was ${details.lastAssessmentDate ? `on <strong>${details.lastAssessmentDate}</strong>` : '<strong>never</strong>'}. DORA Article 28 requires periodic reviews.`,
+    'review-due-30': `The annual DORA vendor review for <strong>${workspaceName}</strong> is scheduled on <strong>${details.reviewDate}</strong> — in 30 days. Initiate a new gap assessment to remain compliant with DORA Article 28.`,
   };
   const message =
     alertMessages[alertType] ||
@@ -422,6 +423,7 @@ const local = {
       'contract-renewal-60': `[Action Required] Contract renewal due in 60 days — ${workspaceName}`,
       'annual-review-overdue': `[Overdue] Annual vendor review required for ${workspaceName}`,
       'assessment-overdue-12mo': `[Reminder] No DORA assessment run in 12 months — ${workspaceName}`,
+      'review-due-30': `[30-Day Notice] Annual vendor review due — ${workspaceName}`,
     };
     const subject = subjects[alertType] || `Compliance Alert — ${workspaceName}`;
     const html = buildMonitoringAlertHtml({ toName, workspaceName, alertType, details });

--- a/backend/tests/integrationtest/risk-decision.integration.test.js
+++ b/backend/tests/integrationtest/risk-decision.integration.test.js
@@ -87,7 +87,11 @@ vi.mock('../../config/queue.js', () => ({
   assessmentQueue: { add: vi.fn().mockResolvedValue({ id: 'j1' }), on: vi.fn() },
   documentIndexQueue: { add: vi.fn().mockResolvedValue({}), on: vi.fn() },
   memoryDecayQueue: { add: vi.fn().mockResolvedValue({}), on: vi.fn() },
-  monitoringQueue: { add: vi.fn().mockResolvedValue({}), on: vi.fn() },
+  monitoringQueue: {
+    add: vi.fn().mockResolvedValue({ id: 'review-r1' }),
+    getJob: vi.fn().mockResolvedValue(null),
+    on: vi.fn(),
+  },
 }));
 
 vi.mock('../../services/fileIngestionService.js', () => ({
@@ -321,6 +325,54 @@ describe('Risk Decision & Clause Sign-off Integration Tests', () => {
 
       expect(getRes.status).toBe(200);
       expect(getRes.body.data.assessment.riskDecision.decision).toBe('conditional');
+    });
+
+    it('queues a review-reminder delayed job for proceed decision', async () => {
+      const { monitoringQueue } = await import('../../config/queue.js');
+      const assessmentId = await createCompleteAssessment(request, user1Token, workspaceId);
+      await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/risk-decision`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ decision: 'proceed' });
+
+      expect(monitoringQueue.add).toHaveBeenCalledWith(
+        'review-reminder',
+        expect.objectContaining({ workspaceId: expect.any(String) }),
+        expect.objectContaining({
+          jobId: expect.stringContaining('review-reminder-'),
+          delay: expect.any(Number),
+        })
+      );
+    });
+
+    it('sets nextReviewDate ~1 year out on workspace for proceed decision', async () => {
+      const assessmentId = await createCompleteAssessment(request, user1Token, workspaceId);
+      const before = Date.now();
+      await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/risk-decision`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ decision: 'proceed' });
+
+      const ws = await mongoose.model('Workspace').findById(workspaceId);
+      expect(ws.nextReviewDate).not.toBeNull();
+      const diffDays = (ws.nextReviewDate.getTime() - before) / 86_400_000;
+      expect(diffDays).toBeGreaterThan(364);
+      expect(diffDays).toBeLessThan(366);
+    });
+
+    it('does not queue a review-reminder for reject decision', async () => {
+      const { monitoringQueue } = await import('../../config/queue.js');
+      vi.clearAllMocks();
+      const assessmentId = await createCompleteAssessment(request, user1Token, workspaceId);
+      await request
+        .patch(`${ASSESSMENT_BASE}/${assessmentId}/risk-decision`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ decision: 'reject' });
+
+      const reminderCalls = monitoringQueue.add.mock.calls.filter(
+        ([name]) => name === 'review-reminder'
+      );
+      expect(reminderCalls).toHaveLength(0);
     });
   });
 

--- a/backend/workers/monitoringWorker.js
+++ b/backend/workers/monitoringWorker.js
@@ -7,7 +7,7 @@
 
 import { Worker } from 'bullmq';
 import { redisConnection } from '../config/redis.js';
-import { runMonitoringAlerts } from '../services/alertMonitorService.js';
+import { runMonitoringAlerts, sendReviewReminderAlert } from '../services/alertMonitorService.js';
 import logger from '../config/logger.js';
 
 const worker = new Worker(
@@ -17,6 +17,14 @@ const worker = new Worker(
       logger.info('Running monitoring alerts', { service: 'monitoringWorker', jobId: job.id });
       await runMonitoringAlerts();
       return { ran: true, timestamp: new Date().toISOString() };
+    } else if (job.name === 'review-reminder') {
+      logger.info('Sending review reminder', {
+        service: 'monitoringWorker',
+        jobId: job.id,
+        workspaceId: job.data.workspaceId,
+      });
+      await sendReviewReminderAlert(job.data.workspaceId);
+      return { sent: true, workspaceId: job.data.workspaceId };
     }
     logger.warn('Unknown monitoring job type', { jobName: job.name, jobId: job.id });
   },


### PR DESCRIPTION
## Summary

- When a `proceed` or `conditional` risk decision is recorded via `PATCH /assessments/:id/risk-decision`, the backend now sets `workspace.nextReviewDate` to +365 days and enqueues a delayed BullMQ job on `monitoringQueue` (~335 days) that fires 30 days before the review date
- New `sendReviewReminderAlert()` in `alertMonitorService` reuses the existing `sendAlertToOwners` helper with a new `review-due-30` alert type
- `monitoringWorker` handles the new `review-reminder` job name
- `emailService` has the matching subject and HTML body for `review-due-30`
- Scheduling is non-critical: wrapped in try/catch so Redis failures never block the API response
- Re-recording a decision removes the old delayed job and enqueues a fresh one (clock reset)
- `reject` decisions receive no scheduling — vendor is not onboarded
- Implements DORA Art. 28(3) periodic re-assessment requirement

## Files changed

| File | Change |
|------|--------|
| `backend/controllers/assessmentController.js` | Import `Workspace` + `monitoringQueue`; scheduling block after `assessment.save()` |
| `backend/workers/monitoringWorker.js` | Import + handle `review-reminder` job name |
| `backend/services/alertMonitorService.js` | Export `sendReviewReminderAlert()` |
| `backend/services/emailService.js` | Add `review-due-30` to subjects + alertMessages |
| `backend/tests/integrationtest/risk-decision.integration.test.js` | `getJob` mock + 3 new tests |

## Test plan

- [x] Backend lint: 0 errors
- [x] Frontend lint: 0 errors (no frontend changes)
- [x] All 1134 backend tests pass (including 3 new tests)
- [x] Pre-push hook ran full suite before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)