### PR TITLE
feat: portfolio compliance score, weekly digest email, rts article mapping

### DIFF
--- a/backend/config/queue.js
+++ b/backend/config/queue.js
@@ -154,6 +154,35 @@ export async function scheduleMemoryDecayJob() {
 }
 
 /**
+ * Schedule weekly digest email job
+ * Runs every 7 days
+ */
+export async function scheduleWeeklyDigestJob() {
+  const jobName = 'send-weekly-digest';
+
+  const existingJobs = await withTimeout(monitoringQueue.getRepeatableJobs(), QUEUE_OP_TIMEOUT);
+  for (const job of existingJobs) {
+    if (job.name === jobName) {
+      await withTimeout(monitoringQueue.removeRepeatableByKey(job.key), QUEUE_OP_TIMEOUT);
+    }
+  }
+
+  await withTimeout(
+    monitoringQueue.add(
+      jobName,
+      { scheduled: true },
+      {
+        repeat: { every: 7 * 24 * 60 * 60 * 1000 },
+        jobId: 'weekly-digest-scheduled',
+      }
+    ),
+    QUEUE_OP_TIMEOUT
+  );
+
+  logger.info('Weekly digest job scheduled', { service: 'queue' });
+}
+
+/**
  * Schedule recurring monitoring alerts job
  * Runs every 24 hours by default
  */
@@ -259,5 +288,6 @@ export default {
   monitoringQueue,
   scheduleMemoryDecayJob,
   scheduleMonitoringJob,
+  scheduleWeeklyDigestJob,
   closeQueues,
 };

--- a/backend/controllers/workspaceMemberController.js
+++ b/backend/controllers/workspaceMemberController.js
@@ -1,5 +1,6 @@
 import { catchAsync, sendSuccess } from '../utils/index.js';
 import { workspaceService } from '../services/WorkspaceService.js';
