### PR TITLE
release: rag fix #229 — chat retrieves from compliance_kb (DORA articles)

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -84,8 +84,16 @@ export default [
     ignores: ['node_modules/**', 'coverage/**', 'dist/**', 'build/**', '*.min.js'],
   },
   {
-    // console.* is the intended output mechanism in these files
-    files: ['instrument.js', 'scripts/**', 'seeds/**', 'utils/rag/qdrantExplorer.js', 'tests/**'],
+    // console.* is the intended output mechanism in these files.
+    // Patterns match both bare (eslint run from backend/) and prefixed
+    // (lint-staged passing absolute paths from repo root) invocations.
+    files: [
+      '**/instrument.js',
+      '**/scripts/**',
+      '**/seeds/**',
+      '**/utils/rag/qdrantExplorer.js',
+      '**/tests/**',
+    ],
     rules: { 'no-console': 'off' },
   },
 ];

--- a/backend/scripts/seedComplianceKb.js
+++ b/backend/scripts/seedComplianceKb.js
@@ -35,7 +35,19 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const QDRANT_URL = process.env.QDRANT_URL || 'http://localhost:6333';
 const QDRANT_API_KEY = process.env.QDRANT_API_KEY;
 export const COMPLIANCE_KB_COLLECTION = 'compliance_kb';
-const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || 'https://ollama.com';
+// Embeddings prefer the dedicated EMBEDDING_OLLAMA_BASE_URL so a self-hosted
+// embedding endpoint can be used while chat goes through Ollama Cloud.
+// Matches the precedence in backend/config/embeddings.js.
+const OLLAMA_BASE_URL =
+  process.env.EMBEDDING_OLLAMA_BASE_URL || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+const OLLAMA_API_KEY =
+  process.env.OLLAMA_API_KEY_1 ||
+  process.env.OLLAMA_API_KEY_2 ||
+  process.env.OLLAMA_API_KEY_3 ||
+  process.env.OLLAMA_API_KEY;
+const OLLAMA_AUTH_HEADERS = OLLAMA_API_KEY
+  ? { Authorization: `Bearer ${OLLAMA_API_KEY}` }
+  : undefined;
 const EMBEDDING_MODEL = process.env.EMBEDDING_MODEL || 'bge-m3:latest';
 const VECTOR_SIZE = 1024; // bge-m3 output dimension
 
@@ -53,6 +65,7 @@ function getEmbeddings() {
   return new OllamaEmbeddings({
     model: EMBEDDING_MODEL,
     baseUrl: OLLAMA_BASE_URL,
+    headers: OLLAMA_AUTH_HEADERS,
   });
 }
 

