### PR TITLE
test: add coverage for getVectorSize to fix CI threshold

### DIFF
--- a/backend/services/fileIngestionService.js
+++ b/backend/services/fileIngestionService.js
@@ -14,14 +14,11 @@ import logger from '../config/logger.js';
 const QDRANT_URL = process.env.QDRANT_URL || 'http://localhost:6333';
 const QDRANT_API_KEY = process.env.QDRANT_API_KEY;
 
-// Determine vector size based on embedding model
-// bge-m3 = 1024, text-embedding-3-small = 1536
-function getVectorSize() {
-  const model = process.env.EMBEDDING_MODEL || 'bge-m3:latest';
+export function getVectorSize(model = process.env.EMBEDDING_MODEL || 'bge-m3:latest') {
   if (model.includes('bge-m3')) return 1024;
   if (model.includes('text-embedding-3')) return 1536;
   if (model.includes('nomic')) return 768;
-  return 1024; // default to bge-m3 dimension
+  return 1024;
 }
 
 const VECTOR_SIZE = getVectorSize();

--- a/backend/tests/unittest/fileIngestionService.unit.test.js
+++ b/backend/tests/unittest/fileIngestionService.unit.test.js
@@ -4,7 +4,28 @@ import {
   assessmentCollectionName,
   createFileIngestionService,
   fileIngestionService,
+  getVectorSize,
 } from '../../services/fileIngestionService.js';
+
+describe('getVectorSize', () => {
+  it('returns 1024 for bge-m3 models', () => {
+    expect(getVectorSize('bge-m3:latest')).toBe(1024);
+    expect(getVectorSize('bge-m3')).toBe(1024);
+  });
+
+  it('returns 1536 for text-embedding-3 models', () => {
+    expect(getVectorSize('text-embedding-3-small')).toBe(1536);
+    expect(getVectorSize('text-embedding-3-large')).toBe(1536);
+  });
+
+  it('returns 768 for nomic models', () => {
+    expect(getVectorSize('nomic-embed-text')).toBe(768);
+  });
+
+  it('returns 1024 default for unknown models', () => {
+    expect(getVectorSize('unknown-model')).toBe(1024);
+  });
+});
 
 // ─── assessmentCollectionName ─────────────────────────────────────────────────
 


### PR DESCRIPTION
Adds 4 unit tests for the getVectorSize helper to bring branch coverage back above 82% threshold.