+import { assessmentRepository } from '../repositories/index.js';
 
 export const createWorkspace = catchAsync(async (req, res) => {
   const workspace = await workspaceService.createWorkspace(req.user.userId, req.body);
@@ -62,4 +63,9 @@ export const updateMember = catchAsync(async (req, res) => {
     req.body
   );
   sendSuccess(res, 200, 'Member updated successfully', { member });
+});
+
+export const getComplianceScore = catchAsync(async (req, res) => {
+  const score = await assessmentRepository.getComplianceScore(req.params.workspaceId);
+  sendSuccess(res, 200, 'Compliance score retrieved', { score });
 });

--- a/backend/index.js
+++ b/backend/index.js
@@ -19,7 +19,7 @@ import './workers/assessmentWorker.js';
 import './workers/questionnaireWorker.js';
 import './workers/monitoringWorker.js';
 import { seedDefaultTemplate } from './seeds/questionnaireTemplate.seed.js';
-import { scheduleMonitoringJob } from './config/queue.js';
+import { scheduleMonitoringJob, scheduleWeeklyDigestJob } from './config/queue.js';
 
 const port = process.env.PORT || 3000;
 
@@ -38,6 +38,13 @@ const startServer = async () => {
     // Schedule monitoring alerts job (non-critical — runs every 24h)
     await scheduleMonitoringJob().catch((err) =>
       logger.error('Failed to schedule monitoring job (non-critical)', {
+        service: 'rag-backend',
+        error: err.message,
+      })
+    );
+
+    await scheduleWeeklyDigestJob().catch((err) =>
+      logger.error('Failed to schedule weekly digest job (non-critical)', {
         service: 'rag-backend',
         error: err.message,
       })

--- a/backend/models/Assessment.js
+++ b/backend/models/Assessment.js
@@ -28,6 +28,7 @@ const clauseSignoffSchema = new mongoose.Schema(
 const gapSchema = new mongoose.Schema(
   {
     article: { type: String, required: true }, // e.g. "DORA Article 28(4)(a)"
+    rtsReference: { type: String, default: '' }, // e.g. "JC 2023 86 (Subcontracting RTS)"
     domain: { type: String }, // e.g. "Third-Party Risk"
     requirement: { type: String, required: true }, // exact regulatory text
     vendorCoverage: { type: String, default: '' }, // what the vendor doc says

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -152,6 +152,7 @@ const userSchema = new mongoose.Schema(
         sync_failed: { type: Boolean, default: true },
         system_alert: { type: Boolean, default: true },
         token_limit_reached: { type: Boolean, default: true },
+        weekly_digest: { type: Boolean, default: true },
       },
     },
     organizationId: {

--- a/backend/prompts/gapAnalysisPrompts.js
+++ b/backend/prompts/gapAnalysisPrompts.js
@@ -98,4 +98,5 @@ Scoring guidance:
 - Mark as "partial" when the vendor mentions the topic but incompletely or vaguely.
 - Mark as "missing" when no relevant evidence was found.
 - Focus especially on Articles 28–30 (third-party contractual requirements) and Articles 31–44 (ICT third-party oversight) — these are mandatory for all financial entity contracts with ICT providers.
-- Produce at least 15 specific gap entries spanning all relevant domains.`;
+- Produce at least 15 specific gap entries spanning all relevant domains.
+- For each gap, include the specific RTS/ITS reference where one exists (e.g. "JC 2023 86" for Art.30 subcontracting, "Commission Delegated Regulation 2024/1774" for ICT risk management, "Commission Delegated Regulation 2024/1779" for incident classification). Leave rtsReference empty when no dedicated RTS/ITS applies to that article.`;

--- a/backend/repositories/AssessmentRepository.js
+++ b/backend/repositories/AssessmentRepository.js
@@ -59,6 +59,38 @@ class AssessmentRepository extends BaseRepository {
     if (withinMs) filter.createdAt = { $gte: new Date(Date.now() - withinMs) };
     return this.model.findOne(filter).sort({ createdAt: -1 }).lean();
   }
+
+  async getComplianceScore(workspaceId) {
+    const riskMap = { Low: 100, Medium: 50, High: 0 };
+    const assessments = await this.model
+      .find({ workspaceId, status: 'complete', framework: 'DORA' })
+      .select('results.overallRisk createdAt')
+      .sort({ createdAt: -1 })
+      .lean();
+
+    if (!assessments.length) return null;
+
+    const scores = assessments.map((a) => riskMap[a.results?.overallRisk] ?? 50);
+    const score = Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
+
+    const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const olderScores = assessments
+      .filter((a) => new Date(a.createdAt) < cutoff)
+      .map((a) => riskMap[a.results?.overallRisk] ?? 50);
+
+    let trend = 0;
+    if (olderScores.length) {
+      const oldScore = Math.round(olderScores.reduce((a, b) => a + b, 0) / olderScores.length);
+      trend = score - oldScore;
+    }
+
+    return {
+      score,
+      trend,
+      status: score >= 80 ? 'green' : score >= 60 ? 'amber' : 'red',
+      assessmentCount: assessments.length,
+    };
+  }
 }
 
 export const assessmentRepository = new AssessmentRepository();

--- a/backend/routes/workspaceRoutes.js
+++ b/backend/routes/workspaceRoutes.js
@@ -13,6 +13,7 @@ import {
   inviteMember,
   revokeMember,
   updateMember,
+  getComplianceScore,
 } from '../controllers/workspaceMemberController.js';
 import { authenticate } from '../middleware/auth.js';
 import { canInviteMembers } from '../middleware/workspaceAuth.js';
@@ -30,6 +31,7 @@ const router = express.Router();
 router.post('/', authenticate, validateBody(createWorkspaceSchema), createWorkspace);
 router.get('/my-workspaces', authenticate, getMyWorkspaces);
 router.get('/roi-export', authenticate, exportRoi);
+router.get('/:workspaceId/compliance-score', authenticate, getComplianceScore);
 router.get('/:workspaceId', authenticate, getWorkspace);
 router.patch('/:workspaceId', authenticate, validateBody(updateWorkspaceSchema), updateWorkspace);
 router.delete('/:workspaceId', authenticate, deleteWorkspace);

--- a/backend/services/alertMonitorService.js
+++ b/backend/services/alertMonitorService.js
@@ -13,6 +13,7 @@
  */
 
 import { WorkspaceMember } from '../models/WorkspaceMember.js';
+import { User } from '../models/User.js';
 import { workspaceRepository, assessmentRepository } from '../repositories/index.js';
 import emailService from './emailService.js';
 import logger from '../config/logger.js';
@@ -293,4 +294,68 @@ async function sendAlertToOwners(workspace, alertType, details) {
       });
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Weekly Digest — summary email sent once per week to workspace owners
+// ---------------------------------------------------------------------------
+
+export async function runWeeklyDigest() {
+  logger.info('Starting weekly digest run', { service: 'alertMonitor' });
+
+  const ownerGroups = await WorkspaceMember.aggregate([
+    { $match: { role: 'owner', status: 'active' } },
+    { $group: { _id: '$userId', workspaceIds: { $push: '$workspaceId' } } },
+  ]);
+
+  let sent = 0;
+  for (const { _id: userId, workspaceIds } of ownerGroups) {
+    try {
+      const user = await User.findById(userId).select('email name notificationPreferences').lean();
+
+      if (!user) continue;
+      if (user.notificationPreferences?.email?.weekly_digest === false) continue;
+
+      const workspaces = await workspaceRepository.find(
+        { _id: { $in: workspaceIds } },
+        { select: 'workspaceName name nextReviewDate _id' }
+      );
+      if (!workspaces.length) continue;
+
+      const cutoff30 = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+
+      const items = await Promise.all(
+        workspaces.map(async (ws) => {
+          const score = await assessmentRepository.getComplianceScore(ws._id);
+          const reviewDue =
+            ws.nextReviewDate && new Date(ws.nextReviewDate) < cutoff30
+              ? new Date(ws.nextReviewDate).toLocaleDateString('en-GB', {
+                  day: 'numeric',
+                  month: 'short',
+                  year: 'numeric',
+                })
+              : null;
+          return {
+            workspaceId: ws._id.toString(),
+            workspaceName: ws.workspaceName || ws.name,
+            score: score?.score ?? null,
+            trend: score?.trend ?? 0,
+            status: score?.status ?? null,
+            reviewDue,
+          };
+        })
+      );
+
+      await emailService.sendWeeklyDigest({ toEmail: user.email, toName: user.name, items });
+      sent++;
+    } catch (err) {
+      logger.error('Failed to send weekly digest', {
+        service: 'alertMonitor',
+        userId,
+        error: err.message,
+      });
+    }
+  }
+
+  logger.info('Weekly digest run complete', { service: 'alertMonitor', sent });
 }

--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -110,6 +110,7 @@ const remote = {
     callEmailService('/internal/email/questionnaire-invitation', p),
   sendMonitoringAlert: (p) => callEmailService('/internal/email/monitoring-alert', p),
   sendOrganizationInvitation: (p) => callEmailService('/internal/email/org-invitation', p),
+  sendWeeklyDigest: (p) => callEmailService('/internal/email/weekly-digest', p),
   verifyConnection: () => callEmailService('/internal/email/health', {}),
 };
 
@@ -159,6 +160,80 @@ function buildMonitoringAlertHtml({ toName, workspaceName, alertType, details })
   <div style="border-top: 1px solid #e2e8f0; margin-top: 32px; padding-top: 16px;">
     <p style="font-size: 12px; color: #94a3b8; margin: 0;">
       This automated alert was sent by Retrieva compliance monitoring. To manage your notification preferences, visit your account settings.
+    </p>
+  </div>
+</body>
+</html>`;
+}
+
+function buildWeeklyDigestHtml({ toName, items }) {
+  const dashboardUrl = `${FRONTEND_URL}/workspaces`;
+  const statusBadge = {
+    green: 'background:#dcfce7;color:#166534;',
+    amber: 'background:#fef9c3;color:#854d0e;',
+    red: 'background:#fee2e2;color:#991b1b;',
+  };
+
+  const rows = items
+    .map((item) => {
+      const badge = item.status
+        ? `<span style="display:inline-block;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;${statusBadge[item.status]}">${item.score ?? '—'}</span>`
+        : '<span style="color:#94a3b8;font-size:13px;">No assessments</span>';
+
+      const trendStr =
+        item.trend > 0
+          ? `<span style="color:#16a34a;font-size:12px;">▲ +${item.trend}</span>`
+          : item.trend < 0
+            ? `<span style="color:#dc2626;font-size:12px;">▼ ${item.trend}</span>`
+            : '';
+
+      const reviewAlert = item.reviewDue
+        ? `<br><span style="color:#d97706;font-size:12px;">⚠ Review due ${item.reviewDue}</span>`
+        : '';
+
+      const link = `${FRONTEND_URL}/workspaces/${item.workspaceId}`;
+
+      return `<tr>
+      <td style="padding:12px 8px;border-bottom:1px solid #f1f5f9;">
+        <a href="${link}" style="color:#0f172a;font-weight:600;text-decoration:none;">${item.workspaceName}</a>${reviewAlert}
+      </td>
+      <td style="padding:12px 8px;border-bottom:1px solid #f1f5f9;text-align:center;">${badge} ${trendStr}</td>
+    </tr>`;
+    })
+    .join('');
+
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;line-height:1.6;color:#1a1a1a;max-width:600px;margin:0 auto;padding:20px;">
+  <div style="border-bottom:3px solid #0f172a;padding-bottom:16px;margin-bottom:24px;">
+    <span style="font-weight:700;font-size:18px;color:#0f172a;">Retrieva</span>
+    <span style="font-size:12px;color:#64748b;margin-left:8px;">Weekly Compliance Digest</span>
+  </div>
+
+  <p style="margin:0 0 16px;">Hi ${toName || 'there'},</p>
+  <p style="margin:0 0 20px;">Here's your weekly summary of vendor compliance scores across your workspaces.</p>
+
+  <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
+    <thead>
+      <tr style="background:#f8fafc;">
+        <th style="padding:10px 8px;text-align:left;font-size:12px;color:#64748b;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;">Vendor</th>
+        <th style="padding:10px 8px;text-align:center;font-size:12px;color:#64748b;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;">Score</th>
+      </tr>
+    </thead>
+    <tbody>${rows}</tbody>
+  </table>
+
+  <div style="text-align:center;margin:32px 0;">
+    <a href="${dashboardUrl}" style="display:inline-block;background:#0f172a;color:#ffffff;text-decoration:none;padding:14px 32px;border-radius:6px;font-weight:600;font-size:15px;">
+      Open Retrieva
+    </a>
+  </div>
+
+  <div style="border-top:1px solid #e2e8f0;margin-top:32px;padding-top:16px;">
+    <p style="font-size:12px;color:#94a3b8;margin:0;">
+      You receive this digest because you own one or more vendor workspaces on Retrieva.
+      To opt out, update your notification preferences in account settings.
     </p>
   </div>
 </body>
@@ -427,6 +502,12 @@ const local = {
     };
     const subject = subjects[alertType] || `Compliance Alert — ${workspaceName}`;
     const html = buildMonitoringAlertHtml({ toName, workspaceName, alertType, details });
+    return _sendEmailInProcess({ to: toEmail, subject, html });
+  },
+
+  async sendWeeklyDigest({ toEmail, toName, items }) {
+    const subject = `Your weekly DORA compliance digest — ${new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long' })}`;
+    const html = buildWeeklyDigestHtml({ toName, items });
     return _sendEmailInProcess({ to: toEmail, subject, html });
   },
 

--- a/backend/services/gapAnalysisAgent.js
+++ b/backend/services/gapAnalysisAgent.js
@@ -65,6 +65,13 @@ function getQdrantClient() {
 
 const gapItemSchema = z.object({
   article: z.string().describe('DORA article reference, e.g. "Article 30(3)(e)"'),
+  rtsReference: z
+    .string()
+    .optional()
+    .default('')
+    .describe(
+      'Specific RTS/ITS reference where applicable, e.g. "JC 2023 86 (Subcontracting RTS)" or "Commission Delegated Regulation 2024/1774 (ICT Risk Management RTS)". Leave empty if no RTS/ITS applies.'
+    ),
   domain: z
     .enum([
       'General Provisions',

--- a/backend/services/gapAnalysisAgent.js
+++ b/backend/services/gapAnalysisAgent.js
@@ -67,10 +67,8 @@ const gapItemSchema = z.object({
   article: z.string().describe('DORA article reference, e.g. "Article 30(3)(e)"'),
   rtsReference: z
     .string()
-    .optional()
-    .default('')
     .describe(
-      'Specific RTS/ITS reference where applicable, e.g. "JC 2023 86 (Subcontracting RTS)" or "Commission Delegated Regulation 2024/1774 (ICT Risk Management RTS)". Leave empty if no RTS/ITS applies.'
+      'Specific RTS/ITS reference where applicable, e.g. "JC 2023 86 (Subcontracting RTS)" or "Commission Delegated Regulation 2024/1774 (ICT Risk Management RTS)". Use empty string when no RTS/ITS applies.'
     ),
   domain: z
     .enum([

--- a/backend/tests/unittest/alertMonitorService.test.js
+++ b/backend/tests/unittest/alertMonitorService.test.js
@@ -43,17 +43,26 @@ vi.mock('../../models/WorkspaceMember.js', () => ({
   },
 }));
 
+vi.mock('../../models/User.js', () => ({
+  User: {
+    findById: vi.fn(),
+  },
+}));
+
 vi.mock('../../services/emailService.js', () => ({
   default: {
     sendMonitoringAlert: vi.fn(),
+    sendWeeklyDigest: vi.fn(),
   },
 }));
 
 import {
   runMonitoringAlerts,
   sendReviewReminderAlert,
+  runWeeklyDigest,
 } from '../../services/alertMonitorService.js';
 import { WorkspaceMember } from '../../models/WorkspaceMember.js';
+import { User } from '../../models/User.js';
 import emailService from '../../services/emailService.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -460,5 +469,93 @@ describe('sendReviewReminderAlert', () => {
         details: expect.objectContaining({ reviewDate: 'soon' }),
       })
     );
+  });
+});
+
+// ─── runWeeklyDigest ──────────────────────────────────────────────────────────
+
+describe('runWeeklyDigest', () => {
+  const userId = 'user-1';
+  const wsId = 'ws-1';
+
+  beforeEach(() => {
+    WorkspaceMember.aggregate = vi.fn();
+    mockAssessmentRepo.getComplianceScore = vi.fn();
+  });
+
+  it('sends weekly digest to each owner with workspace scores', async () => {
+    WorkspaceMember.aggregate.mockResolvedValue([{ _id: userId, workspaceIds: [wsId] }]);
+    User.findById.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue({
+          email: 'owner@example.com',
+          name: 'Owner',
+          notificationPreferences: {},
+        }),
+      }),
+    });
+    mockWorkspaceRepo.find.mockResolvedValue([
+      { _id: wsId, workspaceName: 'Test Vendor', nextReviewDate: null },
+    ]);
+    mockAssessmentRepo.getComplianceScore.mockResolvedValue({
+      score: 80,
+      trend: 5,
+      status: 'green',
+    });
+
+    await runWeeklyDigest();
+
+    expect(emailService.sendWeeklyDigest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toEmail: 'owner@example.com',
+        items: expect.arrayContaining([
+          expect.objectContaining({ workspaceName: 'Test Vendor', score: 80 }),
+        ]),
+      })
+    );
+  });
+
+  it('skips owner who opted out of weekly digest', async () => {
+    WorkspaceMember.aggregate.mockResolvedValue([{ _id: userId, workspaceIds: [wsId] }]);
+    User.findById.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue({
+          email: 'owner@example.com',
+          name: 'Owner',
+          notificationPreferences: { email: { weekly_digest: false } },
+        }),
+      }),
+    });
+
+    await runWeeklyDigest();
+
+    expect(emailService.sendWeeklyDigest).not.toHaveBeenCalled();
+  });
+
+  it('skips owner when user not found', async () => {
+    WorkspaceMember.aggregate.mockResolvedValue([{ _id: userId, workspaceIds: [wsId] }]);
+    User.findById.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue(null),
+      }),
+    });
+
+    await runWeeklyDigest();
+
+    expect(emailService.sendWeeklyDigest).not.toHaveBeenCalled();
+  });
+
+  it('skips owner when no workspaces found', async () => {
+    WorkspaceMember.aggregate.mockResolvedValue([{ _id: userId, workspaceIds: [wsId] }]);
+    User.findById.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue({ email: 'owner@example.com', name: 'Owner' }),
+      }),
+    });
+    mockWorkspaceRepo.find.mockResolvedValue([]);
+
+    await runWeeklyDigest();
+
+    expect(emailService.sendWeeklyDigest).not.toHaveBeenCalled();
   });
 });

