### PR TITLE
hotfix(ci): detach KB seed from CD ssh-action so 10m timeout can't fail deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -106,6 +106,7 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 30m
           script: |
             set -e
             cd /opt/rag
@@ -193,14 +194,18 @@ jobs:
             done
             curl -sf http://localhost:3000 > /dev/null && echo "Frontend: OK" || echo "WARN: Frontend slow to start — check container logs if needed"
 
-            # ── Sync compliance knowledge base (smart sync, non-fatal) ────
+            # ── Sync compliance knowledge base (smart sync, detached) ─────
             # Compares Qdrant point count to JSON article count.
-            # No-op if already in sync; re-seeds automatically when articles
-            # are added. Does NOT block deployment on failure.
-            echo "Syncing compliance knowledge base..."
-            docker exec retrieva-backend node scripts/seedComplianceKb.js \
-              && echo "Compliance KB sync complete" \
-              || echo "WARN: Compliance KB sync failed — KB may be stale, manual re-seed needed"
+            # No-op if already in sync (~1s); first-run seeding embeds 58
+            # articles via Ollama Cloud and can take 10–15 min.
+            # Run detached (-d) so the deploy job is NOT blocked on the
+            # seed — the operator inspects /var/log/retrieva-seed-kb.log
+            # afterwards if compliance_kb is unexpectedly empty.
+            echo "Starting compliance KB sync (detached)..."
+            docker exec -d retrieva-backend sh -c \
+              'node scripts/seedComplianceKb.js > /tmp/seed-kb.log 2>&1' \
+              && echo "Compliance KB sync started in background (logs: docker exec retrieva-backend cat /tmp/seed-kb.log)" \
+              || echo "WARN: Could not start compliance KB sync — manual re-seed needed"
 
             # ── Cleanup ──────────────────────────────────────────────────
             docker image prune -f


### PR DESCRIPTION
## Why this is a hotfix
PR #230's deploy ran successfully — backend + frontend containers came up healthy on prod. But the post-deploy \`seedComplianceKb.js\` step took 9+ minutes embedding 58 DORA articles via Ollama Cloud and got killed by appleboy/ssh-action's default 10-minute \`command_timeout\`. The deploy job exited 1 and the workflow reports failure.

Net effect on prod right now: new code is live (good), but \`compliance_kb\` exists as an empty Qdrant collection (bad — the very thing #229 was supposed to enable). Need this in to either re-trigger CD with the new behavior, or land it before the next deploy.

## Changes
\`.github/workflows/cd.yml\`:
1. **\`command_timeout: 30m\`** on the deploy ssh-action — general safety margin for non-blocking work.
2. **\`docker exec -d\`** for the KB seed — runs detached, deploy returns immediately. Operator inspects \`/tmp/seed-kb.log\` inside the backend container if compliance_kb is unexpectedly empty.

The seed script's smart-sync logic was already there: once compliance_kb has 58 points, the seed exits in <1s. This timeout only bites on first-time seeds, which is exactly today's state.

## After merge
- CD will re-trigger automatically on the merge commit
- Deploy will succeed quickly (seed runs detached)
- Need to inspect \`/tmp/seed-kb.log\` after deploy to confirm seed completed (or re-run if it timed out again — but with the bg seed, retries are easy)

## Test plan
- [ ] CI on this PR passes (CD itself doesn't run on a hotfix PR; it runs on main after merge)
- [ ] After merge, watch the new CD run — the "Sync compliance knowledge base" step should print \`started in background\` and exit fast
- [ ] After deploy, SSH and \`docker exec retrieva-backend cat /tmp/seed-kb.log\` to verify seed completed (\`Seeded 58 entries into compliance_kb\`)
- [ ] \`curl http://localhost:6333/collections/compliance_kb\` (from prod box) shows points_count: 58

## Notes
- After this lands and prod is fixed, the \`hotfix → dev\` back-merge per CLAUDE.md keeps dev in sync