### PR TITLE
release: groq aux-chain routing (#244)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -56,11 +56,11 @@ OLLAMA_API_KEY_3=
 #   chat / formatter   — short, latency-sensitive (target: < 3 s)
 #   analysis / judge   — long, quality-sensitive (gap analysis, evals)
 #
-# Example fast-chat config (uncomment + set GROQ_API_KEY below):
+# Example fast-chat config (uncomment + set GROQ_API_KEY below). LLM_*_MODEL is
+# optional — if unset, chat defaults to llama-3.3-70b-versatile (better prompt
+# following for the rephrase chain) and formatter to llama-3.1-8b-instant.
 # LLM_CHAT_PROVIDER=groq
-# LLM_CHAT_MODEL=llama-3.1-8b-instant
 # LLM_FORMATTER_PROVIDER=groq
-# LLM_FORMATTER_MODEL=llama-3.1-8b-instant
 
 # Groq fast-inference API (https://console.groq.com)
 # Required only if LLM_CHAT_PROVIDER=groq or LLM_FORMATTER_PROVIDER=groq.

--- a/backend/config/llmProvider.js
+++ b/backend/config/llmProvider.js
@@ -50,7 +50,13 @@ function resolveModelForPurpose(purpose, provider) {
   const upper = purpose.toUpperCase();
   const explicit = process.env[`LLM_${upper}_MODEL`] || process.env.LLM_MODEL;
   if (explicit) return explicit;
-  if (provider === LLM_PROVIDERS.GROQ) return 'llama-3.1-8b-instant';
+  // Per-purpose Groq defaults: chat needs strict prompt-following (rephrase
+  // chain on llama-3.1-8b-instant emitted prose preambles in #244), so default
+  // to the larger model. Formatter parses JSON and tolerates noise via
+  // parseJsonArrayLoose, so keep the cheaper 8b default.
+  if (provider === LLM_PROVIDERS.GROQ) {
+    return purpose === 'chat' ? 'llama-3.3-70b-versatile' : 'llama-3.1-8b-instant';
+  }
   return undefined;
 }
 

--- a/backend/services/rag.js
+++ b/backend/services/rag.js
@@ -182,7 +182,9 @@ class RAGService {
       ['user', '{input}'],
       [
         'user',
-        'Given the above conversation, generate a search query to look up in order to get information relevant to the conversation',
+        // Strict output format — fast Groq models (#244) tend to emit prose
+        // preambles that get fed into vector search and degrade retrieval.
+        "Rewrite the user's most recent question as a single self-contained search query that includes any context from the conversation it depends on. Output ONLY the rewritten query — no quotes, no preface, no explanation, no surrounding text.",
       ],
     ]);
 

--- a/backend/services/rag/crossEncoderRerank.js
+++ b/backend/services/rag/crossEncoderRerank.js
@@ -14,7 +14,7 @@
  */
 
 import logger from '../../config/logger.js';
-import { getDefaultLLM } from '../../config/llm.js';
+import { createLLM } from '../../config/llm.js';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { StringOutputParser } from '@langchain/core/output_parsers';
 
@@ -209,7 +209,9 @@ async function rerankWithLLM(query, documents, options = {}) {
   const { topN = RERANK_CONFIG.topN, minScore = RERANK_CONFIG.minScore } = options;
 
   const startTime = Date.now();
-  const llm = await getDefaultLLM();
+  // LLM rerank fires on every chat request, runs in parallel batches — keep on
+  // the chat purpose so it benefits from fast inference.
+  const llm = await createLLM({ purpose: 'chat' });
   const chain = LLM_RERANK_PROMPT.pipe(llm).pipe(new StringOutputParser());
 
   // Score documents in parallel (with concurrency limit)

--- a/backend/services/rag/retrievalEnhancements.js
+++ b/backend/services/rag/retrievalEnhancements.js
@@ -9,7 +9,7 @@
 import { StringOutputParser } from '@langchain/core/output_parsers';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { createHash } from 'crypto';
-import { getDefaultLLM } from '../../config/llm.js';
+import { createLLM } from '../../config/llm.js';
 import logger from '../../config/logger.js';
 
 /**
@@ -58,7 +58,9 @@ let cachedLLM = null;
  */
 async function getLLMInstance() {
   if (!cachedLLM) {
-    cachedLLM = await getDefaultLLM();
+    // Multi-query expansion + HyDE run on every chat request, so they share
+    // the chat purpose to keep the entire chat hot path on the fast provider.
+    cachedLLM = await createLLM({ purpose: 'chat' });
   }
   return cachedLLM;
 }

--- a/backend/tests/unittest/crossEncoderRerank.test.js
+++ b/backend/tests/unittest/crossEncoderRerank.test.js
@@ -16,9 +16,9 @@ vi.mock('../../config/logger.js', () => ({
   },
 }));
 
