### PR TITLE
perf(chat): route auxiliary chat-path llm calls to groq (closes #244)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -56,11 +56,11 @@ OLLAMA_API_KEY_3=
 #   chat / formatter   — short, latency-sensitive (target: < 3 s)
 #   analysis / judge   — long, quality-sensitive (gap analysis, evals)
 #
-# Example fast-chat config (uncomment + set GROQ_API_KEY below):
+# Example fast-chat config (uncomment + set GROQ_API_KEY below). LLM_*_MODEL is
+# optional — if unset, chat defaults to llama-3.3-70b-versatile (better prompt
+# following for the rephrase chain) and formatter to llama-3.1-8b-instant.
 # LLM_CHAT_PROVIDER=groq
-# LLM_CHAT_MODEL=llama-3.1-8b-instant
 # LLM_FORMATTER_PROVIDER=groq
-# LLM_FORMATTER_MODEL=llama-3.1-8b-instant
 
 # Groq fast-inference API (https://console.groq.com)
 # Required only if LLM_CHAT_PROVIDER=groq or LLM_FORMATTER_PROVIDER=groq.

--- a/backend/config/llmProvider.js
+++ b/backend/config/llmProvider.js
@@ -50,7 +50,13 @@ function resolveModelForPurpose(purpose, provider) {
   const upper = purpose.toUpperCase();
   const explicit = process.env[`LLM_${upper}_MODEL`] || process.env.LLM_MODEL;
   if (explicit) return explicit;
-  if (provider === LLM_PROVIDERS.GROQ) return 'llama-3.1-8b-instant';
+  // Per-purpose Groq defaults: chat needs strict prompt-following (rephrase
+  // chain on llama-3.1-8b-instant emitted prose preambles in #244), so default
+  // to the larger model. Formatter parses JSON and tolerates noise via
+  // parseJsonArrayLoose, so keep the cheaper 8b default.
+  if (provider === LLM_PROVIDERS.GROQ) {
+    return purpose === 'chat' ? 'llama-3.3-70b-versatile' : 'llama-3.1-8b-instant';
+  }
   return undefined;
 }
 

--- a/backend/services/rag.js
+++ b/backend/services/rag.js
@@ -182,7 +182,9 @@ class RAGService {
       ['user', '{input}'],
       [
         'user',
-        'Given the above conversation, generate a search query to look up in order to get information relevant to the conversation',
+        // Strict output format — fast Groq models (#244) tend to emit prose
+        // preambles that get fed into vector search and degrade retrieval.
+        "Rewrite the user's most recent question as a single self-contained search query that includes any context from the conversation it depends on. Output ONLY the rewritten query — no quotes, no preface, no explanation, no surrounding text.",
       ],
     ]);
 

--- a/backend/services/rag/crossEncoderRerank.js
+++ b/backend/services/rag/crossEncoderRerank.js
@@ -14,7 +14,7 @@
  */
 
 import logger from '../../config/logger.js';
-import { getDefaultLLM } from '../../config/llm.js';
+import { createLLM } from '../../config/llm.js';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { StringOutputParser } from '@langchain/core/output_parsers';
 
