### PR TITLE
fix(backend): remove deleted worker import and fix sentry redis integration name

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -15,7 +15,6 @@ import { startupInitService } from './services/startupInit.js';
 import { ragService } from './services/rag.js';
 import { answerFormatter } from './services/answerFormatter.js';
 // Import workers to start them with the server
-import './workers/documentIndexWorker.js';
 import './workers/assessmentWorker.js';
 import './workers/questionnaireWorker.js';
 import './workers/monitoringWorker.js';

--- a/backend/instrument.js
+++ b/backend/instrument.js
@@ -27,8 +27,8 @@ try {
     // Use 1.0 in development for full visibility.
     tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
 
-    // Auto-instrument mongoose queries and ioredis commands
-    integrations: [Sentry.mongooseIntegration(), Sentry.ioRedisIntegration()],
+    // Auto-instrument mongoose queries and redis/ioredis commands
+    integrations: [Sentry.mongooseIntegration(), Sentry.redisIntegration()],
 
     // Filter out expected operational errors (4xx) — they are handled by the
     // app and don't represent bugs. Only real crashes reach Sentry.


### PR DESCRIPTION
## Summary

Two root-cause bugs preventing the backend from starting in production:

1. **`ERR_MODULE_NOT_FOUND: documentIndexWorker.js`** — `index.js` still imported a worker file that was deleted in the notion/RAG removal PR. The module graph fails immediately on startup.

2. **`Sentry.ioRedisIntegration is not a function`** — `@sentry/node` v10 does not export `ioRedisIntegration`. The correct export for Redis auto-instrumentation (supports both `redis` and `ioredis`) is `redisIntegration`.

## Changes
- `backend/index.js`: remove stale `import './workers/documentIndexWorker.js'`
- `backend/instrument.js`: `ioRedisIntegration()` → `redisIntegration()`

## Test plan
- [ ] CI green
- [ ] CD backend health check passes on first attempt