### PR TITLE
feat(repositories): add six missing repositories (P2)

### DIFF
--- a/backend/repositories/OrganizationMemberRepository.js
+++ b/backend/repositories/OrganizationMemberRepository.js
@@ -1,0 +1,27 @@
+import { BaseRepository } from './BaseRepository.js';
+import { OrganizationMember } from '../models/OrganizationMember.js';
+
+class OrganizationMemberRepository extends BaseRepository {
+  constructor(model = OrganizationMember) {
+    super(model);
+  }
+
+  async findActiveByUserId(userId) {
+    return this.findOne({ userId, status: 'active' });
+  }
+
+  async findByOrganization(organizationId, status = 'active') {
+    return this.find({ organizationId, status });
+  }
+
+  async revokeMembership(memberId) {
+    return this.updateById(memberId, { status: 'revoked' });
+  }
+
+  async countAdmins(organizationId) {
+    return this.count({ organizationId, role: 'admin', status: 'active' });
+  }
+}
+
+export const organizationMemberRepository = new OrganizationMemberRepository();
+export { OrganizationMemberRepository };

--- a/backend/repositories/OrganizationRepository.js
+++ b/backend/repositories/OrganizationRepository.js
@@ -1,0 +1,11 @@
+import { BaseRepository } from './BaseRepository.js';
+import { Organization } from '../models/Organization.js';
+
+class OrganizationRepository extends BaseRepository {
+  constructor(model = Organization) {
+    super(model);
+  }
+}
+
+export const organizationRepository = new OrganizationRepository();
+export { OrganizationRepository };

--- a/backend/repositories/QuestionnaireTemplateRepository.js
+++ b/backend/repositories/QuestionnaireTemplateRepository.js
@@ -1,0 +1,15 @@
+import { BaseRepository } from './BaseRepository.js';
+import QuestionnaireTemplate from '../models/QuestionnaireTemplate.js';
+
+class QuestionnaireTemplateRepository extends BaseRepository {
+  constructor(model = QuestionnaireTemplate) {
+    super(model);
+  }
+
+  async findDefault() {
+    return this.findOne({ isDefault: true });
+  }
+}
+
+export const questionnaireTemplateRepository = new QuestionnaireTemplateRepository();
+export { QuestionnaireTemplateRepository };

--- a/backend/repositories/UserRepository.js
+++ b/backend/repositories/UserRepository.js
@@ -1,0 +1,19 @@
+import { BaseRepository } from './BaseRepository.js';
+import { User } from '../models/User.js';
+
+class UserRepository extends BaseRepository {
+  constructor(model = User) {
+    super(model);
+  }
+
+  async findByEmail(email, options = {}) {
+    return this.findOne({ email: email.toLowerCase() }, options);
+  }
+
+  async updateLastLogin(userId) {
+    return this.model.updateOne({ _id: userId }, { $set: { lastLogin: new Date() } });
+  }
+}
+
+export const userRepository = new UserRepository();
+export { UserRepository };

--- a/backend/repositories/VendorQuestionnaireRepository.js
+++ b/backend/repositories/VendorQuestionnaireRepository.js
@@ -1,0 +1,15 @@
+import { BaseRepository } from './BaseRepository.js';
+import { VendorQuestionnaire } from '../models/VendorQuestionnaire.js';
+
+class VendorQuestionnaireRepository extends BaseRepository {
+  constructor(model = VendorQuestionnaire) {
+    super(model);
+  }
+
+  async findByToken(token, options = {}) {
+    return this.findOne({ token }, options);
+  }
+}
+
+export const vendorQuestionnaireRepository = new VendorQuestionnaireRepository();
+export { VendorQuestionnaireRepository };

