### PR TITLE
feat(onboarding): welcome screen and getting started checklist (#154 #155)

### DIFF
--- a/backend/controllers/assessmentController.js
+++ b/backend/controllers/assessmentController.js
@@ -66,6 +66,13 @@ export const createAssessment = catchAsync(async (req, res) => {
     fileCount: req.files.length,
   });
 
+  // Mark checklist item — fire and forget, non-critical
+  const { User: UserModel } = await import('../models/User.js');
+  UserModel.updateOne(
+    { _id: userId, 'onboardingChecklist.assessmentCreated': false },
+    { $set: { 'onboardingChecklist.assessmentCreated': true } }
+  ).catch(() => {});
+
   // Upload files to Spaces for persistent storage (non-critical — failures don't block processing)
   if (isStorageConfigured() && req.user.organizationId) {
     await Promise.all(

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -230,6 +230,8 @@ export const login = async (req, res) => {
         isEmailVerified: user.isEmailVerified,
         organizationId: user.organizationId ? user.organizationId.toString() : null,
         organization,
+        onboardingCompleted: user.onboardingCompleted,
+        onboardingChecklist: user.onboardingChecklist,
       },
       // Tokens also returned in body for API clients (mobile apps, etc.)
       ...tokens,
@@ -429,6 +431,8 @@ export const getMe = async (req, res) => {
         lastLogin: user.lastLogin,
         organizationId: user.organizationId ? user.organizationId.toString() : null,
         organization,
+        onboardingCompleted: user.onboardingCompleted,
+        onboardingChecklist: user.onboardingChecklist,
       },
     });
   } catch (error) {
@@ -779,5 +783,49 @@ export const changePassword = async (req, res) => {
       userId: req.user?.userId,
     });
     sendError(res, 500, 'Failed to change password');
+  }
+};
+
+/**
+ * Update onboarding state
+ * PATCH /api/v1/auth/onboarding
+ */
+export const updateOnboarding = async (req, res) => {
+  try {
+    const { completed, checklist } = req.body;
+    const update = {};
+
+    if (completed !== undefined) {
+      update.onboardingCompleted = completed;
+    }
+
+    if (checklist && typeof checklist === 'object') {
+      const allowed = [
+        'vendorCreated',
+        'assessmentCreated',
+        'memberInvited',
+        'monitoringSetup',
+        'dismissed',
+      ];
+      for (const key of allowed) {
+        if (checklist[key] !== undefined) {
+          update[`onboardingChecklist.${key}`] = checklist[key];
+        }
+      }
+    }
+
+    if (Object.keys(update).length === 0) {
+      return sendError(res, 400, 'No valid fields to update');
+    }
+
+    await User.updateOne({ _id: req.user.userId }, { $set: update });
+
+    sendSuccess(res, 200, 'Onboarding state updated');
+  } catch (error) {
+    logger.error('Failed to update onboarding state', {
+      error: error.message,
+      userId: req.user?.userId,
+    });
+    sendError(res, 500, 'Failed to update onboarding state');
   }
 };

--- a/backend/controllers/organizationController.js
+++ b/backend/controllers/organizationController.js
@@ -227,6 +227,12 @@ export const inviteMember = catchAsync(async (req, res) => {
       });
     });
 
