### PR TITLE
release: prod e2e fixes — rag stream, nav, embeddings, idempotency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ CLAUDE.md
 
 # Local test process materials (PDFs, templates, test runs)
 testprocess/
+.playwright-mcp/

--- a/backend/config/embeddingProvider.js
+++ b/backend/config/embeddingProvider.js
@@ -8,7 +8,12 @@ import logger from './logger.js';
 // =============================================================================
 
 // Configuration
-const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || 'https://ollama.com';
+// Embeddings use a dedicated env var so they can run against a separate (typically
+// self-hosted) Ollama instance even when the chat LLM points at Ollama Cloud.
+const OLLAMA_BASE_URL =
+  process.env.EMBEDDING_OLLAMA_BASE_URL ||
+  process.env.OLLAMA_BASE_URL ||
+  'http://localhost:11434';
 const OLLAMA_MODEL = process.env.EMBEDDING_MODEL || 'bge-m3:latest';
 const OPENAI_MODEL = process.env.OPENAI_EMBEDDING_MODEL || 'text-embedding-3-small';
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;

--- a/backend/config/embeddings.js
+++ b/backend/config/embeddings.js
@@ -14,7 +14,12 @@ const EMBEDDING_MODEL = process.env.EMBEDDING_MODEL || 'bge-m3:latest';
 const EMBEDDING_PROVIDER = process.env.EMBEDDING_PROVIDER || 'ollama';
 
 // Ollama configuration
-const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+// Embeddings prefer a dedicated env var so they can target a self-hosted Ollama
+// while the chat LLM uses Ollama Cloud.
+const OLLAMA_BASE_URL =
+  process.env.EMBEDDING_OLLAMA_BASE_URL ||
+  process.env.OLLAMA_BASE_URL ||
+  'http://localhost:11434';
 const OLLAMA_API_KEY =
   process.env.OLLAMA_API_KEY_1 || process.env.OLLAMA_API_KEY_2 || process.env.OLLAMA_API_KEY_3;
 const OLLAMA_AUTH_HEADERS = OLLAMA_API_KEY

--- a/backend/controllers/ragController.js
+++ b/backend/controllers/ragController.js
@@ -1,5 +1,6 @@
 import { executeRAG, InputGuardrailError } from '../services/ragExecutor.js';
 import { catchAsync, sendSuccess, sendError } from '../utils/index.js';
+import logger from '../config/logger.js';
 
 /**
  * POST /api/v1/rag — JSON transport
@@ -32,5 +33,59 @@ export const askQuestion = catchAsync(async (req, res) => {
       return sendError(res, 400, error.message);
     }
     throw error;
+  }
+});
+
+/**
+ * POST /api/v1/rag/stream — SSE transport
+ *
+ * Streams RAG events as Server-Sent Events. Same business logic as askQuestion
+ * (delegates to executeRAG with an onEvent callback) but pipes each event to
+ * the client as `event: <type>\ndata: <json>\n\n` so the UI can render tokens
+ * progressively.
+ */
+export const askQuestionStream = catchAsync(async (req, res) => {
+  const { question, conversationId, filters, useIntentAware = true, forceIntent } = req.body;
+
+  if (!conversationId) {
+    return sendError(res, 400, 'conversationId is required');
+  }
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders?.();
+
+  let closed = false;
+  const send = (event, data) => {
+    if (closed || res.writableEnded) return;
+    res.write(`event: ${event}\n`);
+    res.write(`data: ${JSON.stringify(data)}\n\n`);
+  };
+
+  req.on('close', () => {
+    closed = true;
+  });
+
+  try {
+    await executeRAG({
+      question,
+      conversationId,
+      filters: filters || null,
+      userId: req.user?.userId?.toString(),
+      forceIntent: forceIntent || null,
+      useIntentAware,
+      onEvent: send,
+    });
+  } catch (error) {
+    if (error instanceof InputGuardrailError) {
+      send('error', { message: error.message, code: 'INPUT_GUARDRAIL' });
+    } else {
+      logger.error('RAG stream failed', { error: error.message, stack: error.stack });
+      send('error', { message: 'Stream failed', code: 'STREAM_ERROR' });
+    }
+  } finally {
+    if (!res.writableEnded) res.end();
   }
 });

--- a/backend/models/Conversation.js
+++ b/backend/models/Conversation.js
@@ -67,10 +67,17 @@ conversationSchema.index({ userId: 1, updatedAt: -1 });
 conversationSchema.index({ workspaceId: 1, userId: 1, updatedAt: -1 });
 
 // ISSUE #25 FIX: Compound unique index for idempotency key lookups
