### PR TITLE
release: rag follow-up fixes (json parsing, analytics noop, sse events)

### DIFF
--- a/backend/services/answerFormatter.js
+++ b/backend/services/answerFormatter.js
@@ -3,6 +3,24 @@ import { StringOutputParser } from '@langchain/core/output_parsers';
 import { getDefaultLLM } from '../config/llm.js';
 import logger from '../config/logger.js';
 
+// Tolerant JSON-array parser. Strips markdown fences and any prose surrounding
+// the array, since not every model honours "ONLY a JSON array" (gemma3 often
+// prefixes "Here's a breakdown:" or "I'm sorry,"). Returns null if no array can
+// be recovered — the caller falls back to a heuristic.
+export function parseJsonArrayLoose(raw) {
+  if (typeof raw !== 'string') return null;
+  const stripped = raw.replace(/```json\s*/gi, '').replace(/```/g, '').trim();
+  const start = stripped.indexOf('[');
+  const end = stripped.lastIndexOf(']');
+  if (start === -1 || end === -1 || end <= start) return null;
+  try {
+    const parsed = JSON.parse(stripped.slice(start, end + 1));
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Enhanced Answer Formatting Service
  * Structures RAG answers into sections, extracts key points, code examples, and suggests related topics
@@ -40,9 +58,13 @@ Answer to analyze:
       [
         'system',
         `Extract 3-5 key points from the following answer.
-Return ONLY a JSON array of strings, each being a concise key point (max 80 chars each).
+Output rules — these are absolute:
+- Output MUST start with [ and end with ]
+- Output MUST be valid JSON (a flat array of strings)
+- Each string max 80 chars
+- No prose, no preface, no markdown fences, no trailing commentary
 
-Example: ["JWT provides stateless authentication", "Uses digital signatures for security", "Popular in modern web apps"]
+Example output: ["JWT provides stateless authentication","Uses digital signatures for security","Popular in modern web apps"]
 
 Answer:
 {answer}`,
@@ -56,9 +78,12 @@ Answer:
       [
         'system',
         `Based on the question and answer, suggest 3-4 related topics the user might want to explore.
-Return ONLY a JSON array of strings.
+Output rules — these are absolute:
+- Output MUST start with [ and end with ]
+- Output MUST be valid JSON (a flat array of strings)
+- No prose, no preface, no markdown fences, no trailing commentary
 
-Example: ["OAuth 2.0 authentication", "Session-based authentication", "JWT security best practices"]
+Example output: ["OAuth 2.0 authentication","Session-based authentication","JWT security best practices"]
 
 Question: {question}
 Answer: {answer}`,
@@ -135,13 +160,7 @@ Answer: {answer}`,
 
     try {
       const result = await this.keyPointsChain.invoke({ answer });
-
-      // Try to parse JSON
-      const cleaned = result
-        .replace(/```json\n?/g, '')
-        .replace(/```\n?/g, '')
-        .trim();
-      const keyPoints = JSON.parse(cleaned);
+      const keyPoints = parseJsonArrayLoose(result);
 
       if (Array.isArray(keyPoints) && keyPoints.length > 0) {
         logger.debug('Extracted key points', {
@@ -178,13 +197,7 @@ Answer: {answer}`,
 
     try {
       const result = await this.relatedTopicsChain.invoke({ question, answer });
-
-      // Try to parse JSON
-      const cleaned = result
-        .replace(/```json\n?/g, '')
-        .replace(/```\n?/g, '')
-        .trim();
-      const topics = JSON.parse(cleaned);
+      const topics = parseJsonArrayLoose(result);
 
       if (Array.isArray(topics) && topics.length > 0) {
         logger.debug('Suggested related topics', {

--- a/backend/services/rag.js
+++ b/backend/services/rag.js
@@ -864,7 +864,19 @@ class RAGService {
    * @returns {Function} Validated emit function
    */
   _createValidatedEmit(rawEmit) {
-    const validEventTypes = new Set(['status', 'chunk', 'sources', 'done', 'error', 'metadata']);
+    // Keep this in sync with the events the frontend useStreaming hook handles.
+    // `replace` lets the hallucination guard swap the streamed answer for a
+    // safe fallback; `saved` notifies the UI that messages have been persisted.
+    const validEventTypes = new Set([
+      'status',
+      'chunk',
+      'sources',
+      'done',
+      'error',
+      'metadata',
+      'replace',
+      'saved',
+    ]);
 
     const validatePayload = (type, data) => {
       if (typeof data !== 'object' || data === null) {
@@ -897,6 +909,16 @@ class RAGService {
           break;
         case 'metadata':
           // metadata can have arbitrary structure
+          break;
+        case 'replace':
+          if (typeof data.text !== 'string') {
+            return { valid: false, error: 'replace event requires text string' };
+          }
+          break;
+        case 'saved':
+          if (typeof data.conversationId !== 'string') {
+            return { valid: false, error: 'saved event requires conversationId string' };
+          }
           break;
       }
       return { valid: true };

--- a/backend/services/rag/analyticsTracker.js
+++ b/backend/services/rag/analyticsTracker.js
@@ -69,6 +69,13 @@ export async function trackQueryAnalytics({
   citedSources = [],
   conversationId = null,
 }) {
+  // Analytics persistence is currently disabled — callers pass Analytics: null.
+  // Skip cleanly so the noop doesn't crash with "Cannot read properties of null
+  // (reading 'create')". When the Analytics collection is reintroduced, callers
+  // can pass the model and tracking resumes automatically.
+  if (!Analytics || typeof Analytics.create !== 'function') {
+    return;
+  }
   try {
     const analyticsData = {
       requestId,

--- a/backend/tests/unittest/analyticsTrackerNoop.test.js
+++ b/backend/tests/unittest/analyticsTrackerNoop.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { trackQueryAnalytics } from '../../services/rag/analyticsTracker.js';
+
+const makeLogger = () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() });
+const makeCache = () => ({ getQuestionHash: () => 'hash' });
+
+describe('trackQueryAnalytics no-op guard', () => {
+  it('returns silently when Analytics model is null', async () => {
+    const logger = makeLogger();
+    await trackQueryAnalytics({
+      Analytics: null,
+      cache: makeCache(),
+      logger,
+      requestId: 'r1',
+      question: 'hi',
+      cacheHit: false,
+    });
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('returns silently when Analytics model lacks a create method', async () => {
+    const logger = makeLogger();
+    await trackQueryAnalytics({
+      Analytics: { somethingElse: () => {} },
+      cache: makeCache(),
+      logger,
+      requestId: 'r2',
+      question: 'hi',
+      cacheHit: true,
+    });
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('writes through when a valid Analytics model is provided', async () => {
+    const create = vi.fn().mockResolvedValue({});
+    const logger = makeLogger();
+    await trackQueryAnalytics({
+      Analytics: { create },
+      cache: makeCache(),
+      logger,
+      requestId: 'r3',
+      question: 'hi',
+      cacheHit: false,
+      citedSources: [{ url: 'u', title: 't', type: 'page' }],
+      conversationId: 'c1',
+    });
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('logs but does not throw when Analytics.create rejects', async () => {
+    const create = vi.fn().mockRejectedValue(new Error('db down'));
+    const logger = makeLogger();
+    await trackQueryAnalytics({
+      Analytics: { create },
+      cache: makeCache(),
+      logger,
+      requestId: 'r4',
+      question: 'hi',
+      cacheHit: false,
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      'Analytics tracking failed',
+      expect.any(Object)
+    );
+  });
+});

--- a/backend/tests/unittest/answerFormatterParser.test.js
+++ b/backend/tests/unittest/answerFormatterParser.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { parseJsonArrayLoose } from '../../services/answerFormatter.js';
+
+describe('parseJsonArrayLoose', () => {
+  it('parses a clean JSON array', () => {
+    const out = parseJsonArrayLoose('["a","b","c"]');
+    expect(out).toEqual(['a', 'b', 'c']);
+  });
+
+  it('strips a ```json fenced code block', () => {
+    const out = parseJsonArrayLoose('```json\n["x","y"]\n```');
+    expect(out).toEqual(['x', 'y']);
+  });
+
+  it('extracts the array even when the model wraps it in prose', () => {
+    const raw = "Here's a breakdown:\n[\"alpha\", \"beta\"]\nLet me know if you need more.";
+    expect(parseJsonArrayLoose(raw)).toEqual(['alpha', 'beta']);
+  });
+
+  it('extracts the array when the prose precedes it', () => {
+    const raw = 'I\'m sorry, but as requested: ["one","two","three"]';
+    expect(parseJsonArrayLoose(raw)).toEqual(['one', 'two', 'three']);
+  });
+
+  it('returns null when no array brackets are present', () => {
+    expect(parseJsonArrayLoose('just prose with no array')).toBeNull();
+  });
+
+  it('returns null on non-string input', () => {
+    expect(parseJsonArrayLoose(null)).toBeNull();
+    expect(parseJsonArrayLoose(42)).toBeNull();
+  });
+
+  it('returns null when bracketed content is not valid JSON', () => {
+    expect(parseJsonArrayLoose('[not, valid, json]')).toBeNull();
+  });
+
+  it('returns null when the JSON parses to a non-array', () => {
+    expect(parseJsonArrayLoose('{"a":1}')).toBeNull();
+  });
+});

--- a/backend/tests/unittest/ragService.test.js
+++ b/backend/tests/unittest/ragService.test.js
@@ -330,6 +330,44 @@ describe('_createValidatedEmit', () => {
       expect.any(Object)
     );
   });
+
+  it('forwards valid "replace" event (hallucination fallback)', () => {
+    const rawEmit = vi.fn();
+    const emit = svc._createValidatedEmit(rawEmit);
+    emit('replace', { text: 'safer answer' });
+    expect(rawEmit).toHaveBeenCalledWith(
+      'replace',
+      expect.objectContaining({ text: 'safer answer' })
+    );
+  });
+
+  it('blocks "replace" event with missing text field', () => {
+    const rawEmit = vi.fn();
+    const emit = svc._createValidatedEmit(rawEmit);
+    emit('replace', { wrong: true });
+    expect(rawEmit).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Invalid streaming event payload',
+      expect.any(Object)
+    );
+  });
+
+  it('forwards valid "saved" event (persistence ack)', () => {
+    const rawEmit = vi.fn();
+    const emit = svc._createValidatedEmit(rawEmit);
+    emit('saved', { conversationId: 'abc123' });
+    expect(rawEmit).toHaveBeenCalledWith(
+      'saved',
+      expect.objectContaining({ conversationId: 'abc123' })
+    );
+  });
+
+  it('blocks "saved" event without conversationId', () => {
+    const rawEmit = vi.fn();
+    const emit = svc._createValidatedEmit(rawEmit);
+    emit('saved', {});
+    expect(rawEmit).not.toHaveBeenCalled();
+  });
 });
 
 // ─── _rephraseQuery ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Promotes #202 to main. Hardens the RAG path after gemma3:12b: tolerant JSON parsing in answer formatter, analytics tracker noop when no model wired, accepts replace + saved on SSE allow-list, plus tests for all new branches.