@@ -209,7 +209,9 @@ async function rerankWithLLM(query, documents, options = {}) {
   const { topN = RERANK_CONFIG.topN, minScore = RERANK_CONFIG.minScore } = options;
 
   const startTime = Date.now();
-  const llm = await getDefaultLLM();
+  // LLM rerank fires on every chat request, runs in parallel batches — keep on
+  // the chat purpose so it benefits from fast inference.
+  const llm = await createLLM({ purpose: 'chat' });
   const chain = LLM_RERANK_PROMPT.pipe(llm).pipe(new StringOutputParser());
 
   // Score documents in parallel (with concurrency limit)

--- a/backend/services/rag/retrievalEnhancements.js
+++ b/backend/services/rag/retrievalEnhancements.js
@@ -9,7 +9,7 @@
 import { StringOutputParser } from '@langchain/core/output_parsers';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { createHash } from 'crypto';
-import { getDefaultLLM } from '../../config/llm.js';
+import { createLLM } from '../../config/llm.js';
 import logger from '../../config/logger.js';
 
 /**
@@ -58,7 +58,9 @@ let cachedLLM = null;
  */
 async function getLLMInstance() {
   if (!cachedLLM) {
-    cachedLLM = await getDefaultLLM();
+    // Multi-query expansion + HyDE run on every chat request, so they share
+    // the chat purpose to keep the entire chat hot path on the fast provider.
+    cachedLLM = await createLLM({ purpose: 'chat' });
   }
   return cachedLLM;
 }

--- a/backend/tests/unittest/crossEncoderRerank.test.js
+++ b/backend/tests/unittest/crossEncoderRerank.test.js
@@ -16,9 +16,9 @@ vi.mock('../../config/logger.js', () => ({
   },
 }));
 
