### PR TITLE
fix(workers): wire orphan workers and drop unused memory-decay queue

### DIFF
--- a/backend/config/queue.js
+++ b/backend/config/queue.js
@@ -3,7 +3,6 @@ import { Queue } from 'bullmq';
 import { redisConnection } from './redis.js';
 import logger from './logger.js';
 
-const MEMORY_DECAY_INTERVAL_HOURS = parseInt(process.env.MEMORY_DECAY_INTERVAL_HOURS) || 24;
 const MONITORING_INTERVAL_HOURS = parseInt(process.env.MONITORING_INTERVAL_HOURS) || 24;
 
 /**
@@ -78,31 +77,6 @@ export const monitoringQueue = new Queue('monitoringJobs', {
 });
 
 /**
- * Queue for memory decay and archival operations
- * Handles:
- * - Archiving old conversations
- * - Entity decay processing
- * - Orphaned data cleanup
- */
-export const memoryDecayQueue = new Queue('memoryDecay', {
-  connection: redisConnection,
-  defaultJobOptions: {
-    attempts: 3,
-    backoff: {
-      type: 'exponential',
-      delay: 60000, // Start with 1 minute
-    },
-    removeOnComplete: {
-      count: 10,
-      age: 24 * 60 * 60, // Keep for 1 day
-    },
-    removeOnFail: {
-      count: 20,
-    },
-  },
-});
-
-/**
  * Helper: wrap a promise with a timeout
  */
 function withTimeout(promise, ms) {
@@ -116,42 +90,6 @@ function withTimeout(promise, ms) {
 }
 
 const QUEUE_OP_TIMEOUT = parseInt(process.env.QUEUE_OP_TIMEOUT_MS) || 10000;
-
-/**
- * Schedule recurring memory decay job
- * Runs every 24 hours by default
- */
-export async function scheduleMemoryDecayJob() {
-  const jobName = 'scheduled-memory-decay';
-
-  // Remove existing repeatable job if any (with timeout to prevent hanging)
-  const existingJobs = await withTimeout(memoryDecayQueue.getRepeatableJobs(), QUEUE_OP_TIMEOUT);
-  for (const job of existingJobs) {
-    if (job.name === jobName) {
-      await withTimeout(memoryDecayQueue.removeRepeatableByKey(job.key), QUEUE_OP_TIMEOUT);
-    }
-  }
-
-  // Schedule new repeatable job
-  await withTimeout(
-    memoryDecayQueue.add(
-      jobName,
-      { scheduled: true, timestamp: new Date().toISOString() },
-      {
-        repeat: {
-          every: MEMORY_DECAY_INTERVAL_HOURS * 60 * 60 * 1000, // Convert hours to ms
-        },
-        jobId: 'memory-decay-scheduled',
-      }
-    ),
-    QUEUE_OP_TIMEOUT
-  );
-
-  logger.info('Memory decay job scheduled', {
-    service: 'queue',
-    intervalHours: MEMORY_DECAY_INTERVAL_HOURS,
-  });
-}
 
 /**
  * Schedule weekly digest email job
@@ -218,17 +156,10 @@ export async function scheduleMonitoringJob() {
 
 // ISSUE #34 FIX: Store event listener references for cleanup
 const queueEventListeners = {
-  memoryDecay: null,
   assessmentJobs: null,
   questionnaireJobs: null,
   monitoringJobs: null,
 };
-
-// Log queue events with stored references
-queueEventListeners.memoryDecay = (error) => {
-  logger.error('Memory decay queue error:', { error: error.message, stack: error.stack });
-};
-memoryDecayQueue.on('error', queueEventListeners.memoryDecay);
 
 queueEventListeners.assessmentJobs = (error) => {
   logger.error('Assessment jobs queue error:', { error: error.message, stack: error.stack });
@@ -254,9 +185,6 @@ logger.info('BullMQ queues initialized successfully');
 export const closeQueues = async () => {
   try {
     // Remove event listeners to prevent memory leaks
-    if (queueEventListeners.memoryDecay) {
-      memoryDecayQueue.off('error', queueEventListeners.memoryDecay);
-    }
     if (queueEventListeners.assessmentJobs) {
       assessmentQueue.off('error', queueEventListeners.assessmentJobs);
     }
@@ -270,7 +198,6 @@ export const closeQueues = async () => {
     }
 
     await Promise.all([
-      memoryDecayQueue.close(),
       assessmentQueue.close(),
       questionnaireQueue.close(),
       monitoringQueue.close(),
@@ -282,11 +209,9 @@ export const closeQueues = async () => {
 };
 
 export default {
-  memoryDecayQueue,
   assessmentQueue,
   questionnaireQueue,
   monitoringQueue,
-  scheduleMemoryDecayJob,
   scheduleMonitoringJob,
   scheduleWeeklyDigestJob,
   closeQueues,

--- a/backend/services/deadLetterQueue.js
+++ b/backend/services/deadLetterQueue.js
@@ -13,7 +13,6 @@
 
 import { DeadLetterJob } from '../models/DeadLetterJob.js';
 import logger from '../config/logger.js';
-import { memoryDecayQueue } from '../config/queue.js';
 
 /**
  * Route a failed job to the Dead Letter Queue
@@ -289,9 +288,7 @@ export async function bulkDismissOld(olderThanDays = 7, dismissedBy = 'system') 
  * Get queue by name
  */
 function getQueueByName(queueName) {
-  const queues = {
-    memoryDecay: memoryDecayQueue,
-  };
+  const queues = {};
   return queues[queueName] || null;
 }
 

--- a/backend/tests/integrationtest/assessment.integration.test.js
+++ b/backend/tests/integrationtest/assessment.integration.test.js
@@ -98,7 +98,6 @@ vi.mock('../../config/queue.js', () => ({
     getJob: vi.fn().mockResolvedValue(null),
     on: vi.fn(),
   },
-  memoryDecayQueue: { add: vi.fn().mockResolvedValue({}), on: vi.fn() },
 }));
 
 // File ingestion service — prevents Qdrant connections