--- a/backend/services/rag.js
+++ b/backend/services/rag.js
@@ -18,7 +18,12 @@ import {
 import { rerankDocuments } from './rag/documentRanking.js';
 import { evaluateAnswer, extractCitedSources, toValidationResult } from './rag/llmJudge.js';
 import { compressDocuments, initChains } from './rag/retrievalEnhancements.js';
-import { formatContext, formatSources } from '../utils/rag/contextFormatter.js';
+import {
+  formatContext,
+  formatSources,
+  deduplicateDocuments,
+} from '../utils/rag/contextFormatter.js';
+import { retrieveRegulationDocs as defaultRetrieveRegulationDocs } from './rag/complianceKbRetriever.js';
 import { sanitizeDocuments, sanitizeFormattedContext } from '../utils/security/contextSanitizer.js';
 import { sanitizeLLMOutput } from '../utils/security/outputSanitizer.js';
 import { scanOutputForSensitiveInfo } from '../utils/security/piiMasker.js';
@@ -120,6 +125,8 @@ class RAGService {
     this._injectedLLM = dependencies.llm || null;
     this.llm = null; // Will be set during init()
     this.vectorStoreFactory = dependencies.vectorStoreFactory || defaultVectorStoreFactory;
+    this.retrieveRegulationDocs =
+      dependencies.retrieveRegulationDocs || defaultRetrieveRegulationDocs;
     this.cache = dependencies.cache || defaultCache;
     this.answerFormatter = dependencies.answerFormatter || defaultAnswerFormatter;
     this.logger = dependencies.logger || defaultLogger;
@@ -520,16 +527,49 @@ class RAGService {
       throw error;
     }
 
-    // Direct vector store retrieval
-    const rawDocs = await this.vectorStore.similaritySearch(searchQuery, 15, qdrantFilter);
-    const rerankedDocs = rerankDocuments(rawDocs, searchQuery, 15);
+    // Direct vector store retrieval — fan out to vendor (workspace-scoped)
+    // and regulation (shared compliance_kb) collections in parallel.
+    // Issue #206: chat must see DORA article text, not just uploaded vendor docs.
+    // Use allSettled so one collection's failure (e.g. embedding-dim drift,
+    // unseeded compliance_kb) doesn't take down the other.
+    const [vendorResult, regulationResult] = await Promise.allSettled([
+      this.vectorStore.similaritySearch(searchQuery, 15, qdrantFilter),
+      this.retrieveRegulationDocs(searchQuery, 5),
+    ]);
+
+    const vendorDocsRaw = vendorResult.status === 'fulfilled' ? vendorResult.value : [];
+    if (vendorResult.status === 'rejected') {
+      this.logger.warn('Vendor collection retrieval failed — continuing with regulation only', {
+        service: 'rag',
+        requestId,
+        error: vendorResult.reason?.message,
+      });
+    }
+    const regulationDocs = regulationResult.status === 'fulfilled' ? regulationResult.value : [];
+    if (regulationResult.status === 'rejected') {
+      this.logger.warn('Regulation collection retrieval failed — continuing with vendor only', {
+        service: 'rag',
+        requestId,
+        error: regulationResult.reason?.message,
+      });
+    }
+
+    const vendorDocs = vendorDocsRaw.map((doc) => ({
+      ...doc,
+      metadata: { ...(doc.metadata || {}), source: doc.metadata?.source || 'vendor' },
+    }));
+
+    const mergedDocs = deduplicateDocuments([...vendorDocs, ...regulationDocs]);
+    const rerankedDocs = rerankDocuments(mergedDocs, searchQuery, 15);
 
     const retrieval = {
       documents: rerankedDocs,
       allQueries: [searchQuery],
       metrics: {
         strategy: 'direct',
-        docsCollected: rawDocs.length,
+        docsCollected: mergedDocs.length,
+        vendorDocs: vendorDocs.length,
+        regulationDocs: regulationDocs.length,
         docsAfterRerank: rerankedDocs.length,
       },
     };
@@ -537,7 +577,9 @@ class RAGService {
     this.logger.info('Retrieval complete', {
       service: 'rag',
       requestId,
-      docsCollected: rawDocs.length,
+      vendorDocs: vendorDocs.length,
+      regulationDocs: regulationDocs.length,
+      docsCollected: mergedDocs.length,
       docsAfterRerank: rerankedDocs.length,
     });
 

--- a/backend/services/rag/complianceKbRetriever.js
+++ b/backend/services/rag/complianceKbRetriever.js
@@ -1,0 +1,120 @@
+/**
+ * complianceKbRetriever.js
+ *
+ * Retrieves DORA regulation text from the shared, read-only `compliance_kb`
+ * Qdrant collection (seeded by `backend/scripts/seedComplianceKb.js`).
+ *
+ * Unlike the workspace retriever, this collection has no tenant filter —
+ * regulation text is public reference data, identical for every workspace.
+ *
+ * Returned documents are tagged with `metadata.source = 'regulation'` and a
+ * human-readable `documentTitle` (e.g. `"DORA Article 28: ICT third-party risk"`)
+ * so the existing context formatter and citation pipeline render them
+ * distinctly from vendor-uploaded documents.
+ */
+
+import { QdrantVectorStore } from '@langchain/qdrant';
+import { embeddings as defaultEmbeddings } from '../../config/embeddings.js';
+import logger from '../../config/logger.js';
+
+export const COMPLIANCE_KB_COLLECTION = 'compliance_kb';
+
+const QDRANT_URL = process.env.QDRANT_URL || 'http://localhost:6333';
+const QDRANT_API_KEY = process.env.QDRANT_API_KEY;
+
+let cachedStore = null;
+let cachedStorePromise = null;
+
+/**
+ * Lazy-init the QdrantVectorStore for the compliance_kb collection.
+ * Returns null if the collection is unavailable so callers can gracefully
+ * degrade to vendor-only retrieval (e.g. local dev without seed run).
+ */
+async function getComplianceKbStore(embeddings = defaultEmbeddings) {
+  if (cachedStore) return cachedStore;
+  if (cachedStorePromise) return cachedStorePromise;
+
+  cachedStorePromise = (async () => {
+    try {
+      const store = await QdrantVectorStore.fromExistingCollection(embeddings, {
+        url: QDRANT_URL,
+        apiKey: QDRANT_API_KEY,
+        collectionName: COMPLIANCE_KB_COLLECTION,
+        contentPayloadKey: 'pageContent',
+      });
+      cachedStore = store;
+      return store;
+    } catch (error) {
+      logger.warn('compliance_kb collection unavailable — regulation retrieval disabled', {
+        service: 'compliance-kb-retriever',
+        collection: COMPLIANCE_KB_COLLECTION,
+        error: error.message,
+      });
+      return null;
+    } finally {
+      cachedStorePromise = null;
+    }
+  })();
+
+  return cachedStorePromise;
+}
+
+/**
+ * Map a raw compliance_kb document to the shape the RAG context formatter
+ * expects, so citations render as the article number rather than "Untitled".
+ */
+function adaptRegulationDoc(doc) {
+  const meta = doc.metadata || {};
+  const regulation = meta.regulation || 'Regulation';
+  const article = meta.article || '';
+  const title = meta.title || '';
+
+  const documentTitle =
+    [regulation, article].filter(Boolean).join(' ') + (title ? `: ${title}` : '');
+
+  return {
+    pageContent: doc.pageContent,
+    metadata: {
+      ...meta,
+      source: 'regulation',
+      documentTitle: documentTitle || regulation,
+      heading_path: [regulation, article].filter(Boolean),
+      documentType: 'regulation',
+    },
+  };
+}
+
+/**
+ * Retrieve top-k regulation chunks for a query.
+ * Returns an empty array if the collection is missing or any error occurs —
+ * regulation context is additive, never load-bearing.
+ *
+ * @param {string} query
+ * @param {number} [k=5]
+ * @returns {Promise<Array<{pageContent: string, metadata: object}>>}
+ */
+export async function retrieveRegulationDocs(query, k = 5) {
+  if (!query || typeof query !== 'string') return [];
+
+  const store = await getComplianceKbStore();
+  if (!store) return [];
+
+  try {
+    const docs = await store.similaritySearch(query, k);
+    return docs.map(adaptRegulationDoc);
+  } catch (error) {
+    logger.warn('compliance_kb similarity search failed', {
+      service: 'compliance-kb-retriever',
+      error: error.message,
+    });
+    return [];
+  }
+}
+
+/**
+ * Test-only: reset the cached store (used by unit tests).
+ */
+export function _resetForTests() {
+  cachedStore = null;
+  cachedStorePromise = null;
+}

--- a/backend/tests/unittest/complianceKbRetriever.test.js
+++ b/backend/tests/unittest/complianceKbRetriever.test.js
@@ -1,0 +1,98 @@
+/**
+ * Unit tests — complianceKbRetriever
+ *
+ * Verifies that:
+ *   - Regulation docs are tagged with `source: 'regulation'`
+ *   - documentTitle is built from regulation + article + title
+ *   - Returns [] gracefully when collection or search fails
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { fromExistingCollection } = vi.hoisted(() => ({
+  fromExistingCollection: vi.fn(),
+}));
+
+vi.mock('@langchain/qdrant', () => ({
+  QdrantVectorStore: { fromExistingCollection },
+}));
+
+vi.mock('../../config/embeddings.js', () => ({
+  embeddings: { embedQuery: vi.fn() },
+  BATCH_CONFIG: {},
+  getEmbeddingMetrics: vi.fn(),
+  isCloudAvailable: vi.fn(),
+  createEmbeddingContext: vi.fn(),
+}));
+
+vi.mock('../../config/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+  retrieveRegulationDocs,
+  _resetForTests,
+} from '../../services/rag/complianceKbRetriever.js';
+
+beforeEach(() => {
+  fromExistingCollection.mockReset();
+  _resetForTests();
+});
+
+describe('retrieveRegulationDocs', () => {
+  it('returns regulation-tagged docs with derived documentTitle', async () => {
+    const similaritySearch = vi.fn().mockResolvedValue([
+      {
+        pageContent: 'Financial entities shall...',
+        metadata: {
+          regulation: 'DORA',
+          article: 'Article 28',
+          title: 'ICT third-party risk',
+          domain: 'Third-party risk',
+        },
+      },
+    ]);
+    fromExistingCollection.mockResolvedValue({ similaritySearch });
+
+    const docs = await retrieveRegulationDocs('what does Article 28 require?', 5);
+
+    expect(similaritySearch).toHaveBeenCalledWith('what does Article 28 require?', 5);
+    expect(docs).toHaveLength(1);
+    expect(docs[0].metadata.source).toBe('regulation');
+    expect(docs[0].metadata.documentTitle).toBe('DORA Article 28: ICT third-party risk');
+    expect(docs[0].metadata.heading_path).toEqual(['DORA', 'Article 28']);
+    expect(docs[0].metadata.documentType).toBe('regulation');
+  });
+
+  it('returns [] when the collection is unavailable', async () => {
+    fromExistingCollection.mockRejectedValue(new Error('collection not found'));
+    const docs = await retrieveRegulationDocs('any query');
+    expect(docs).toEqual([]);
+  });
+
+  it('returns [] when similarity search throws', async () => {
+    const similaritySearch = vi.fn().mockRejectedValue(new Error('qdrant down'));
+    fromExistingCollection.mockResolvedValue({ similaritySearch });
+    const docs = await retrieveRegulationDocs('any query');
+    expect(docs).toEqual([]);
+  });
+
+  it('returns [] for empty or non-string queries', async () => {
+    expect(await retrieveRegulationDocs('')).toEqual([]);
+    expect(await retrieveRegulationDocs(null)).toEqual([]);
+    expect(await retrieveRegulationDocs(undefined)).toEqual([]);
+    expect(fromExistingCollection).not.toHaveBeenCalled();
+  });
+
+  it('caches the store across calls', async () => {
+    const similaritySearch = vi.fn().mockResolvedValue([]);
+    fromExistingCollection.mockResolvedValue({ similaritySearch });
+
+    await retrieveRegulationDocs('q1');
+    await retrieveRegulationDocs('q2');
+    await retrieveRegulationDocs('q3');
+
+    expect(fromExistingCollection).toHaveBeenCalledTimes(1);
+    expect(similaritySearch).toHaveBeenCalledTimes(3);
+  });
+});

--- a/backend/tests/unittest/ragService.test.js
+++ b/backend/tests/unittest/ragService.test.js
@@ -59,6 +59,12 @@ vi.mock('../../services/rag/analyticsTracker.js', () => ({
 vi.mock('../../utils/rag/contextFormatter.js', () => ({
   formatContext: vi.fn(() => 'formatted context'),
   formatSources: vi.fn(() => [{ sourceNumber: 1, title: 'Doc', url: '' }]),
+  deduplicateDocuments: vi.fn((docs) => docs),
+}));
+vi.mock('../../services/rag/complianceKbRetriever.js', () => ({
+  retrieveRegulationDocs: vi.fn(() => []),
+  COMPLIANCE_KB_COLLECTION: 'compliance_kb',
+  _resetForTests: vi.fn(),
 }));
 vi.mock('../../utils/security/contextSanitizer.js', () => ({
   sanitizeDocuments: vi.fn((docs) => docs),
@@ -448,6 +454,137 @@ describe('askWithConversation', () => {
     await svc.askWithConversation('question', { conversationId: 'conv-1' });
 
     expect(mockCache.get).toHaveBeenCalledWith('question', null, 'conv-1');
+  });
+
+  // Issue #206 — chat must merge regulation docs from compliance_kb with vendor docs
+  it('queries compliance_kb in parallel and merges regulation + vendor docs before rerank', async () => {
+    const { rerankDocuments } = await import('../../services/rag/documentRanking.js');
+    const { deduplicateDocuments } = await import('../../utils/rag/contextFormatter.js');
+    rerankDocuments.mockImplementation((docs) => docs);
+    deduplicateDocuments.mockImplementation((docs) => docs);
+
+    const { svc, mockCache, mockConversation } = makeService();
+    svc._initialized = true;
+
+    const vendorDoc = { pageContent: 'vendor chunk', metadata: { documentTitle: 'AWS-Doc.pdf' } };
+    const vendorSearch = vi.fn().mockResolvedValue([vendorDoc]);
+    svc.vectorStore = { similaritySearch: vendorSearch };
+
+    const regulationDoc = {
+      pageContent: 'Article 28 text',
+      metadata: { source: 'regulation', documentTitle: 'DORA Article 28: ICT third-party risk' },
+    };
+    const retrieveRegulationDocs = vi.fn().mockResolvedValue([regulationDoc]);
+    svc.retrieveRegulationDocs = retrieveRegulationDocs;
+
+    mockCache.get.mockResolvedValue(null);
+    mockConversation.findById.mockResolvedValue({ _id: 'conv-1', workspaceId: 'ws-1' });
+
+    // Stub out the rest of the pipeline so the test focuses on retrieval merge.
+    svc._generateAnswer = vi.fn().mockResolvedValue('answer');
+    svc._processAnswer = vi.fn().mockResolvedValue({
+      validation: {
+        confidence: 0.9,
+        isGrounded: true,
+        hasHallucinations: false,
+        isLowQuality: false,
+        issues: [],
+      },
+      citedSources: [],
+    });
+    svc._saveMessages = vi.fn().mockResolvedValue();
+    svc._buildAndCacheResult = vi.fn().mockResolvedValue({ answer: 'answer' });
+
+    await svc.askWithConversation('what does Article 28 require?', { conversationId: 'conv-1' });
+
+    expect(vendorSearch).toHaveBeenCalledTimes(1);
+    expect(retrieveRegulationDocs).toHaveBeenCalledTimes(1);
+    expect(retrieveRegulationDocs).toHaveBeenCalledWith(expect.any(String), 5);
+
+    // Reranker should see merged set (vendor first, regulation second).
+    const mergedArg = rerankDocuments.mock.calls[0][0];
+    expect(mergedArg).toHaveLength(2);
+    expect(mergedArg[0].metadata.source).toBe('vendor');
+    expect(mergedArg[1].metadata.source).toBe('regulation');
+  });
+
+  it('still answers when vendor retrieval throws (e.g. embedding-dim drift)', async () => {
+    const { rerankDocuments } = await import('../../services/rag/documentRanking.js');
+    const { deduplicateDocuments } = await import('../../utils/rag/contextFormatter.js');
+    rerankDocuments.mockImplementation((docs) => docs);
+    deduplicateDocuments.mockImplementation((docs) => docs);
+
+    const { svc, mockCache, mockConversation } = makeService();
+    svc._initialized = true;
+
+    // Vendor collection rejects (e.g. wrong vector dim). Regulation must still flow.
+    svc.vectorStore = {
+      similaritySearch: vi.fn().mockRejectedValue(new Error('Vector dimension error')),
+    };
+    const regulationDoc = {
+      pageContent: 'Article 28 text',
+      metadata: { source: 'regulation', documentTitle: 'DORA Article 28' },
+    };
+    svc.retrieveRegulationDocs = vi.fn().mockResolvedValue([regulationDoc]);
+
+    mockCache.get.mockResolvedValue(null);
+    mockConversation.findById.mockResolvedValue({ _id: 'conv-1', workspaceId: 'ws-1' });
+
+    svc._generateAnswer = vi.fn().mockResolvedValue('answer');
+    svc._processAnswer = vi.fn().mockResolvedValue({
+      validation: {
+        confidence: 0.9,
+        isGrounded: true,
+        hasHallucinations: false,
+        isLowQuality: false,
+        issues: [],
+      },
+      citedSources: [],
+    });
+    svc._saveMessages = vi.fn().mockResolvedValue();
+    svc._buildAndCacheResult = vi.fn().mockResolvedValue({ answer: 'answer' });
+
+    await expect(
+      svc.askWithConversation('What does Article 28 require?', { conversationId: 'conv-1' })
+    ).resolves.toBeDefined();
+
+    const mergedArg = rerankDocuments.mock.calls[0][0];
+    expect(mergedArg).toHaveLength(1);
+    expect(mergedArg[0].metadata.source).toBe('regulation');
+  });
+
+  it('still answers when compliance_kb returns no docs (graceful degrade)', async () => {
+    const { rerankDocuments } = await import('../../services/rag/documentRanking.js');
+    const { deduplicateDocuments } = await import('../../utils/rag/contextFormatter.js');
+    rerankDocuments.mockImplementation((docs) => docs);
+    deduplicateDocuments.mockImplementation((docs) => docs);
+
+    const { svc, mockCache, mockConversation } = makeService();
+    svc._initialized = true;
+    svc.vectorStore = { similaritySearch: vi.fn().mockResolvedValue([]) };
+    svc.retrieveRegulationDocs = vi.fn().mockResolvedValue([]);
+
+    mockCache.get.mockResolvedValue(null);
+    mockConversation.findById.mockResolvedValue({ _id: 'conv-1', workspaceId: 'ws-1' });
+
+    svc._generateAnswer = vi.fn().mockResolvedValue('answer');
+    svc._processAnswer = vi.fn().mockResolvedValue({
+      validation: {
+        confidence: 0.9,
+        isGrounded: true,
+        hasHallucinations: false,
+        isLowQuality: false,
+        issues: [],
+      },
+      citedSources: [],
+    });
+    svc._saveMessages = vi.fn().mockResolvedValue();
+    svc._buildAndCacheResult = vi.fn().mockResolvedValue({ answer: 'answer' });
+
+    await expect(
+      svc.askWithConversation('any question', { conversationId: 'conv-1' })
+    ).resolves.toBeDefined();
+    expect(svc.retrieveRegulationDocs).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Promotes the single commit currently on \`dev\` to \`main\` for prod auto-deploy.

## Included
- **#229 — fix(rag)**: chat retrieves from \`compliance_kb\` so DORA-text questions hit regulation context. Closes #206 once this lands.

\`bf60b69 fix(rag): chat retrieves from compliance_kb so dora-text questions hit regulation context (#229)\`

## CI status (from #229)
✅ Backend Tests · Frontend Tests · Frontend E2E · Backend Security Audit · Docker Build (backend + frontend) · CI Success — all passed.

## Local end-to-end verification (already performed on #229)
Question: \`What does DORA Article 28(3) require?\`

Backend log:
\`\`\`
"vendorDocs": 0
"regulationDocs": 5
"docsCollected": 5
"message": "Retrieval complete"
\`\`\`

Top-5 retrieved docs include the matching \`DORA Article 28: General Principles — ICT Third-Party Risk Management\`.

## Post-deploy verification on prod
- [ ] Confirm \`compliance_kb\` collection exists on prod Qdrant (\`curl https://<qdrant>/collections\`)
- [ ] If missing or stale, re-seed: \`SOPS-decrypt prod env\` → \`node backend/scripts/seedComplianceKb.js\` (requires valid \`OLLAMA_API_KEY_*\` for Ollama Cloud auth)
- [ ] Ask \`/rag/stream\` a regulation-only question against prod, confirm \`regulationDocs > 0\` in the \`Retrieval complete\` log line
- [ ] Confirm citations title with \`DORA Article N: ...\` for regulation answers
- [ ] Spot-check that vendor-doc answers still work for any existing tenant