+  // Mark checklist item — fire and forget, non-critical
+  User.updateOne(
+    { _id: inviterId, 'onboardingChecklist.memberInvited': false },
+    { $set: { 'onboardingChecklist.memberInvited': true } }
+  ).catch(() => {});
+
   logger.info('Org invite sent', {
     service: 'organization',
     orgId,

--- a/backend/controllers/workspaceMemberController.js
+++ b/backend/controllers/workspaceMemberController.js
@@ -56,6 +56,12 @@ export const createWorkspace = catchAsync(async (req, res) => {
 
   await WorkspaceMember.addOwner(workspace._id, userId);
 
+  // Mark checklist item — fire and forget, non-critical
+  User.updateOne(
+    { _id: userId, 'onboardingChecklist.vendorCreated': false },
+    { $set: { 'onboardingChecklist.vendorCreated': true } }
+  ).catch(() => {});
+
   logger.info('Workspace created', { service: 'workspace', workspaceId: workspace._id, userId });
 
   sendSuccess(res, 201, 'Workspace created', {

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -159,6 +159,18 @@ const userSchema = new mongoose.Schema(
       ref: 'Organization',
       default: null,
     },
+    // Onboarding state
+    onboardingCompleted: {
+      type: Boolean,
+      default: false,
+    },
+    onboardingChecklist: {
+      vendorCreated: { type: Boolean, default: false },
+      assessmentCreated: { type: Boolean, default: false },
+      memberInvited: { type: Boolean, default: false },
+      monitoringSetup: { type: Boolean, default: false },
+      dismissed: { type: Boolean, default: false },
+    },
   },
   {
     timestamps: true,

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -11,6 +11,7 @@ import {
   verifyEmail,
   resendVerification,
   changePassword,
+  updateOnboarding,
 } from '../controllers/authController.js';
 import { validateBody } from '../middleware/validate.js';
 import { authenticate } from '../middleware/auth.js';
@@ -104,5 +105,12 @@ router.post('/resend-verification', authenticate, resendVerification);
  * @access  Private
  */
 router.post('/change-password', authenticate, validateBody(changePasswordSchema), changePassword);
+
+/**
+ * @route   PATCH /api/v1/auth/onboarding
+ * @desc    Update onboarding state (welcome screen dismissed, checklist flags)
+ * @access  Private
+ */
+router.patch('/onboarding', authenticate, updateOnboarding);
 
 export default router;

--- a/backend/tests/unittest/organization-controller.unit.test.js
+++ b/backend/tests/unittest/organization-controller.unit.test.js
@@ -107,6 +107,7 @@ vi.mock('../../models/User.js', () => ({
   User: {
     findById: vi.fn(),
     findByIdAndUpdate: vi.fn(),
+    updateOne: vi.fn().mockResolvedValue({ modifiedCount: 1 }),
   },
 }));
 
@@ -137,6 +138,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   safeDecrypt.mockImplementation((v) => v);
   emailService.sendOrganizationInvitation.mockResolvedValue({ success: true });
+  User.updateOne.mockResolvedValue({ modifiedCount: 1 });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -6,6 +6,7 @@ import { Sidebar } from '@/components/layout/sidebar';
 import { Header } from '@/components/layout/header';
 import { MobileSidebar } from '@/components/layout/mobile-sidebar';
 import { ModalOutlet } from '@/components/layout/modal-outlet';
+import { WelcomeScreen } from '@/components/onboarding/WelcomeScreen';
 import { useUIStore } from '@/lib/stores/ui-store';
 import { useAuthStore } from '@/lib/stores/auth-store';
 import { useWorkspaceStore } from '@/lib/stores/workspace-store';
@@ -23,6 +24,7 @@ export default function DashboardLayout({
   const isLoading = useAuthStore((state) => state.isLoading);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const organizationId = useAuthStore((state) => state.user?.organizationId);
+  const onboardingCompleted = useAuthStore((state) => state.user?.onboardingCompleted);
   const fetchWorkspaces = useWorkspaceStore((state) => state.fetchWorkspaces);
 
   // Handle responsive behavior
@@ -108,6 +110,11 @@ export default function DashboardLayout({
 
       {/* Global Modals */}
       <ModalOutlet />
+
+      {/* Onboarding welcome screen — shown once after org creation */}
+      {isAuthenticated && organizationId && onboardingCompleted === false && (
+        <WelcomeScreen />
+      )}
     </div>
   );
 }

--- a/frontend/src/app/(dashboard)/workspaces/page.tsx
+++ b/frontend/src/app/(dashboard)/workspaces/page.tsx
@@ -15,8 +15,10 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { GettingStartedChecklist } from '@/components/onboarding/GettingStartedChecklist';
 import { useWorkspaceStore } from '@/lib/stores/workspace-store';
 import { useUIStore, MODAL_IDS } from '@/lib/stores/ui-store';
+import { useAuthStore } from '@/lib/stores/auth-store';
 import { getRoleDisplayName, getRoleBadgeColor } from '@/lib/utils/permissions';
 import type { VendorTier, VendorStatus } from '@/types';
 
@@ -65,6 +67,8 @@ export default function WorkspacesPage() {
   const workspaces = useWorkspaceStore((state) => state.workspaces);
   const fetchWorkspaces = useWorkspaceStore((state) => state.fetchWorkspaces);
   const openModal = useUIStore((state) => state.openModal);
+  const onboardingChecklist = useAuthStore((state) => state.user?.onboardingChecklist);
+  const onboardingCompleted = useAuthStore((state) => state.user?.onboardingCompleted);
 
   // Handle OAuth callback query params
   useEffect(() => {
@@ -95,6 +99,11 @@ export default function WorkspacesPage() {
 
   return (
     <div className="p-6 max-w-5xl mx-auto">
+      {/* Getting started checklist — shown until dismissed or completed */}
+      {onboardingChecklist && !onboardingCompleted && !onboardingChecklist.dismissed && (
+        <GettingStartedChecklist checklist={onboardingChecklist} />
+      )}
+
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>

--- a/frontend/src/components/onboarding/GettingStartedChecklist.tsx
+++ b/frontend/src/components/onboarding/GettingStartedChecklist.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Check, X, Building2, ShieldCheck, ClipboardList, Users, Activity } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useAuthStore } from '@/lib/stores/auth-store';
+import { authApi } from '@/lib/api';
+import { useUIStore, MODAL_IDS } from '@/lib/stores/ui-store';
+import type { OnboardingChecklist } from '@/types';
+import { cn } from '@/lib/utils';
+
+interface ChecklistItem {
+  key: keyof Omit<OnboardingChecklist, 'dismissed'>;
+  icon: React.ElementType;
+  label: string;
+  cta: string;
+  onClick: () => void;
+}
+
+interface Props {
+  checklist: OnboardingChecklist;
+}
+
+export function GettingStartedChecklist({ checklist }: Props) {
+  const router = useRouter();
+  const updateUser = useAuthStore((state) => state.updateUser);
+  const openModal = useUIStore((state) => state.openModal);
+
+  const dismiss = async () => {
+    try {
+      await authApi.updateOnboarding({ checklist: { dismissed: true } });
+    } catch {
+      // Non-critical
+    }
+    updateUser({
+      onboardingChecklist: { ...checklist, dismissed: true },
+    });
+  };
+
+  const items: ChecklistItem[] = [
+    {
+      key: 'vendorCreated',
+      icon: Building2,
+      label: 'Add your first vendor',
+      cta: 'Add vendor',
+      onClick: () => openModal(MODAL_IDS.CREATE_WORKSPACE),
+    },
+    {
+      key: 'assessmentCreated',
+      icon: ShieldCheck,
+      label: 'Run your first gap analysis',
+      cta: 'New analysis',
+      onClick: () => router.push('/assessments/new'),
+    },
+    {
+      key: 'memberInvited',
+      icon: Users,
+      label: 'Invite a team member',
+      cta: 'Invite',
+      onClick: () => router.push('/settings/team'),
+    },
+    {
+      key: 'monitoringSetup',
+      icon: Activity,
+      label: 'Set up vendor monitoring',
+      cta: 'Configure',
+      onClick: () => router.push('/workspaces'),
+    },
+  ];
+
+  // Always show org creation as done (user is in dashboard = org exists)
+  const orgItem = {
+    key: 'org' as const,
+    icon: ClipboardList,
+    label: 'Create your organisation',
+    done: true,
+  };
+
+  const completedCount = 1 + items.filter((i) => checklist[i.key]).length;
+  const totalCount = 1 + items.length;
+  const progressPct = Math.round((completedCount / totalCount) * 100);
+
+  if (checklist.dismissed) return null;
+
+  return (
+    <div className="mb-6 rounded-lg border bg-card shadow-sm">
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 pt-4 pb-3 border-b">
+        <div className="flex items-center gap-3">
+          <p className="text-sm font-semibold">Getting started</p>
+          <span className="text-xs text-muted-foreground">
+            {completedCount} of {totalCount} complete
+          </span>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 text-muted-foreground hover:text-foreground"
+          onClick={dismiss}
+          aria-label="Dismiss checklist"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-1 bg-muted">
+        <div
+          className="h-1 bg-primary transition-all duration-500"
+          style={{ width: `${progressPct}%` }}
+        />
+      </div>
+
+      {/* Items */}
+      <div className="divide-y">
+        {/* Org item — always done */}
+        <div className="flex items-center gap-3 px-5 py-3">
+          <div className="h-5 w-5 shrink-0 rounded-full bg-primary flex items-center justify-center">
+            <Check className="h-3 w-3 text-primary-foreground" strokeWidth={3} />
+          </div>
+          <orgItem.icon className="h-4 w-4 text-muted-foreground shrink-0" />
+          <span className="text-sm text-muted-foreground line-through">{orgItem.label}</span>
+        </div>
+
+        {items.map(({ key, icon: Icon, label, cta, onClick }) => {
+          const done = checklist[key];
+          return (
+            <div key={key} className="flex items-center gap-3 px-5 py-3">
+              <div
+                className={cn(
+                  'h-5 w-5 shrink-0 rounded-full border-2 flex items-center justify-center transition-colors',
+                  done
+                    ? 'bg-primary border-primary'
+                    : 'border-muted-foreground/30 bg-transparent'
+                )}
+              >
+                {done && <Check className="h-3 w-3 text-primary-foreground" strokeWidth={3} />}
+              </div>
+              <Icon className={cn('h-4 w-4 shrink-0', done ? 'text-muted-foreground' : 'text-foreground')} />
+              <span className={cn('flex-1 text-sm', done && 'text-muted-foreground line-through')}>
+                {label}
+              </span>
+              {!done && (
+                <Button variant="outline" size="sm" className="h-7 text-xs" onClick={onClick}>
+                  {cta}
+                </Button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/onboarding/WelcomeScreen.tsx
+++ b/frontend/src/components/onboarding/WelcomeScreen.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Building2, Users, BookOpen, ArrowRight, ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useAuthStore } from '@/lib/stores/auth-store';
+import { authApi } from '@/lib/api';
+import { useUIStore, MODAL_IDS } from '@/lib/stores/ui-store';
+
+export function WelcomeScreen() {
+  const router = useRouter();
+  const user = useAuthStore((state) => state.user);
+  const updateUser = useAuthStore((state) => state.updateUser);
+  const openModal = useUIStore((state) => state.openModal);
+  const [dismissing, setDismissing] = useState(false);
+
+  const firstName = user?.name?.split(' ')[0] ?? 'there';
+
+  const dismiss = async (then?: () => void) => {
+    if (dismissing) return;
+    setDismissing(true);
+    try {
+      await authApi.updateOnboarding({ completed: true });
+      updateUser({ onboardingCompleted: true });
+      then?.();
+    } catch {
+      // Non-critical — still dismiss locally
+      updateUser({ onboardingCompleted: true });
+      then?.();
+    }
+  };
+
+  const actions = [
+    {
+      icon: Building2,
+      title: 'Add your first vendor',
+      description: 'Create a workspace for an ICT vendor and start the DORA compliance workflow.',
+      cta: 'Add vendor',
+      onClick: () => dismiss(() => openModal(MODAL_IDS.CREATE_WORKSPACE)),
+    },
+    {
+      icon: Users,
+      title: 'Invite your team',
+      description: 'Bring in your compliance analysts, ICT risk managers, and stakeholders.',
+      cta: 'Invite members',
+      onClick: () => dismiss(() => router.push('/settings/team')),
+    },
+    {
+      icon: BookOpen,
+      title: 'Read the playbook',
+      description: 'A step-by-step guide to everything Retrieva can do for your team.',
+      cta: 'Open playbook',
+      onClick: () => dismiss(() => window.open('https://retrieva.online', '_blank')),
+    },
+  ];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+      <div className="w-full max-w-2xl mx-4 rounded-xl border bg-card shadow-2xl p-8">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-2">
+          <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+            <ShieldCheck className="h-5 w-5 text-primary" />
+          </div>
+          <span className="text-sm font-medium text-muted-foreground">Retrieva</span>
+        </div>
+        <h1 className="font-display text-2xl font-semibold tracking-tight mt-4">
+          Welcome, {firstName} 👋
+        </h1>
+        <p className="mt-2 text-muted-foreground text-sm leading-relaxed">
+          Retrieva helps you assess ICT vendors against DORA requirements, identify compliance gaps,
+          and monitor risk in real time. Here&apos;s how to get started.
+        </p>
+
+        {/* Action cards */}
+        <div className="mt-6 grid gap-3">
+          {actions.map(({ icon: Icon, title, description, cta, onClick }) => (
+            <button
+              key={title}
+              onClick={onClick}
+              className="group flex items-center gap-4 rounded-lg border bg-muted/30 px-4 py-3.5 text-left transition-colors hover:bg-muted/60 hover:border-primary/30"
+            >
+              <div className="h-9 w-9 shrink-0 rounded-md bg-primary/10 flex items-center justify-center group-hover:bg-primary/15 transition-colors">
+                <Icon className="h-4 w-4 text-primary" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium">{title}</p>
+                <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">{description}</p>
+              </div>
+              <div className="flex items-center gap-1 text-xs font-medium text-primary shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                {cta}
+                <ArrowRight className="h-3 w-3" />
+              </div>
+            </button>
+          ))}
+        </div>
+
+        {/* Footer CTA */}
+        <div className="mt-6 flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">
+            You can always find these options in the sidebar.
+          </p>
+          <Button onClick={() => dismiss()} disabled={dismissing}>
+            Get started
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -127,4 +127,21 @@ export const authApi = {
     );
     return response.data;
   },
+
+  /**
+   * Update onboarding state (welcome screen + checklist flags)
+   */
+  updateOnboarding: async (data: {
+    completed?: boolean;
+    checklist?: Partial<{
+      vendorCreated: boolean;
+      assessmentCreated: boolean;
+      memberInvited: boolean;
+      monitoringSetup: boolean;
+      dismissed: boolean;
+    }>;
+  }) => {
+    const response = await apiClient.patch<ApiResponse>('/auth/onboarding', data);
+    return response.data;
+  },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -33,6 +33,14 @@ export interface UserOrganization {
   trialEndsAt?: string | null;
 }
 
+export interface OnboardingChecklist {
+  vendorCreated: boolean;
+  assessmentCreated: boolean;
+  memberInvited: boolean;
+  monitoringSetup: boolean;
+  dismissed: boolean;
+}
+
 export interface User {
   id: string;
   email: string;
@@ -43,6 +51,8 @@ export interface User {
   lastLogin?: string;
   organizationId?: string | null;
   organization?: UserOrganization | null;
+  onboardingCompleted?: boolean;
+  onboardingChecklist?: OnboardingChecklist;
 }
 
 export interface AuthTokens {


### PR DESCRIPTION
## Summary
- **feat(onboarding)**: One-time welcome screen shown after org creation — greets user by name, 3 action cards (add vendor, invite team, read playbook), dismissed permanently via server-side flag
- **feat(onboarding)**: Getting started checklist on vendors page — 5-item progress tracker that auto-checks as user completes each action (vendor created, assessment run, member invited); dismissible

## Backend
- `User` model: `onboardingCompleted` + `onboardingChecklist` fields
- New `PATCH /api/v1/auth/onboarding` endpoint
- `/me` and login responses include onboarding state
- Workspace, assessment, org controllers set checklist flags automatically (fire-and-forget)

## Test plan
- [ ] New user registers → creates org → welcome screen appears immediately
- [ ] Dismissing welcome screen → never appears again on refresh or new session
- [ ] Vendors page shows checklist for new users with 1/5 complete
- [ ] Each action auto-checks the corresponding item
- [ ] Existing users (no `onboardingCompleted` field) → no screen shown
- [ ] CI passes

Closes #154
Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)