-// Mock LLM
+// Mock LLM — rerank now uses createLLM({purpose:'chat'}) per #244
 vi.mock('../../config/llm.js', () => ({
-  getDefaultLLM: vi.fn().mockResolvedValue({
+  createLLM: vi.fn().mockResolvedValue({
     invoke: vi.fn().mockResolvedValue({
       content: '{"score": 8, "reason": "Highly relevant"}',
     }),
@@ -122,9 +122,7 @@ describe('Cross-Encoder Re-ranking', () => {
       RERANK_CONFIG.provider = 'cohere';
       RERANK_CONFIG.cohereApiKey = null; // Will cause error
 
-      const docs = [
-        { pageContent: 'Document 1', metadata: { score: 0.9 } },
-      ];
+      const docs = [{ pageContent: 'Document 1', metadata: { score: 0.9 } }];
 
       const result = await crossEncoderRerank('test query', docs);
 

--- a/backend/tests/unittest/llmProviderPurpose.test.js
+++ b/backend/tests/unittest/llmProviderPurpose.test.js
@@ -145,4 +145,38 @@ describe('createLLM purpose dispatch', () => {
       purpose: 'analysis',
     });
   });
+
+  it('groq chat default is llama-3.3-70b-versatile (rephrase quality fix from #244)', async () => {
+    // No explicit LLM_*_MODEL — exercise the resolveModelForPurpose default path
+    process.env.LLM_CHAT_PROVIDER = 'groq';
+
+    const { getActiveLLMMeta } = await import('../../config/llmProvider.js');
+
+    expect(getActiveLLMMeta('chat')).toEqual({
+      provider: 'groq',
+      model: 'llama-3.3-70b-versatile',
+      purpose: 'chat',
+    });
+  });
+
+  it('groq formatter default stays on llama-3.1-8b-instant (cheap + JSON-tolerant)', async () => {
+    process.env.LLM_FORMATTER_PROVIDER = 'groq';
+
+    const { getActiveLLMMeta } = await import('../../config/llmProvider.js');
+
+    expect(getActiveLLMMeta('formatter')).toEqual({
+      provider: 'groq',
+      model: 'llama-3.1-8b-instant',
+      purpose: 'formatter',
+    });
+  });
+
+  it('explicit LLM_CHAT_MODEL still wins over the new default', async () => {
+    process.env.LLM_CHAT_PROVIDER = 'groq';
+    process.env.LLM_CHAT_MODEL = 'mixtral-8x7b-32768';
+
+    const { getActiveLLMMeta } = await import('../../config/llmProvider.js');
+
+    expect(getActiveLLMMeta('chat').model).toBe('mixtral-8x7b-32768');
+  });
 });

--- a/backend/tests/unittest/ragService.test.js
+++ b/backend/tests/unittest/ragService.test.js
@@ -13,7 +13,10 @@ vi.mock('../../config/logger.js', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 vi.mock('../../config/langsmith.js', () => ({ getCallbacks: vi.fn(() => []) }));
-vi.mock('../../config/llm.js', () => ({ getDefaultLLM: vi.fn() }));
+vi.mock('../../config/llm.js', () => ({
+  createLLM: vi.fn(),
+  getActiveLLMMeta: vi.fn(() => ({ provider: 'ollama', model: 'gemma3:12b', purpose: 'chat' })),
+}));
 vi.mock('../../config/vectorStore.js', () => ({ getVectorStore: vi.fn() }));
 vi.mock('../../utils/rag/ragCache.js', () => ({ ragCache: { get: vi.fn(), set: vi.fn() } }));
 vi.mock('../../services/answerFormatter.js', () => ({


### PR DESCRIPTION
## Summary
Promotes the #244 fix from `dev` to `main`. Single commit shipping:

- **#245** perf(chat): route auxiliary chat-path llm calls to groq (closes #244)

## What it does
Finishes the chat fast-path. Routes multi-query expansion + HyDE + cross-encoder rerank LLM calls to `purpose:'chat'`, sets per-purpose Groq defaults (`chat=llama-3.3-70b-versatile`, `formatter=llama-3.1-8b-instant`), and tightens the rephrase prompt so smaller-model output stops polluting vector search.

Local timing dropped from 65–69s (prod with #240 alone) to **TTFT 598 ms / total 1323 ms**.

## Behavior change
None unless `LLM_CHAT_PROVIDER=groq` + `GROQ_API_KEY` are set in prod env. Without those, the chat path stays on Ollama Cloud as it does today.

## Pre-deploy checklist
After this merges and CD deploys, the operator must:
1. Rotate the leaked Groq key from earlier sessions.
2. SOPS-hotfix `backend/.env.production.enc` to add:
   ```
   LLM_CHAT_PROVIDER=groq
   LLM_FORMATTER_PROVIDER=groq
   GROQ_API_KEY=<rotated key>
   ```
   No need to set `LLM_CHAT_MODEL` / `LLM_FORMATTER_MODEL` — the code defaults handle them now.
3. Verify `totalTime < 3000` on `retrieva.online` chat.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: CD deploys cleanly
- [ ] After SOPS hotfix re-enable: prod chat `totalTime < 3000` and `llmProvider=groq` in logs
- [ ] After merge: fast-forward `main` back into `dev` per repo rule