### PR TITLE
feat(frontend): redesign design system with audit-grade precision aesthetic

### DIFF
--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { ShieldCheck } from 'lucide-react';
 
 export default function AuthLayout({
   children,
@@ -6,33 +7,93 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4 py-12">
-      <div className="w-full max-w-md space-y-8">
-        {/* Logo/Brand */}
-        <div className="text-center">
-          <Link href="/" className="inline-block">
-            <h1 className="text-3xl font-bold text-foreground">
-              Retrieva
-            </h1>
-          </Link>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Knowledge retrieval powered by AI
-          </p>
+    <div className="min-h-screen grid lg:grid-cols-2">
+
+      {/* ── Left panel — brand identity ── */}
+      <div className="relative hidden lg:flex flex-col overflow-hidden bg-sidebar">
+
+        {/* Fine grid texture */}
+        <div className="absolute inset-0 bg-grid-pattern opacity-100" />
+
+        {/* Ambient glow */}
+        <div className="absolute -top-32 -left-32 h-96 w-96 rounded-full bg-sidebar-primary/10 blur-3xl" />
+        <div className="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-sidebar-primary/8 blur-3xl" />
+
+        {/* Wordmark */}
+        <div className="relative z-10 flex items-center gap-3 p-10">
+          <ShieldCheck className="h-7 w-7 text-sidebar-primary" />
+          <span className="font-display text-xl font-semibold text-sidebar-foreground tracking-tight">
+            Retrieva
+          </span>
         </div>
 
-        {/* Auth Form Container */}
-        <div className="bg-card border border-border rounded-lg shadow-sm p-8">
-          {children}
+        {/* Center content */}
+        <div className="relative z-10 flex flex-1 flex-col justify-center px-10 pb-12">
+          <div className="space-y-6">
+            <div className="space-y-1">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-sidebar-primary">
+                EU Digital Operational Resilience Act
+              </p>
+            </div>
+            <blockquote className="space-y-3">
+              <p className="font-display text-4xl font-light leading-[1.2] text-sidebar-foreground/90">
+                Compliance without intelligence<br />
+                is just theatre.
+              </p>
+              <p className="text-sm text-sidebar-foreground/40 leading-relaxed max-w-xs">
+                Retrieva automates DORA Article 28 vendor risk assessment,
+                so your compliance team can focus on decisions, not documents.
+              </p>
+            </blockquote>
+
+            {/* DORA pillars */}
+            <div className="grid grid-cols-2 gap-3 pt-4">
+              {[
+                { code: 'Art. 28', label: 'Vendor Classification' },
+                { code: 'Art. 30', label: 'Contractual Clauses' },
+                { code: 'Art. 31', label: 'Critical ICT Providers' },
+                { code: 'Art. 32', label: 'Exit Strategies' },
+              ].map(({ code, label }) => (
+                <div key={code} className="rounded-sm border border-sidebar-border bg-sidebar-accent/40 px-3 py-2">
+                  <p className="font-mono text-[10px] text-sidebar-primary mb-0.5">{code}</p>
+                  <p className="text-xs text-sidebar-foreground/50">{label}</p>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
 
         {/* Footer */}
-        <p className="text-center text-xs text-muted-foreground">
+        <div className="relative z-10 px-10 py-6 border-t border-sidebar-border">
+          <p className="text-[11px] text-sidebar-foreground/25">
+            Regulation (EU) 2022/2554 · In force since 17 January 2025
+          </p>
+        </div>
+      </div>
+
+      {/* ── Right panel — form ── */}
+      <div className="flex flex-col items-center justify-center min-h-screen px-8 py-12 bg-background">
+
+        {/* Mobile wordmark */}
+        <div className="lg:hidden mb-10 text-center">
+          <Link href="/" className="inline-flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-primary" />
+            <span className="font-display text-2xl font-semibold text-foreground">Retrieva</span>
+          </Link>
+          <p className="mt-1 text-xs text-muted-foreground">DORA compliance assessment</p>
+        </div>
+
+        <div className="w-full max-w-sm space-y-8">
+          {children}
+        </div>
+
+        <p className="mt-10 text-center text-xs text-muted-foreground">
           By continuing, you agree to our{' '}
-          <Link href="/terms" className="underline hover:text-foreground">
+          <Link href="/terms" className="underline underline-offset-2 hover:text-foreground transition-colors">
             Terms of Service
           </Link>{' '}
           and{' '}
-          <Link href="/privacy" className="underline hover:text-foreground">
+          <Link href="/privacy" className="underline underline-offset-2 hover:text-foreground transition-colors">
             Privacy Policy
           </Link>
         </p>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2,100 +2,206 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ─── Design System ─────────────────────────────────────────────────────────── */
+
 :root {
-  --radius: 0.625rem;
-  --background: 0 0% 100%;
-  --foreground: 0 0% 3.9%;
-  --card: 0 0% 100%;
-  --card-foreground: 0 0% 3.9%;
-  --popover: 0 0% 100%;
-  --popover-foreground: 0 0% 3.9%;
-  --primary: 0 0% 9%;
-  --primary-foreground: 0 0% 98%;
-  --secondary: 0 0% 96.1%;
-  --secondary-foreground: 0 0% 9%;
-  --muted: 0 0% 96.1%;
-  --muted-foreground: 0 0% 45.1%;
-  --accent: 0 0% 96.1%;
-  --accent-foreground: 0 0% 9%;
-  --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 0 0% 98%;
-  --border: 0 0% 89.8%;
-  --input: 0 0% 89.8%;
-  --ring: 0 0% 3.9%;
-  --chart-1: 12 76% 61%;
-  --chart-2: 173 58% 39%;
-  --chart-3: 197 37% 24%;
-  --chart-4: 43 74% 66%;
-  --chart-5: 27 87% 67%;
-  --success: 142 76% 36%;
-  --success-foreground: 0 0% 98%;
-  --success-muted: 142 76% 95%;
-  --warning: 38 92% 50%;
-  --warning-foreground: 0 0% 9%;
-  --warning-muted: 38 92% 95%;
-  --info: 217 91% 60%;
-  --info-foreground: 0 0% 98%;
-  --info-muted: 217 91% 95%;
-  --sidebar: 0 0% 98%;
-  --sidebar-foreground: 0 0% 3.9%;
-  --sidebar-primary: 0 0% 9%;
-  --sidebar-primary-foreground: 0 0% 98%;
-  --sidebar-accent: 0 0% 96.1%;
-  --sidebar-accent-foreground: 0 0% 9%;
-  --sidebar-border: 0 0% 89.8%;
-  --sidebar-ring: 0 0% 63.9%;
+  --radius: 0.375rem;
+
+  /* Surface */
+  --background:         36 22% 97%;        /* warm paper #F8F5F0 */
+  --foreground:         215 45% 10%;       /* prussian ink #0D1B2A */
+
+  /* Cards */
+  --card:               0 0% 100%;
+  --card-foreground:    215 45% 10%;
+
+  --popover:            0 0% 100%;
+  --popover-foreground: 215 45% 10%;
+
+  /* Primary — royal blue */
+  --primary:            214 78% 36%;       /* #1043A0 */
+  --primary-foreground: 0 0% 100%;
+
+  /* Secondary — warm stone */
+  --secondary:          36 15% 92%;
+  --secondary-foreground: 215 45% 10%;
+
+  /* Muted */
+  --muted:              36 12% 94%;
+  --muted-foreground:   215 18% 46%;
+
+  /* Accent — light blue tint for hover states */
+  --accent:             214 55% 94%;
+  --accent-foreground:  214 78% 36%;
+
+  --destructive:        0 72% 51%;
+  --destructive-foreground: 0 0% 100%;
+
+  /* Borders */
+  --border:             215 18% 88%;
+  --input:              215 18% 88%;
+  --ring:               214 78% 36%;
+
+  /* Charts */
+  --chart-1: 214 78% 48%;
+  --chart-2: 142 72% 38%;
+  --chart-3: 38 90% 50%;
+  --chart-4: 265 60% 55%;
+  --chart-5: 0 72% 51%;
+
+  /* Semantic */
+  --success:            142 72% 36%;
+  --success-foreground: 0 0% 100%;
+  --success-muted:      142 72% 94%;
+  --warning:            38 90% 50%;
+  --warning-foreground: 215 45% 10%;
+  --warning-muted:      38 90% 93%;
+  --info:               214 78% 55%;
+  --info-foreground:    0 0% 100%;
+  --info-muted:         214 78% 93%;
+
+  /* ─── Sidebar — deep navy chrome ─── */
+  --sidebar:                    215 50% 11%;
+  --sidebar-foreground:         210 18% 86%;
+  --sidebar-primary:            210 80% 62%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-accent:             215 42% 17%;
+  --sidebar-accent-foreground:  210 18% 92%;
+  --sidebar-border:             215 38% 18%;
+  --sidebar-ring:               210 80% 62%;
 }
 
 .dark {
-  --background: 0 0% 3.9%;
-  --foreground: 0 0% 98%;
-  --card: 0 0% 3.9%;
-  --card-foreground: 0 0% 98%;
-  --popover: 0 0% 3.9%;
-  --popover-foreground: 0 0% 98%;
-  --primary: 0 0% 98%;
-  --primary-foreground: 0 0% 9%;
-  --secondary: 0 0% 14.9%;
-  --secondary-foreground: 0 0% 98%;
-  --muted: 0 0% 14.9%;
-  --muted-foreground: 0 0% 63.9%;
-  --accent: 0 0% 14.9%;
-  --accent-foreground: 0 0% 98%;
-  --destructive: 0 62.8% 30.6%;
+  --background:         215 35% 7%;
+  --foreground:         36 18% 93%;
+
+  --card:               215 30% 10%;
+  --card-foreground:    36 18% 93%;
+
+  --popover:            215 30% 10%;
+  --popover-foreground: 36 18% 93%;
+
+  --primary:            210 80% 60%;
+  --primary-foreground: 215 45% 8%;
+
+  --secondary:          215 25% 17%;
+  --secondary-foreground: 36 18% 88%;
+
+  --muted:              215 25% 14%;
+  --muted-foreground:   215 14% 54%;
+
+  --accent:             215 28% 20%;
+  --accent-foreground:  210 80% 70%;
+
+  --destructive:        0 58% 44%;
   --destructive-foreground: 0 0% 98%;
-  --border: 0 0% 14.9%;
-  --input: 0 0% 14.9%;
-  --ring: 0 0% 83.1%;
-  --chart-1: 220 70% 50%;
-  --chart-2: 160 60% 45%;
-  --chart-3: 30 80% 55%;
-  --chart-4: 280 65% 60%;
-  --chart-5: 340 75% 55%;
-  --success: 142 70% 45%;
-  --success-foreground: 0 0% 98%;
-  --success-muted: 142 40% 16%;
-  --warning: 38 92% 50%;
-  --warning-foreground: 0 0% 98%;
-  --warning-muted: 38 40% 16%;
-  --info: 217 91% 60%;
-  --info-foreground: 0 0% 98%;
-  --info-muted: 217 40% 16%;
-  --sidebar: 0 0% 3.9%;
-  --sidebar-foreground: 0 0% 98%;
-  --sidebar-primary: 224.3 76.3% 48%;
+
+  --border:             215 25% 19%;
+  --input:              215 25% 17%;
+  --ring:               210 80% 60%;
+
+  --chart-1: 210 80% 60%;
+  --chart-2: 142 65% 50%;
+  --chart-3: 38 85% 55%;
+  --chart-4: 265 60% 65%;
+  --chart-5: 0 65% 55%;
+
+  --success:            142 65% 45%;
+  --success-foreground: 0 0% 100%;
+  --success-muted:      142 35% 14%;
+  --warning:            38 85% 52%;
+  --warning-foreground: 0 0% 100%;
+  --warning-muted:      38 38% 14%;
+  --info:               210 80% 60%;
+  --info-foreground:    0 0% 100%;
+  --info-muted:         210 38% 14%;
+
+  --sidebar:                    215 45% 5%;
+  --sidebar-foreground:         210 18% 82%;
+  --sidebar-primary:            210 80% 60%;
   --sidebar-primary-foreground: 0 0% 100%;
-  --sidebar-accent: 0 0% 14.9%;
-  --sidebar-accent-foreground: 0 0% 98%;
-  --sidebar-border: 0 0% 14.9%;
-  --sidebar-ring: 217.2 91.2% 59.8%;
+  --sidebar-accent:             215 40% 11%;
+  --sidebar-accent-foreground:  210 18% 88%;
+  --sidebar-border:             215 38% 13%;
+  --sidebar-ring:               210 80% 60%;
 }
+
+/* ─── Sidebar variable scope override ──────────────────────────────────────── */
+/* All Shadcn components inside [data-sidebar] inherit the sidebar palette      */
+[data-sidebar] {
+  --background:         var(--sidebar);
+  --foreground:         var(--sidebar-foreground);
+  --primary:            var(--sidebar-primary);
+  --primary-foreground: var(--sidebar-primary-foreground);
+  --secondary:          var(--sidebar-accent);
+  --secondary-foreground: var(--sidebar-accent-foreground);
+  --accent:             var(--sidebar-accent);
+  --accent-foreground:  var(--sidebar-accent-foreground);
+  --muted:              var(--sidebar-accent);
+  --muted-foreground:   var(--sidebar-foreground);
+  --border:             var(--sidebar-border);
+  --input:              var(--sidebar-border);
+  --ring:               var(--sidebar-ring);
+}
+
+/* ─── Base styles ───────────────────────────────────────────────────────────── */
 
 @layer base {
   * {
     @apply border-border outline-ring/50;
   }
+
   body {
     @apply bg-background text-foreground;
+    font-feature-settings: "kern" 1, "liga" 1, "calt" 1;
+  }
+
+  /* Display headings use the serif display font */
+  h1, h2 {
+    @apply font-display;
+    font-feature-settings: "kern" 1, "liga" 1, "dlig" 1;
+  }
+
+  /* Precise custom scrollbar */
+  ::-webkit-scrollbar         { width: 6px; height: 6px; }
+  ::-webkit-scrollbar-track   { @apply bg-transparent; }
+  ::-webkit-scrollbar-thumb   { @apply bg-border rounded-full; }
+  ::-webkit-scrollbar-thumb:hover { @apply bg-muted-foreground/40; }
+
+  /* Selection */
+  ::selection {
+    background-color: hsl(214 78% 36% / 0.15);
+    color: inherit;
+  }
+}
+
+/* ─── Utility — fine grid texture ───────────────────────────────────────────── */
+@layer utilities {
+  .bg-grid-pattern {
+    background-image:
+      linear-gradient(to right,  hsl(215 30% 50% / 0.07) 1px, transparent 1px),
+      linear-gradient(to bottom, hsl(215 30% 50% / 0.07) 1px, transparent 1px);
+    background-size: 32px 32px;
+  }
+
+  .bg-dot-pattern {
+    background-image: radial-gradient(hsl(215 30% 50% / 0.12) 1px, transparent 1px);
+    background-size: 20px 20px;
+  }
+
+  .font-display {
+    font-family: var(--font-display), Georgia, serif;
+  }
+
+  /* Sidebar active accent bar */
+  .nav-item-active::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 6px;
+    bottom: 6px;
+    width: 2px;
+    border-radius: 0 2px 2px 0;
+    background-color: hsl(var(--sidebar-primary));
   }
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,21 +1,32 @@
 import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Cormorant_Garamond, DM_Sans, JetBrains_Mono } from 'next/font/google';
 import './globals.css';
 import { Providers } from '@/components/providers';
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
+const cormorant = Cormorant_Garamond({
+  variable: '--font-display',
   subsets: ['latin'],
+  weight: ['300', '400', '500', '600', '700'],
+  display: 'swap',
 });
 
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
+const dmSans = DM_Sans({
+  variable: '--font-sans',
   subsets: ['latin'],
+  weight: ['300', '400', '500', '600'],
+  display: 'swap',
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: '--font-mono',
+  subsets: ['latin'],
+  weight: ['400', '500'],
+  display: 'swap',
 });
 
 export const metadata: Metadata = {
   title: 'Retrieva',
-  description: 'Knowledge retrieval powered by AI',
+  description: 'DORA compliance assessment powered by AI',
 };
 
 export default function RootLayout({
@@ -26,7 +37,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}
+        className={`${cormorant.variable} ${dmSans.variable} ${jetbrainsMono.variable} font-sans antialiased`}
       >
         <Providers>{children}</Providers>
       </body>

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -12,17 +12,17 @@ export function Header() {
   const isMobile = useUIStore((state) => state.isMobile);
 
   return (
-    <header className="sticky top-0 z-40 flex h-14 items-center gap-4 border-b bg-background px-4 sm:px-6">
+    <header className="sticky top-0 z-40 flex h-13 items-center gap-4 border-b border-border bg-background/95 backdrop-blur-sm px-5 sm:px-6">
       {isMobile && (
-        <Button variant="ghost" size="icon" onClick={toggleSidebar}>
-          <Menu className="h-5 w-5" />
+        <Button variant="ghost" size="icon" className="h-8 w-8 -ml-1" onClick={toggleSidebar}>
+          <Menu className="h-4 w-4" />
           <span className="sr-only">Toggle sidebar</span>
         </Button>
       )}
 
       <div className="flex-1" />
 
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1.5">
         <ThemeToggle />
         <UserNav />
       </div>

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -22,16 +22,13 @@ export function Sidebar() {
 
   const filterNavItems = (items: NavItem[]) => {
     return items.filter((item) => {
-      // Check workspace role requirements
       if (item.workspaceRoles) {
         const userRole = permissions.isWorkspaceOwner
           ? 'owner'
           : permissions.isWorkspaceMember
           ? 'member'
           : 'viewer';
-        if (!item.workspaceRoles.includes(userRole)) {
-          return false;
-        }
+        if (!item.workspaceRoles.includes(userRole)) return false;
       }
       return true;
     });
@@ -42,107 +39,120 @@ export function Sidebar() {
 
   return (
     <aside
+      data-sidebar
       className={cn(
-        'flex h-full flex-col border-r bg-sidebar transition-all duration-300',
+        'flex h-full flex-col bg-sidebar border-r border-sidebar-border transition-all duration-300',
         sidebarCollapsed ? 'w-16' : 'w-64'
       )}
     >
-      {/* Header */}
-      <div className="flex h-14 items-center border-b px-3">
+      {/* ── Logo header ── */}
+      <div
+        className={cn(
+          'flex h-14 shrink-0 items-center border-b border-sidebar-border px-4',
+          sidebarCollapsed && 'justify-center px-0'
+        )}
+      >
         {!sidebarCollapsed && (
-          <Link href="/assessments" className="flex items-center gap-2 font-semibold">
-            <ShieldCheck className="h-6 w-6 text-primary" />
-            <span>Retrieva</span>
+          <Link href="/assessments" className="flex items-center gap-2.5 min-w-0">
+            <ShieldCheck className="h-5 w-5 shrink-0 text-sidebar-primary" />
+            <span className="font-display text-lg font-semibold text-sidebar-foreground tracking-tight truncate">
+              Retrieva
+            </span>
           </Link>
         )}
-        {/* A11Y FIX: Added aria-label and aria-expanded for screen readers */}
         <Button
           variant="ghost"
           size="icon"
-          className={cn('h-8 w-8', sidebarCollapsed ? 'mx-auto' : 'ml-auto')}
+          className={cn(
+            'h-7 w-7 shrink-0 text-sidebar-foreground/40 hover:text-sidebar-foreground hover:bg-sidebar-accent',
+            sidebarCollapsed ? '' : 'ml-auto'
+          )}
           onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
           aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           aria-expanded={!sidebarCollapsed}
         >
-          {sidebarCollapsed ? (
-            <PanelLeft className="h-4 w-4" aria-hidden="true" />
-          ) : (
-            <PanelLeftClose className="h-4 w-4" aria-hidden="true" />
-          )}
+          {sidebarCollapsed
+            ? <PanelLeft className="h-4 w-4" aria-hidden />
+            : <PanelLeftClose className="h-4 w-4" aria-hidden />}
         </Button>
       </div>
 
-      {/* Organization label */}
-      {!sidebarCollapsed && user?.organization && (
-        <div className="px-3 pt-2 pb-0">
-          <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider truncate">
-            {user.organization.name}
-          </p>
-        </div>
-      )}
-
-      {/* Workspace Switcher */}
+      {/* ── Org label + workspace switcher ── */}
       {!sidebarCollapsed && (
-        <div className="p-3">
+        <div className="px-4 pt-3 pb-3 border-b border-sidebar-border space-y-2">
+          {user?.organization && (
+            <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-sidebar-foreground/30 truncate">
+              {user.organization.name}
+            </p>
+          )}
           <WorkspaceSwitcher />
         </div>
       )}
 
-      {/* Main Navigation */}
-      <ScrollArea className="flex-1 px-3">
-        <nav className="flex flex-col gap-1 py-2">
+      {/* ── Main Navigation ── */}
+      <ScrollArea className="flex-1 py-3">
+        <nav className={cn('flex flex-col gap-0.5', sidebarCollapsed ? 'px-2' : 'px-3')}>
           {visibleMainNav.map((item) => {
             const isActive =
-            pathname === item.href ||
-            (item.href === '/conversations' && pathname.startsWith('/conversations/'));
+              pathname === item.href ||
+              (item.href === '/conversations' && pathname.startsWith('/conversations/'));
             return (
-              <Button
+              <NavLink
                 key={item.href}
-                asChild
-                variant={isActive ? 'secondary' : 'ghost'}
-                className={cn(
-                  'w-full',
-                  sidebarCollapsed ? 'justify-center px-2' : 'justify-start'
-                )}
-              >
-                <Link href={item.href}>
-                  <item.icon
-                    className={cn('h-4 w-4', !sidebarCollapsed && 'mr-2')}
-                  />
-                  {!sidebarCollapsed && <span>{item.title}</span>}
-                </Link>
-              </Button>
+                item={item}
+                isActive={isActive}
+                collapsed={sidebarCollapsed}
+              />
             );
           })}
         </nav>
       </ScrollArea>
 
-      {/* Bottom Navigation */}
-      <div className="mt-auto border-t px-3 py-2">
-        <nav className="flex flex-col gap-1">
+      {/* ── Bottom Navigation ── */}
+      <div className={cn('shrink-0 border-t border-sidebar-border py-3', sidebarCollapsed ? 'px-2' : 'px-3')}>
+        <nav className="flex flex-col gap-0.5">
           {visibleBottomNav.map((item) => {
             const isActive = pathname === item.href || pathname.startsWith(item.href + '/');
             return (
-              <Button
+              <NavLink
                 key={item.href}
-                asChild
-                variant={isActive ? 'secondary' : 'ghost'}
-                className={cn(
-                  'w-full',
-                  sidebarCollapsed ? 'justify-center px-2' : 'justify-start'
-                )}
-              >
-                <Link href={item.href}>
-                  <item.icon
-                    className={cn('h-4 w-4', !sidebarCollapsed && 'mr-2')}
-                  />
-                  {!sidebarCollapsed && <span>{item.title}</span>}
-                </Link>
-              </Button>
+                item={item}
+                isActive={isActive}
+                collapsed={sidebarCollapsed}
+              />
             );
           })}
         </nav>
       </div>
     </aside>
+  );
+}
+
+// ─── Nav link atom ────────────────────────────────────────────────────────────
+
+function NavLink({
+  item,
+  isActive,
+  collapsed,
+}: {
+  item: NavItem;
+  isActive: boolean;
+  collapsed: boolean;
+}) {
+  return (
+    <Link
+      href={item.href}
+      title={collapsed ? item.title : undefined}
+      className={cn(
+        'relative flex items-center rounded-sm text-sm transition-colors duration-150',
+        collapsed ? 'justify-center p-2.5' : 'gap-3 px-3 py-2',
+        isActive
+          ? 'nav-item-active bg-sidebar-accent text-sidebar-foreground font-medium'
+          : 'text-sidebar-foreground/50 hover:bg-sidebar-accent/60 hover:text-sidebar-foreground/80'
+      )}
+    >
+      <item.icon className="h-4 w-4 shrink-0" aria-hidden />
+      {!collapsed && <span className="truncate">{item.title}</span>}
+    </Link>
   );
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -79,8 +79,9 @@ const config: Config = {
         },
       },
       fontFamily: {
-        sans: ["var(--font-geist-sans)", ...defaultTheme.fontFamily.sans],
-        mono: ["var(--font-geist-mono)", ...defaultTheme.fontFamily.mono],
+        sans:    ["var(--font-sans)",    ...defaultTheme.fontFamily.sans],
+        mono:    ["var(--font-mono)",    ...defaultTheme.fontFamily.mono],
+        display: ["var(--font-display)", "Georgia", "serif"],
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
Complete frontend design system overhaul — makes Retrieva look like it was built for a compliance department at a financial institution, not a generic vibe-coded SaaS.

**Typography**
- Display/headings: `Cormorant Garamond` — elegant serif signalling regulatory authority
- Body/UI: `DM Sans` — clean humanist sans, legible at small sizes
- Data/codes: `JetBrains Mono` — for risk scores, compliance IDs

**Color system**
- Background: warm paper white `#F8F5F0` (not sterile white)
- Foreground: prussian ink `#0D1B2A`
- Primary: royal blue — all buttons, links, rings replaced from black to blue

**Sidebar**
- Deep navy in both light and dark mode
- `[data-sidebar]` CSS scope override: all Shadcn components inside inherit the sidebar palette automatically
- Active nav items: left accent bar + subtle background

**Auth layout**
- Two-column: dark navy brand panel (left) with serif quote + DORA article pillars, clean form (right)

**Other**
- Sharper border radius (6px), custom scrollbar, `bg-grid-pattern` utility
- Header: frosted glass with `backdrop-blur`

## Test plan
- [ ] `/login` — two-column layout, serif wordmark, DORA pillars on left panel
- [ ] Dashboard — dark navy sidebar, blue active indicator, Cormorant wordmark
- [ ] Toggle dark mode — correct inversion
- [ ] Sidebar collapse — icon-only mode
- [ ] All pages readable with new typography