-// Mock LLM
+// Mock LLM — rerank now uses createLLM({purpose:'chat'}) per #244
 vi.mock('../../config/llm.js', () => ({
-  getDefaultLLM: vi.fn().mockResolvedValue({
+  createLLM: vi.fn().mockResolvedValue({
     invoke: vi.fn().mockResolvedValue({
       content: '{"score": 8, "reason": "Highly relevant"}',
     }),
@@ -122,9 +122,7 @@ describe('Cross-Encoder Re-ranking', () => {
       RERANK_CONFIG.provider = 'cohere';
       RERANK_CONFIG.cohereApiKey = null; // Will cause error
 
-      const docs = [
-        { pageContent: 'Document 1', metadata: { score: 0.9 } },
-      ];
+      const docs = [{ pageContent: 'Document 1', metadata: { score: 0.9 } }];
 
       const result = await crossEncoderRerank('test query', docs);
 

--- a/backend/tests/unittest/llmProviderPurpose.test.js
+++ b/backend/tests/unittest/llmProviderPurpose.test.js
@@ -145,4 +145,38 @@ describe('createLLM purpose dispatch', () => {
       purpose: 'analysis',
     });
   });
+
+  it('groq chat default is llama-3.3-70b-versatile (rephrase quality fix from #244)', async () => {
+    // No explicit LLM_*_MODEL — exercise the resolveModelForPurpose default path
+    process.env.LLM_CHAT_PROVIDER = 'groq';
+
+    const { getActiveLLMMeta } = await import('../../config/llmProvider.js');
+
+    expect(getActiveLLMMeta('chat')).toEqual({
+      provider: 'groq',
+      model: 'llama-3.3-70b-versatile',
+      purpose: 'chat',
+    });
+  });
+
+  it('groq formatter default stays on llama-3.1-8b-instant (cheap + JSON-tolerant)', async () => {
+    process.env.LLM_FORMATTER_PROVIDER = 'groq';
+
+    const { getActiveLLMMeta } = await import('../../config/llmProvider.js');
+
+    expect(getActiveLLMMeta('formatter')).toEqual({
+      provider: 'groq',
+      model: 'llama-3.1-8b-instant',
+      purpose: 'formatter',
+    });
+  });
+
+  it('explicit LLM_CHAT_MODEL still wins over the new default', async () => {
+    process.env.LLM_CHAT_PROVIDER = 'groq';
+    process.env.LLM_CHAT_MODEL = 'mixtral-8x7b-32768';
+
+    const { getActiveLLMMeta } = await import('../../config/llmProvider.js');
+
+    expect(getActiveLLMMeta('chat').model).toBe('mixtral-8x7b-32768');
+  });
 });

--- a/backend/tests/unittest/ragService.test.js
+++ b/backend/tests/unittest/ragService.test.js
@@ -13,7 +13,10 @@ vi.mock('../../config/logger.js', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 vi.mock('../../config/langsmith.js', () => ({ getCallbacks: vi.fn(() => []) }));
-vi.mock('../../config/llm.js', () => ({ getDefaultLLM: vi.fn() }));
+vi.mock('../../config/llm.js', () => ({
+  createLLM: vi.fn(),
+  getActiveLLMMeta: vi.fn(() => ({ provider: 'ollama', model: 'gemma3:12b', purpose: 'chat' })),
+}));
 vi.mock('../../config/vectorStore.js', () => ({ getVectorStore: vi.fn() }));
 vi.mock('../../utils/rag/ragCache.js', () => ({ ragCache: { get: vi.fn(), set: vi.fn() } }));
 vi.mock('../../services/answerFormatter.js', () => ({


### PR DESCRIPTION
## Summary
Finishes the work started in #240. Routes the chat-path auxiliary LLM calls (multi-query expansion, HyDE, cross-encoder rerank) to `purpose:'chat'`, picks per-purpose Groq defaults, and tightens the rephrase prompt so smaller-model output doesn't pollute vector search.

## Why
After #240/#242 went to prod, end-to-end testing on retrieva.online showed `/rag/stream` `totalTime` of **65–69s** (vs ~20s Ollama baseline). Root cause: only the final generation call was routed to Groq. Multi-query, HyDE, and rerank still hit Ollama Cloud via `getDefaultLLM()` at 10–20s each.

PR #243 reverted prod env to disable the broken fast-path. Code from #240 stayed on `main` (no-op without env vars).

## Changes
| File | Change |
|---|---|
| `services/rag/retrievalEnhancements.js:61` | `getDefaultLLM()` → `createLLM({purpose:'chat'})` |
| `services/rag/crossEncoderRerank.js:212` | `getDefaultLLM()` → `createLLM({purpose:'chat'})` |
| `config/llmProvider.js:50` | Per-purpose Groq default: `chat → llama-3.3-70b-versatile`, `formatter → llama-3.1-8b-instant` |
| `services/rag.js:180` | Rephrase prompt rewritten: forbids preamble/quotes/explanation. Smaller-model output was emitting prose blobs being fed into vector search. |
| `tests/unittest/llmProviderPurpose.test.js` | +3 tests: 70b chat default, 8b formatter default, explicit override still wins |
| `tests/unittest/crossEncoderRerank.test.js`, `tests/unittest/ragService.test.js` | Update mocks (`getDefaultLLM` → `createLLM`) |
| `.env.example` | Document new defaults; example config no longer pins models |

Judge + gap analysis stay on Ollama by design (quality > latency there).

## Local validation
End-to-end against docker-compose stack:
```
TTFT_ms: 598
TOTAL_ms: 1323
chunks: 216
rephrase_output: "What does Article 28 of DORA require for ICT third-party risk management"
rephrase_ms: 191
```
Compare to prod-with-only-#240: `TTFT ~unmeasured, TOTAL 65327 ms, rephrase = 5-bullet preamble`.

`npx vitest run` — **1433/1433 backend tests pass** (53s).

The Mongo persistence step still errors locally (single-node dev Mongo can't run transactions — pre-existing limitation, not a regression). Server-side generation completes successfully before the persist; that's the path under test.

## Test plan
- [ ] Pull this branch locally, run `docker compose up -d --force-recreate --no-deps backend` with `LLM_CHAT_PROVIDER=groq` set, fire a chat query, confirm `totalTime < 5000` in logs
- [ ] Quality spot-check: 5 representative DORA questions — citations + relevance match prior baseline; rephrase produces clean single query (no preamble)
- [ ] After merge to `dev` → `main`, **rotate the leaked Groq key** then SOPS hotfix prod env to re-enable
- [ ] Prod e2e: confirm `totalTime < 3000` on `retrieva.online` chat
- [ ] Gap analysis still produces 15 gaps for AWS DORA fixture (no provider drift on the worker path)

## Closes
Closes #244

## Notes
The Groq key shared in earlier chat is leaked — it must be rotated before re-enabling on prod. The new prompt-tightening also benefits the Ollama path (no behavior change for clean models, slight improvement for smaller ones).