### PR TITLE
fix(infra): replace wget with node in backend compose healthcheck

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -137,7 +137,7 @@ services:
       - NODE_ENV=production
       - DOCKER_ENV=true
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3007/health"]
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3007/health',(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
docker-compose.production.yml had a wget-based healthcheck for the backend that overrides the Dockerfile HEALTHCHECK. Since the backend now uses node:20-slim (no wget), this caused the docker_container_unhealthy Netdata alert. Fix uses native node http.get (always available in node images).