### PR TITLE
release: async judge + clickable citations (#249)

### DIFF
--- a/backend/services/rag.js
+++ b/backend/services/rag.js
@@ -16,7 +16,13 @@ import {
 
 // Extracted modules
 import { rerankDocuments } from './rag/documentRanking.js';
-import { evaluateAnswer, extractCitedSources, toValidationResult } from './rag/llmJudge.js';
+import {
+  evaluateAnswer,
+  extractCitedSources,
+  toValidationResult,
+  extractCitedSourcesFromText,
+  buildSkippedJudgeValidation,
+} from './rag/llmJudge.js';
 import { compressDocuments, initChains } from './rag/retrievalEnhancements.js';
 import {
   formatContext,
@@ -642,6 +648,71 @@ class RAGService {
         onEvent: onEvent || undefined,
         responseInstruction: combinedInstruction,
       });
+
+      // Fast path (#244 follow-up): skip the synchronous LLM judge in the chat
+      // request. The judge currently runs gemma3:12b on Ollama Cloud (~5 s) and
+      // dominates totalTime now that retrieval is on Groq. With this flag set,
+      // we extract citations locally via regex, ship 'done' immediately, and
+      // fire the judge in the background for telemetry only. Hallucination
+      // gating is sacrificed by design — only enable when answer quality is
+      // already validated by other means (RAG grounding + retrieval reranking).
+      if (process.env.RAG_CHAT_ASYNC_JUDGE === 'true') {
+        const citedSources = extractCitedSourcesFromText(response, sources);
+        const validation = buildSkippedJudgeValidation(citedSources.length);
+
+        await this._saveMessages(conversationId, question, response);
+
+        const result = await this._buildAndCacheResult({
+          answer: response,
+          sources,
+          validation,
+          citedSources,
+          question,
+          requestId,
+          conversationId,
+          workspaceId,
+          retrievalMetrics: retrieval.metrics,
+          startTime,
+        });
+
+        emit('metadata', {
+          confidence: validation.confidence,
+          citationCount: citedSources.length,
+          citedSources,
+          isGrounded: validation.isGrounded,
+          hasHallucinations: validation.hasHallucinations,
+          isRelevant: validation.isRelevant,
+          reasoning: validation.reasoning,
+          judged: false,
+        });
+        emit('saved', { conversationId });
+        emit('done', { message: 'Streaming complete' });
+
+        // Background judge — fire and forget. Used for telemetry only; no UI
+        // impact since the SSE response is already closing. Wrap in try/catch
+        // so a slow/down judge LLM can't crash the request.
+        Promise.resolve()
+          .then(() => this._processAnswer(response, sources, question, context))
+          .then(({ validation: bgValidation }) => {
+            if (bgValidation.hasHallucinations) {
+              this.logger.warn('Async judge flagged hallucination after stream close', {
+                service: 'rag',
+                requestId,
+                conversationId,
+                confidence: bgValidation.confidence,
+              });
+            }
+          })
+          .catch((err) => {
+            this.logger.warn('Background judge failed (non-fatal)', {
+              service: 'rag',
+              requestId,
+              error: err.message,
+            });
+          });
+
+        return result;
+      }
 
       emit('status', { message: 'Evaluating answer...' });
 

--- a/backend/services/rag/llmJudge.js
+++ b/backend/services/rag/llmJudge.js
@@ -279,3 +279,34 @@ export function toValidationResult(evaluation) {
     reasoning: evaluation.reasoning,
   };
 }
+
+export function extractCitedSourcesFromText(answer = '', sources = []) {
+  if (!answer || sources.length === 0) return [];
+  const found = new Set();
+  const regex = /\[Source\s+(\d+)\]/g;
+  let match;
+  while ((match = regex.exec(answer)) !== null) {
+    const idx = Number(match[1]);
+    if (idx >= 1 && idx <= sources.length) found.add(idx);
+  }
+  return Array.from(found)
+    .sort((a, b) => a - b)
+    .map((idx) => sources[idx - 1]);
+}
+
+export function buildSkippedJudgeValidation(citationCount = 0) {
+  return {
+    isLowQuality: false,
+    confidence: 1,
+    issues: [],
+    citationCount,
+    validCitationCount: citationCount,
+    meetsMinConfidence: true,
+    isGrounded: true,
+    isRelevant: true,
+    isComplete: true,
+    hasHallucinations: false,
+    reasoning: 'Skipped (RAG_CHAT_ASYNC_JUDGE)',
+    judged: false,
+  };
+}

--- a/backend/tests/unittest/llmJudgeFastPath.test.js
+++ b/backend/tests/unittest/llmJudgeFastPath.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractCitedSourcesFromText,
+  buildSkippedJudgeValidation,
+} from '../../services/rag/llmJudge.js';
+
+const sources = [
+  { id: 's1', title: 'DORA Article 28', sourceNumber: 1 },
+  { id: 's2', title: 'DORA Article 29', sourceNumber: 2 },
+  { id: 's3', title: 'DORA Article 30', sourceNumber: 3 },
+];
+
+describe('extractCitedSourcesFromText (fast-path local extractor for #244)', () => {
+  it('returns empty when no sources or no answer', () => {
+    expect(extractCitedSourcesFromText('', sources)).toEqual([]);
+    expect(extractCitedSourcesFromText('hello [Source 1]', [])).toEqual([]);
+  });
+
+  it('extracts a single citation', () => {
+    const out = extractCitedSourcesFromText('Article 28 says X [Source 1].', sources);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('s1');
+  });
+
+  it('deduplicates repeated citations and preserves source order', () => {
+    const text = 'A [Source 2]. B [Source 1]. C [Source 2]. D [Source 3].';
+    const out = extractCitedSourcesFromText(text, sources);
+    expect(out.map((s) => s.id)).toEqual(['s1', 's2', 's3']);
+  });
+
+  it('ignores out-of-range citations', () => {
+    const text = 'Maybe [Source 99] or [Source 1].';
+    const out = extractCitedSourcesFromText(text, sources);
+    expect(out.map((s) => s.id)).toEqual(['s1']);
+  });
+
+  it('tolerates extra whitespace inside the bracket', () => {
+    const text = 'Note [Source  2] here.';
+    const out = extractCitedSourcesFromText(text, sources);
+    expect(out.map((s) => s.id)).toEqual(['s2']);
+  });
+});
+
+describe('buildSkippedJudgeValidation', () => {
+  it('marks the validation as un-judged so telemetry can split fast-path traces', () => {
+    const v = buildSkippedJudgeValidation(2);
+    expect(v.judged).toBe(false);
+    expect(v.citationCount).toBe(2);
+    expect(v.hasHallucinations).toBe(false);
+    expect(v.isGrounded).toBe(true);
+    expect(v.confidence).toBe(1);
+  });
+});