-// Ensures only one conversation per user+workspace+idempotencyKey combination
+// Ensures only one conversation per user+workspace+idempotencyKey combination.
+// Use partialFilterExpression instead of sparse: { sparse: true } only skips
+// documents missing the field entirely, but Mongoose stores `null` for absent
+// nested keys, which then collide as duplicates. Restrict the unique index to
+// rows where the key is actually a string.
 conversationSchema.index(
   { userId: 1, workspaceId: 1, 'metadata.idempotencyKey': 1 },
-  { unique: true, sparse: true }
+  {
+    unique: true,
+    partialFilterExpression: { 'metadata.idempotencyKey': { $type: 'string' } },
+  }
 );
 
 // Update lastMessageAt when conversation is modified

--- a/backend/routes/ragRoutes.js
+++ b/backend/routes/ragRoutes.js
@@ -1,9 +1,9 @@
 import express from 'express';
-import { askQuestion } from '../controllers/ragController.js';
+import { askQuestion, askQuestionStream } from '../controllers/ragController.js';
 import { validateBody } from '../middleware/validate.js';
 import { authenticate } from '../middleware/auth.js';
 import { requireWorkspaceAccess } from '../middleware/workspaceAuth.js';
-import { askQuestionSchema } from '../validators/schemas.js';
+import { askQuestionSchema, streamQuestionSchema } from '../validators/schemas.js';
 import { ragQueryLimiter, ragBurstLimiter } from '../middleware/ragRateLimiter.js';
 
 const router = express.Router();
@@ -21,6 +21,21 @@ router.post(
   ragQueryLimiter,
   validateBody(askQuestionSchema),
   askQuestion
+);
+
+/**
+ * @route   POST /api/v1/rag/stream
+ * @desc    Ask a question and stream the answer over SSE
+ * @access  Private - requires authentication AND workspace membership
+ */
+router.post(
+  '/rag/stream',
+  authenticate,
+  requireWorkspaceAccess,
+  ragBurstLimiter,
+  ragQueryLimiter,
+  validateBody(streamQuestionSchema),
+  askQuestionStream
 );
 
 export { router as ragRoutes };

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -136,7 +136,7 @@ services:
       resources:
         limits:
           cpus: '2'
-          memory: 2560M
+          memory: 4G
     logging:
       driver: "json-file"
       options:

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -15,7 +15,6 @@ const PAGE_TITLES: Record<string, string> = {
   '/assessments':         'Gap Analysis',
   '/questionnaires':      'Questionnaires',
   '/chat':                'Ask AI',
-  '/sources':             'Documents',
   '/conversations':       'Conversation History',
   '/settings':            'Settings',
   '/settings/security':   'Security',

--- a/frontend/src/shared/constants/nav-items.ts
+++ b/frontend/src/shared/constants/nav-items.ts
@@ -1,7 +1,6 @@
 import {
   MessageSquare,
   FolderOpen,
-  Database,
   Settings,
   Building2,
   ShieldCheck,
@@ -36,7 +35,6 @@ export const desktopNavSections: NavSection[] = [
     label: 'Intelligence',
     items: [
       { title: 'Ask AI', href: '/chat', icon: MessageSquare },
-      { title: 'Documents', href: '/sources', icon: Database, workspaceRoles: ['owner', 'member'] },
       { title: 'History', href: '/conversations', icon: FolderOpen },
     ],
   },
@@ -49,7 +47,6 @@ export const mobileMainNavItems: NavItem[] = [
   { title: 'Gap Analysis', href: '/assessments', icon: ShieldCheck },
   { title: 'Questionnaires', href: '/questionnaires', icon: ClipboardList, workspaceRoles: ['owner', 'member'] },
   { title: 'Ask AI', href: '/chat', icon: MessageSquare },
-  { title: 'Documents', href: '/sources', icon: Database, workspaceRoles: ['owner', 'member'] },
   { title: 'History', href: '/conversations', icon: FolderOpen },
 ];
 


### PR DESCRIPTION
## Summary

Promotes `dev` to `main` with the production-blocking E2E fixes from PR #198:

- `POST /api/v1/rag/stream` SSE route (chat was 404'ing)
- Removed broken `/sources` Documents nav link
- Embeddings now read `EMBEDDING_OLLAMA_BASE_URL` so they hit the self-hosted ollama container while the chat LLM stays on Ollama Cloud
- Conversations idempotency unique index switched from `sparse` to `partialFilterExpression` (fixed E11000 on second conversation per workspace)
- Bumped prod ollama memory limit 2.5G → 4G so `bge-m3` loads without OOM

All fixes already verified end-to-end on retrieva.online (account `kanmegnea@gmail.com`): chat streams answers, all sidebar links resolve, AWS DORA gap analysis (`69f8634db1dbf340bb2ba581`) ran to completion with 15 gaps identified.

## Test plan
- [x] PR #198 CI green (lint + backend + frontend + e2e + docker build + security)
- [ ] CI green on this PR
- [ ] After merge: auto-deploy completes; smoke check chat answer + assessment list on `retrieva.online`
- [ ] Confirm prod env `LLM_MODEL`/`JUDGE_LLM_MODEL` is `gemma3:12b` (already applied on server, not in this PR)
