### PR TITLE
fix(types): add css module ambient declaration for ts bundler resolution

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -44,3 +44,4 @@ yarn-error.log*
 next-env.d.ts
 /.tsbuildinfo-test
 
+.claude/

--- a/frontend/src/types/css.d.ts
+++ b/frontend/src/types/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';


### PR DESCRIPTION
## Summary

- Adds `src/types/css.d.ts` with `declare module '*.css'` to silence the TypeScript `moduleResolution: bundler` error on the `import './globals.css'` side-effect import in `app/layout.tsx`
- Also adds `.claude/` to `frontend/.gitignore`

## Test plan

- [ ] `npx tsc --noEmit` — no CSS-related errors
- [ ] `npm run build` — clean build
- [ ] `npm run test:run` — all 506 tests pass