### PR TITLE
fix(backend): use node for docker healthcheck instead of curl

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -62,9 +62,10 @@ USER expressjs
 # Expose port
 EXPOSE 3007
 
-# Health check (curl is available in slim, wget is not)
+# Health check — use node (always available) instead of curl/wget which are
+# not included in node:20-slim by default.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:3007/health || exit 1
+    CMD node -e "require('http').get('http://localhost:3007/health',(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 
 # Start the application
 CMD ["node", "--import", "./instrument.js", "index.js"]


### PR DESCRIPTION
## Problem

`node:20-slim` does not include `curl` by default. The Docker `HEALTHCHECK` used `curl -f http://localhost:3007/health` which always failed inside the container, causing Docker to mark `retrieva-backend` as **unhealthy** even though the application itself was responding correctly (the CD pipeline's external `curl` from the host passed fine).

This triggered a Netdata alert: `docker_container_unhealthy` for `retrieva-backend`.

## Fix

Replace the curl healthcheck with a native `node` HTTP call — Node.js is always available in a Node image:

```
node -e "require('http').get('http://localhost:3007/health',(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
```

## Also done (separate action)
- Rebooted the production server to clear the `system_post_update_reboot_status` Netdata alert (kernel/library updates were pending)