--- a/backend/repositories/WorkspaceMemberRepository.js
+++ b/backend/repositories/WorkspaceMemberRepository.js
@@ -1,0 +1,27 @@
+import { BaseRepository } from './BaseRepository.js';
+import { WorkspaceMember } from '../models/WorkspaceMember.js';
+
+class WorkspaceMemberRepository extends BaseRepository {
+  constructor(model = WorkspaceMember) {
+    super(model);
+  }
+
+  async findMembership(workspaceId, userId) {
+    return this.findOne({ workspaceId, userId, status: 'active' });
+  }
+
+  async findActiveByUserId(userId) {
+    return this.find({ userId, status: 'active' });
+  }
+
+  async findByWorkspace(workspaceId, status = 'active') {
+    return this.find({ workspaceId, status });
+  }
+
+  async deleteByWorkspace(workspaceId) {
+    return this.deleteMany({ workspaceId });
+  }
+}
+
+export const workspaceMemberRepository = new WorkspaceMemberRepository();
+export { WorkspaceMemberRepository };

--- a/backend/repositories/index.js
+++ b/backend/repositories/index.js
@@ -26,3 +26,21 @@ export { MessageRepository, messageRepository } from './MessageRepository.js';
 export { ConversationRepository, conversationRepository } from './ConversationRepository.js';
 export { AssessmentRepository, assessmentRepository } from './AssessmentRepository.js';
 export { WorkspaceRepository, workspaceRepository } from './WorkspaceRepository.js';
+export { UserRepository, userRepository } from './UserRepository.js';
+export { OrganizationRepository, organizationRepository } from './OrganizationRepository.js';
+export {
+  OrganizationMemberRepository,
+  organizationMemberRepository,
+} from './OrganizationMemberRepository.js';
+export {
+  WorkspaceMemberRepository,
+  workspaceMemberRepository,
+} from './WorkspaceMemberRepository.js';
+export {
+  QuestionnaireTemplateRepository,
+  questionnaireTemplateRepository,
+} from './QuestionnaireTemplateRepository.js';
+export {
+  VendorQuestionnaireRepository,
+  vendorQuestionnaireRepository,
+} from './VendorQuestionnaireRepository.js';


### PR DESCRIPTION
## Summary

P2 from the backend architecture audit. Adds repository wrappers for the six models that lacked them, so future controller/service refactors (P3) have a complete repository layer to call into.

**Net diff:** 7 files, +132 lines, 0 deletions. Pure additive — no consumers changed yet.

## New repositories

| Repository | Model | Domain methods (beyond BaseRepository) |
|---|---|---|
| `UserRepository` | `User` | `findByEmail(email, options)`, `updateLastLogin(userId)` |
| `OrganizationRepository` | `Organization` | _(none — BaseRepository sufficient for current patterns)_ |
| `OrganizationMemberRepository` | `OrganizationMember` | `findActiveByUserId`, `findByOrganization(orgId, status)`, `revokeMembership`, `countAdmins` |
| `WorkspaceMemberRepository` | `WorkspaceMember` | `findMembership(workspaceId, userId)`, `findActiveByUserId`, `findByWorkspace(wsId, status)`, `deleteByWorkspace` |
| `QuestionnaireTemplateRepository` | `QuestionnaireTemplate` | `findDefault()` |
| `VendorQuestionnaireRepository` | `VendorQuestionnaire` | `findByToken(token, options)` |

Each domain method was chosen from grep-observed patterns in current controllers/services — these are the queries that recur and would benefit from a stable, intent-revealing name.

All six repositories follow the existing pattern from `AssessmentRepository` / `WorkspaceRepository` / `ConversationRepository` / `MessageRepository`:

- Extend `BaseRepository`
- Constructor accepts a model override (for test injection)
- Export both the class and a singleton instance
- Re-exported from `repositories/index.js`

## Test plan

- [x] `node --check` passes on all 7 new/edited files
- [x] `docker compose up -d --build backend` boots cleanly:
  - All three worker banners present (Assessment / Questionnaire / Monitoring)
  - `BullMQ queues initialized successfully`
  - `Monitoring alerts job scheduled`
  - Zero module-load errors
  - `GET /health` returns `{"status":"success"}`
- [ ] CI to run full backend + frontend test suite

## What this doesn't do

- **No consumers changed.** Controllers and services still call models directly. That sweep is P3 work, broken into per-controller PRs.
- No new BaseRepository methods. Existing ones are enough for the patterns added here.