--- a/backend/tests/integrationtest/risk-decision.integration.test.js
+++ b/backend/tests/integrationtest/risk-decision.integration.test.js
@@ -85,7 +85,6 @@ vi.mock('../../services/authAuditService.js', () => ({
 
 vi.mock('../../config/queue.js', () => ({
   assessmentQueue: { add: vi.fn().mockResolvedValue({ id: 'j1' }), on: vi.fn() },
-  memoryDecayQueue: { add: vi.fn().mockResolvedValue({}), on: vi.fn() },
   monitoringQueue: {
     add: vi.fn().mockResolvedValue({ id: 'review-r1' }),
     getJob: vi.fn().mockResolvedValue(null),

--- a/backend/workers/index.js
+++ b/backend/workers/index.js
@@ -1,4 +1,6 @@
 import './assessmentWorker.js';
+import './questionnaireWorker.js';
+import './monitoringWorker.js';
 import logger from '../config/logger.js';
 import { disconnectRedis } from '../config/redis.js';
 import { closeQueues } from '../config/queue.js';
@@ -9,6 +11,8 @@ logger.info('BullMQ Workers Started');
 logger.info('='.repeat(60));
 logger.info('Active workers:');
 logger.info('  - Assessment Worker (concurrency: 2)');
+logger.info('  - Questionnaire Worker');
+logger.info('  - Monitoring Worker (24h schedule)');
 logger.info('='.repeat(60));
 
 /**


### PR DESCRIPTION
## Summary

P0 from the backend architecture audit — fixes two silently-broken queue/worker subsystems and removes one fully unused queue.

- **Wire orphan workers** into `workers/index.js`: previously only `assessmentWorker` was imported; `questionnaireWorker` and `monitoringWorker` were never started when running `npm run workers` (the separate-process entrypoint). The in-process API server already loads all three via `backend/index.js`, so this aligns the two entrypoints.
- **Delete `memoryDecayQueue` + `scheduleMemoryDecayJob`** from `config/queue.js`: no producer ever called the scheduler and no worker consumed the queue. Pure scaffold.
- **Drop dangling `memoryDecayQueue` import** from `services/deadLetterQueue.js` (this whole file is slated for P1 dead-code removal, but fixing the broken import now keeps the file parseable).
- **Update two integration test mocks** to drop the now-irrelevant `memoryDecayQueue` stub key.

Net diff: **5 files, +5 / -81 lines**.

## Test plan

- [x] `node --check` passes on all 3 modified backend source files
- [x] 63/63 unit tests pass across queue-touching files (`questionnaireController.test.js`, `assessmentService.unit.test.js`, `assessment-controller.unit.test.js`)
- [x] `docker compose up -d --build backend` boots cleanly:
  - All three worker banners present: `Assessment Worker: Active`, `Questionnaire Worker: Active`, `Monitoring Worker: Active (24h schedule)`
  - `Monitoring alerts job scheduled` logged at startup
  - `BullMQ queues initialized successfully` with no `memoryDecay` references
  - No startup errors
  - `GET /health` returns `{"status":"success"}`
- [x] `npm run workers` parity verified inside container: now lists all three workers (previously only Assessment)
- [ ] CI to run full backend + frontend test suite (skipped locally due to unrelated iCloud Drive sync corruption of node_modules on this dev machine; clean CI environment is the authoritative validation)

## Follow-ups

- **P1 dead-code removal** (next PR): `services/deadLetterQueue.js`, `loaders/documentLoader.js`, `services/rag/{indexDeduplication,contextExpansion}.js`, `utils/rag/documentRetryTracker.js`, `services/search/**`, `models/InvertedIndex.js`
- **P2–P5** from the audit: missing repositories, service extraction from controllers, repository adoption sweep