--- a/backend/tests/unittest/emailService.test.js
+++ b/backend/tests/unittest/emailService.test.js
@@ -509,6 +509,51 @@ describe('buildMonitoringAlertHtml content', () => {
   });
 });
 
+// ─── sendWeeklyDigest (local path) ───────────────────────────────────────────
+
+describe('sendWeeklyDigest', () => {
+  beforeEach(() => {
+    mockResendSend.mockResolvedValue({ data: { id: 'msg-digest' }, error: null });
+  });
+
+  it('sends email with score table in subject and body', async () => {
+    const items = [
+      {
+        workspaceId: 'ws-1',
+        workspaceName: 'Acme',
+        score: 85,
+        trend: 3,
+        status: 'green',
+        reviewDue: null,
+      },
+      {
+        workspaceId: 'ws-2',
+        workspaceName: 'Beta Corp',
+        score: 55,
+        trend: -5,
+        status: 'red',
+        reviewDue: '1 Jun 2026',
+      },
+    ];
+    await emailService.sendWeeklyDigest({ toEmail: 'owner@example.com', toName: 'Alice', items });
+    const call = mockResendSend.mock.calls[0][0];
+    expect(call.to).toBe('owner@example.com');
+    expect(call.subject).toContain('weekly');
+    expect(call.html).toContain('Acme');
+    expect(call.html).toContain('Beta Corp');
+  });
+
+  it('handles empty items array without throwing', async () => {
+    await emailService.sendWeeklyDigest({
+      toEmail: 'owner@example.com',
+      toName: 'Alice',
+      items: [],
+    });
+    const call = mockResendSend.mock.calls[0][0];
+    expect(call.html).toBeDefined();
+  });
+});
+
 // ─── Remote path (EMAIL_SERVICE_URL configured) ───────────────────────────────
 
 describe('remote path (EMAIL_SERVICE_URL set)', () => {
@@ -590,6 +635,16 @@ describe('remote path (EMAIL_SERVICE_URL set)', () => {
     expect(mockInternalPost).toHaveBeenCalledWith(
       'http://email-service:3001',
       '/internal/email/workspace-invitation',
+      payload
+    );
+  });
+
+  it('sendWeeklyDigest delegates to /internal/email/weekly-digest', async () => {
+    const payload = { toEmail: 'alice@example.com', toName: 'Alice', items: [] };
+    await remoteService.sendWeeklyDigest(payload);
+    expect(mockInternalPost).toHaveBeenCalledWith(
+      'http://email-service:3001',
+      '/internal/email/weekly-digest',
       payload
     );
   });

--- a/backend/workers/monitoringWorker.js
+++ b/backend/workers/monitoringWorker.js
@@ -7,7 +7,11 @@
 
 import { Worker } from 'bullmq';
 import { redisConnection } from '../config/redis.js';
-import { runMonitoringAlerts, sendReviewReminderAlert } from '../services/alertMonitorService.js';
+import {
+  runMonitoringAlerts,
+  runWeeklyDigest,
+  sendReviewReminderAlert,
+} from '../services/alertMonitorService.js';
 import logger from '../config/logger.js';
 
 const worker = new Worker(
@@ -16,6 +20,10 @@ const worker = new Worker(
     if (job.name === 'run-monitoring-alerts') {
       logger.info('Running monitoring alerts', { service: 'monitoringWorker', jobId: job.id });
       await runMonitoringAlerts();
+      return { ran: true, timestamp: new Date().toISOString() };
+    } else if (job.name === 'send-weekly-digest') {
+      logger.info('Running weekly digest', { service: 'monitoringWorker', jobId: job.id });
+      await runWeeklyDigest();
       return { ran: true, timestamp: new Date().toISOString() };
     } else if (job.name === 'review-reminder') {
       logger.info('Sending review reminder', {

--- a/frontend/src/features/workspaces/api/workspaces.ts
+++ b/frontend/src/features/workspaces/api/workspaces.ts
@@ -51,6 +51,13 @@ export interface UpdateMemberData {
   permissions?: Partial<WorkspacePermissions>;
 }
 
+export interface ComplianceScore {
+  score: number;
+  trend: number;
+  status: 'green' | 'amber' | 'red';
+  assessmentCount: number;
+}
+
 function normalizeWorkspace(workspace: WorkspaceApiResponse): WorkspaceWithMembership {
   const workspaceId = workspace.id || workspace._id || '';
   const workspaceName = workspace.workspaceName || workspace.name || '';
@@ -219,5 +226,12 @@ export const workspacesApi = {
     link.click();
     link.remove();
     window.URL.revokeObjectURL(url);
+  },
+
+  getComplianceScore: async (workspaceId: string) => {
+    const response = await apiClient.get<
+      ApiResponse<{ score: ComplianceScore | null }>
+    >(`/workspaces/${workspaceId}/compliance-score`);
+    return response.data.data?.score ?? null;
   },
 };

--- a/frontend/src/features/workspaces/components/compliance-score-card.tsx
+++ b/frontend/src/features/workspaces/components/compliance-score-card.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
+import type { ComplianceScore } from '@/features/workspaces/api/workspaces';
+
+interface ComplianceScoreCardProps {
+  score: ComplianceScore | null;
+}
+
+const STATUS_STYLES = {
+  green: 'text-green-700 bg-green-50 border-green-200',
+  amber: 'text-amber-700 bg-amber-50 border-amber-200',
+  red: 'text-red-700 bg-red-50 border-red-200',
+} as const;
+
+const STATUS_LABEL = {
+  green: 'Good',
+  amber: 'Needs attention',
+  red: 'At risk',
+} as const;
+
+export function ComplianceScoreCard({ score }: ComplianceScoreCardProps) {
+  if (!score) return null;
+
+  const TrendIcon = score.trend > 0 ? TrendingUp : score.trend < 0 ? TrendingDown : Minus;
+  const trendColor =
+    score.trend > 0
+      ? 'text-green-600'
+      : score.trend < 0
+        ? 'text-red-600'
+        : 'text-muted-foreground';
+  const trendLabel =
+    score.trend > 0
+      ? `+${score.trend} pts`
+      : score.trend < 0
+        ? `${score.trend} pts`
+        : 'No change';
+
+  return (
+    <Card className="mb-4">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+          Portfolio Compliance Score
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-4">
+          <div
+            className={`text-4xl font-bold tabular-nums px-4 py-2 rounded-md border ${STATUS_STYLES[score.status]}`}
+          >
+            {score.score}
+          </div>
+          <div className="space-y-1">
+            <span
+              className={`text-xs font-semibold px-2 py-0.5 rounded-full border ${STATUS_STYLES[score.status]}`}
+            >
+              {STATUS_LABEL[score.status]}
+            </span>
+            <div className={`flex items-center gap-1 text-sm font-medium ${trendColor}`}>
+              <TrendIcon className="h-3.5 w-3.5" />
+              {trendLabel} vs 30 days ago
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {score.assessmentCount} completed assessment
+              {score.assessmentCount !== 1 ? 's' : ''}
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/workspaces/components/workspace-overview-page.tsx
+++ b/frontend/src/features/workspaces/components/workspace-overview-page.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { Skeleton } from '@/shared/ui/skeleton';
 import { ComplianceChecklistCard } from '@/features/workspaces/components/compliance-checklist-card';
+import { ComplianceScoreCard } from '@/features/workspaces/components/compliance-score-card';
 import { MonitoringCard } from '@/features/workspaces/components/monitoring-card';
 import { WorkspaceAssessmentsCard } from '@/features/workspaces/components/workspace-assessments-card';
 import { WorkspaceHeader } from '@/features/workspaces/components/workspace-header';
@@ -37,6 +38,7 @@ export function WorkspaceOverviewPage({ params }: WorkspaceOverviewPageProps) {
     isAssessmentsLoading,
     isAssessmentsError,
     questionnaires,
+    complianceScore,
   } = useWorkspaceOverview(id);
 
   if (!workspace && isWorkspaceLoading) {
@@ -78,6 +80,8 @@ export function WorkspaceOverviewPage({ params }: WorkspaceOverviewPageProps) {
       </Link>
 
       <WorkspaceHeader workspace={workspace} workspaceId={id} isOwner={isOwner} />
+
+      <ComplianceScoreCard score={complianceScore} />
 
       <ComplianceChecklistCard
         workspace={workspace}

--- a/frontend/src/features/workspaces/hooks/use-workspace-overview.ts
+++ b/frontend/src/features/workspaces/hooks/use-workspace-overview.ts
@@ -1,10 +1,12 @@
 'use client';
 
 import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { useAssessmentListQuery } from '@/features/assessments/queries/use-assessment-list-query';
 import { useQuestionnaireListQuery } from '@/features/questionnaires/queries/use-questionnaire-list-query';
 import { useWorkspaceQuery } from '@/features/workspaces/queries/use-workspace-queries';
+import { workspacesApi } from '@/features/workspaces/api/workspaces';
 import { useWorkspaceStore } from '@/state/workspace-store';
 
 export function useWorkspaceOverview(workspaceId: string) {
@@ -24,6 +26,12 @@ export function useWorkspaceOverview(workspaceId: string) {
     refetchWhileProcessing: true,
   });
   const questionnairesQuery = useQuestionnaireListQuery({ workspaceId });
+  const complianceScoreQuery = useQuery({
+    queryKey: ['compliance-score', workspaceId],
+    queryFn: () => workspacesApi.getComplianceScore(workspaceId),
+    enabled: !!workspaceId,
+    staleTime: 5 * 60 * 1000,
+  });
 
   return {
     workspace: workspaceQuery.data,
@@ -32,5 +40,6 @@ export function useWorkspaceOverview(workspaceId: string) {
     isAssessmentsLoading: assessmentsQuery.isLoading,
     isAssessmentsError: assessmentsQuery.isError,
     questionnaires: questionnairesQuery.data ?? [],
+    complianceScore: complianceScoreQuery.data ?? null,
   };
 }


### PR DESCRIPTION
## Summary

- **Portfolio compliance score** (closes #161): new `GET /:workspaceId/compliance-score` endpoint aggregates completed DORA assessments into a 0-100 score with RAG status (green/amber/red) and 30-day trend. Displayed on the workspace overview page via `ComplianceScoreCard`.
- **Weekly digest email** (closes #163): `runWeeklyDigest()` in `alertMonitorService` sends a per-owner summary of all their workspaces (score, trend, upcoming review dates). Scheduled via BullMQ repeatable job every 7 days. Respects `weekly_digest` notification preference opt-out.
- **RTS article mapping** (closes #164): gap analysis output now includes `rtsReference` field (e.g. "JC 2023 86 (Subcontracting RTS)"). LLM prompt instructs the model to cite the specific RTS/ITS regulation per gap entry. Field added to `Assessment.gapSchema` and surfaced through the gap analysis agent.

## Test plan

- [ ] CI passes (backend unit + integration + frontend)
- [ ] Workspace overview page shows compliance score card when assessments exist
- [ ] Score card shows correct RAG colour: green ≥ 80, amber ≥ 60, red < 60
- [ ] Weekly digest job appears in BullMQ dashboard after server start
- [ ] Completed gap analysis entries include `rtsReference` populated by LLM