--- a/frontend/src/components/chat/message-bubble.tsx
+++ b/frontend/src/components/chat/message-bubble.tsx
@@ -12,7 +12,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import type { Message } from '@/types';
-import { SourceCitations } from './source-citations';
+import { SourceCitations, SourceReference } from './source-citations';
 // ISSUE #39 FIX: Import sanitization utility for XSS protection
 import { sanitizeMessageContent, containsSuspiciousContent } from '@/lib/utils/sanitize';
 
@@ -87,13 +87,18 @@ export function MessageBubble({
         >
           {/* Message text with markdown support */}
           <div className="prose prose-sm dark:prose-invert max-w-none">
-            <MessageContent content={message.content} isStreaming={isStreaming} />
+            <MessageContent
+              content={message.content}
+              isStreaming={isStreaming}
+              messageId={message.id}
+              sourcesCount={message.sources?.length ?? 0}
+            />
           </div>
         </div>
 
         {/* Source citations for assistant messages */}
         {!isUser && message.sources && message.sources.length > 0 && (
-          <SourceCitations sources={message.sources} />
+          <SourceCitations sources={message.sources} messageId={message.id} />
         )}
 
         {/* Actions for assistant messages */}
@@ -198,29 +203,72 @@ export function MessageBubble({
   );
 }
 
+function scrollToSource(messageId: string, n: number) {
+  if (typeof document === 'undefined') return;
+  const el = document.getElementById(`source-${messageId}-${n}`);
+  if (!el) return;
+  el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  el.classList.add('ring-2', 'ring-primary');
+  setTimeout(() => el.classList.remove('ring-2', 'ring-primary'), 1200);
+}
+
+function renderLineWithCitations(
+  line: string,
+  messageId: string | undefined,
+  sourcesCount: number,
+  keyPrefix: string
+) {
+  if (!messageId || sourcesCount === 0) return line;
+  const parts: Array<string | { idx: number }> = [];
+  const regex = /\[Source (\d+)\]/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(line)) !== null) {
+    if (match.index > lastIndex) parts.push(line.slice(lastIndex, match.index));
+    const idx = Number(match[1]);
+    if (idx >= 1 && idx <= sourcesCount) parts.push({ idx });
+    else parts.push(match[0]);
+    lastIndex = match.index + match[0].length;
+  }
+  if (parts.length === 0) return line;
+  if (lastIndex < line.length) parts.push(line.slice(lastIndex));
+  return parts.map((part, i) => {
+    if (typeof part === 'string') return <span key={`${keyPrefix}-${i}`}>{part}</span>;
+    return (
+      <SourceReference
+        key={`${keyPrefix}-${i}`}
+        index={part.idx}
+        onClick={() => scrollToSource(messageId, part.idx)}
+      />
+    );
+  });
+}
+
 // Simple markdown-like content renderer
 // ISSUE #39 FIX: Added XSS sanitization for message content
 function MessageContent({
   content,
   isStreaming,
+  messageId,
+  sourcesCount = 0,
 }: {
   content: string;
   isStreaming: boolean;
+  messageId?: string;
+  sourcesCount?: number;
 }) {
-  // Memoize sanitized content to avoid re-sanitizing on every render
   const sanitizedContent = useMemo(() => {
     containsSuspiciousContent(content);
     return sanitizeMessageContent(content);
   }, [content]);
 
-  // Simple rendering - can be enhanced with a proper markdown library
   const lines = sanitizedContent.split('\n');
 
   return (
     <div className="whitespace-pre-wrap break-words">
       {lines.map((line, i) => (
         <span key={i}>
-          {line}
+          {renderLineWithCitations(line, messageId, sourcesCount, `m-${i}`)}
           {i < lines.length - 1 && <br />}
         </span>
       ))}

--- a/frontend/src/components/chat/source-citations.tsx
+++ b/frontend/src/components/chat/source-citations.tsx
@@ -29,9 +29,12 @@ function isValidExternalUrl(url: string): boolean {
 interface SourceCitationsProps {
   sources: Source[];
   maxVisible?: number;
+  /** Stable id of the parent message — used to mint per-message DOM ids on
+   * each source card so inline `[Source N]` references can scroll to them. */
+  messageId?: string;
 }
 
-export function SourceCitations({ sources, maxVisible = 3 }: SourceCitationsProps) {
+export function SourceCitations({ sources, maxVisible = 3, messageId }: SourceCitationsProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [expandedSources, setExpandedSources] = useState<Set<string>>(new Set());
 
@@ -69,6 +72,7 @@ export function SourceCitations({ sources, maxVisible = 3 }: SourceCitationsProp
             index={index + 1}
             isExpanded={expandedSources.has(source.id)}
             onToggle={() => toggleSource(source.id)}
+            domId={messageId ? `source-${messageId}-${index + 1}` : undefined}
           />
         ))}
       </div>
@@ -102,9 +106,11 @@ interface SourceCardProps {
   index: number;
   isExpanded: boolean;
   onToggle: () => void;
+  /** DOM id used by inline `[Source N]` jump buttons to scroll here. */
+  domId?: string;
 }
 
-function SourceCard({ source, index, isExpanded, onToggle }: SourceCardProps) {
+function SourceCard({ source, index, isExpanded, onToggle, domId }: SourceCardProps) {
   const hasContent = source.content && source.content.length > 0;
   const truncatedContent =
     source.content && source.content.length > 200
@@ -112,7 +118,10 @@ function SourceCard({ source, index, isExpanded, onToggle }: SourceCardProps) {
       : source.content;
 
   return (
-    <div className="border rounded-lg bg-card overflow-hidden">
+    <div
+      id={domId}
+      className="border rounded-lg bg-card overflow-hidden transition-shadow scroll-mt-20"
+    >
       <Collapsible open={isExpanded} onOpenChange={onToggle}>
         <CollapsibleTrigger asChild>
           <button


### PR DESCRIPTION
## Summary
Promotes #249 from `dev` to `main`. Single commit shipping:

- **#249** perf(chat): async judge + clickable [Source N] refs (#244 polish)

## What it does
- New `RAG_CHAT_ASYNC_JUDGE` env flag — when set in prod, drops chat `totalTime` from ~9.8s to <3s by running the LLM judge in the background after stream close.
- Frontend: inline `[Source N]` tokens become clickable buttons that scroll to the matching source card and briefly highlight it.

## Behavior change
Code-only — no behavior change without `RAG_CHAT_ASYNC_JUDGE=true` in prod env. The frontend citation click is always-on but only renders when sources exist.

## Pre-deploy checklist
After CD deploys, the operator must:
1. SOPS-hotfix `backend/.env.production.enc` to add `RAG_CHAT_ASYNC_JUDGE=true`.
2. Verify prod `totalTime < 3000` on retrieva.online chat.
3. Click an inline `[Source N]` token in a chat answer; verify it scrolls + highlights the corresponding source card.

## Hallucination gating note
With `RAG_CHAT_ASYNC_JUDGE=true`, the synchronous hallucination block is bypassed. Current prod has `hallucinationBlocking.strictMode=false`, so this is a small step beyond today's behavior. Background judge logs `warn` when it flags hallucination — audit those for any pattern before considering whether to keep the flag on.

## Test plan
- [ ] CI green
- [ ] After merge: SOPS env + CD deploy
- [ ] retrieva.online chat: totalTime < 3000 in `docker logs retrieva-backend`
- [ ] Inline `[Source N]` jumps work
- [ ] Back-merge `main → dev`