### PR TITLE
refactor: extract ConversationService from conversationController (P3a)

### DIFF
--- a/backend/controllers/conversationController.js
+++ b/backend/controllers/conversationController.js
@@ -1,41 +1,12 @@
-import { Conversation } from '../models/Conversation.js';
-import { Message } from '../models/Message.js';
-import { WorkspaceMember } from '../models/WorkspaceMember.js';
-import { ragService } from '../services/rag.js';
-import {
-  catchAsync,
-  sendSuccess,
-  sendError,
-  getUserId,
-  parsePagination,
-  verifyOwnership,
-} from '../utils/index.js';
+import { conversationService } from '../services/ConversationService.js';
+import { catchAsync, sendSuccess, getUserId, parsePagination } from '../utils/index.js';
 import logger from '../config/logger.js';
-
-/**
- * Get user's primary workspace ID (first active workspace they belong to)
- * @param {string} userId - User's MongoDB ID
- * @returns {Promise<string|null>} Workspace ID or null if none found
- */
-async function getUserPrimaryWorkspace(userId) {
-  const membership = await WorkspaceMember.findOne({
-    userId,
-    status: 'active',
-  }).populate('workspaceId', '_id');
-
-  return membership?.workspaceId?._id?.toString() || null;
-}
 
 /**
  * Create a new conversation
  * POST /api/v1/conversations
- *
- * FIX: Auto-assign user's workspace if not provided (fixes "default" workspace issue)
- * ISSUE #25 FIX: Added idempotency key support to prevent race conditions
  */
 export const createConversation = catchAsync(async (req, res) => {
-  // ISSUE #15 FIX: Sanitize logged data - don't log full request body
-  // which may contain sensitive user content
   logger.debug('createConversation called', {
     hasTitle: !!req.body?.title,
     hasWorkspaceId: !!(req.headers['x-workspace-id'] || req.body?.workspaceId),
@@ -44,76 +15,16 @@ export const createConversation = catchAsync(async (req, res) => {
 
   const { title } = req.body;
   const userId = getUserId(req);
-
-  // ISSUE #25 FIX: Support idempotency key to prevent duplicate creations
   const idempotencyKey = req.headers['x-idempotency-key'] || req.body.idempotencyKey;
+  const workspaceId =
+    req.headers['x-workspace-id'] || req.body.workspaceId || req.query.workspaceId;
 
-  // Get workspaceId from header, body, query, or auto-lookup user's workspace
-  let workspaceId = req.headers['x-workspace-id'] || req.body.workspaceId || req.query.workspaceId;
-
-  // If no workspace specified, auto-lookup user's primary workspace
-  if (!workspaceId) {
-    workspaceId = await getUserPrimaryWorkspace(userId);
-    if (workspaceId) {
-      logger.info('Auto-assigned user workspace', {
-        service: 'conversation',
-        userId,
-        workspaceId,
-      });
-    }
-  }
-
-  logger.info('Creating conversation', {
-    service: 'conversation',
+  const { conversation, wasCreated } = await conversationService.createConversation({
     userId,
-    workspaceId: workspaceId || 'default',
     title,
-    hasIdempotencyKey: !!idempotencyKey,
+    workspaceId,
+    idempotencyKey,
   });
-
-  const conversationData = {
-    title: title || 'New Conversation',
-    userId,
-    workspaceId: workspaceId || 'default',
-  };
-
-  let conversation;
-  let wasCreated = true;
-
-  // ISSUE #25 FIX: If idempotency key provided, use findOneAndUpdate to prevent duplicates
-  if (idempotencyKey) {
-    const result = await Conversation.findOneAndUpdate(
-      {
-        userId,
-        workspaceId: conversationData.workspaceId,
-        'metadata.idempotencyKey': idempotencyKey,
-      },
-      {
-        $setOnInsert: {
-          ...conversationData,
-          metadata: { idempotencyKey },
-        },
-      },
-      {
-        upsert: true,
-        new: true,
-        setDefaultsOnInsert: true,
-        rawResult: true,
-      }
-    );
-    conversation = result.value;
-    wasCreated = result.lastErrorObject?.upserted !== undefined;
-
-    if (!wasCreated) {
-      logger.info('Returning existing conversation (idempotent request)', {
-        service: 'conversation',
-        conversationId: conversation._id,
-        idempotencyKey,
-      });
-    }
-  } else {
-    conversation = await Conversation.create(conversationData);
-  }
 
   logger.info(wasCreated ? 'Created new conversation' : 'Retrieved existing conversation', {
     service: 'conversation',
@@ -136,34 +47,17 @@ export const createConversation = catchAsync(async (req, res) => {
 /**
  * Get all conversations for a user
  * GET /api/v1/conversations
- *
- * SECURITY FIX: Filter by workspaceId for tenant isolation
- * ISSUE #22 FIX: Added .lean() for read-only query
- * ISSUE #23 FIX: Parallelized find and count queries
  */
 export const getConversations = catchAsync(async (req, res) => {
   const userId = getUserId(req);
   const { limit, skip } = parsePagination(req.query, { defaultLimit: 50, maxLimit: 100 });
-
-  // Get workspaceId from header
   const workspaceId = req.headers['x-workspace-id'] || req.query.workspaceId;
 
-  // Build query filter
-  const query = { userId };
-  if (workspaceId) {
-    query.workspaceId = workspaceId;
-  }
-
-  // ISSUE #23 FIX: Run find and count in parallel
-  const [conversations, total] = await Promise.all([
-    Conversation.find(query)
-      .sort({ updatedAt: -1 })
-      .limit(limit)
-      .skip(skip)
-      .select('title userId workspaceId messageCount lastMessageAt createdAt updatedAt')
-      .lean(), // ISSUE #22 FIX: Use lean() for read-only queries
-    Conversation.countDocuments(query),
-  ]);
+  const { conversations, total } = await conversationService.listConversations(userId, {
+    workspaceId,
+    limit,
+    skip,
+  });
 
   sendSuccess(res, 200, 'Conversations retrieved successfully', {
     conversations: conversations.map((c) => ({
@@ -188,40 +82,17 @@ export const getConversations = catchAsync(async (req, res) => {
 /**
  * Get a specific conversation with messages
  * GET /api/v1/conversations/:id
- * ISSUE #22 FIX: Added .lean() for read-only queries
- * ISSUE #23 FIX: Parallelized message queries after auth check
  */
 export const getConversation = catchAsync(async (req, res) => {
   const { id } = req.params;
   const { limit, skip } = parsePagination(req.query, { defaultLimit: 100, maxLimit: 500 });
   const userId = getUserId(req);
 
-  // Need full document for ownership check first
-  const conversation = await Conversation.findById(id).lean();
-  if (!conversation) {
-    return sendError(res, 404, 'Conversation not found');
-  }
-
-  if (!verifyOwnership(conversation.userId, userId)) {
-    logger.warn('Unauthorized conversation access attempt', {
-      service: 'conversation',
-      conversationId: id,
-      requestUserId: userId,
-      ownerUserId: conversation.userId,
-    });
-    return sendError(res, 403, 'Access denied');
-  }
-
-  // ISSUE #23 FIX: Parallelize message fetch and count after auth check
-  const [messages, totalMessages] = await Promise.all([
-    Message.find({ conversationId: id })
-      .sort({ timestamp: 1 })
-      .limit(limit)
-      .skip(skip)
-      .select('role content sources timestamp')
-      .lean(), // ISSUE #22 FIX
-    Message.countDocuments({ conversationId: id }),
-  ]);
+  const { conversation, messages, totalMessages } = await conversationService.getConversation(
+    id,
+    userId,
+    { limit, skip }
+  );
 
   sendSuccess(res, 200, 'Conversation retrieved successfully', {
     conversation: {
@@ -258,36 +129,7 @@ export const askQuestion = catchAsync(async (req, res) => {
   const { question, filters } = req.body;
   const userId = getUserId(req);
 
-  if (!question || question.trim().length === 0) {
-    return sendError(res, 400, 'Question is required');
-  }
-
-  if (question.length > 5000) {
-    return sendError(res, 400, 'Question is too long (max 5000 characters)');
-  }
-
-  // Verify conversation exists
-  const conversation = await Conversation.findById(id);
-  if (!conversation) {
-    return sendError(res, 404, 'Conversation not found');
-  }
-
-  if (!verifyOwnership(conversation.userId, userId)) {
-    return sendError(res, 403, 'Access denied');
-  }
-
-  logger.info('Processing question in conversation', {
-    service: 'conversation',
-    conversationId: id,
-    questionLength: question.length,
-    filters: filters || 'none', // Enhancement 12: Log filters
-  });
-
-  // Enhancement 12: Use RAG service with optional filters
-  const answer = await ragService.askWithConversation(question, {
-    conversationId: id,
-    filters: filters || null,
-  });
+  const answer = await conversationService.askQuestion(id, userId, { question, filters });
 
   sendSuccess(res, 200, 'Question answered successfully', {
     answer,
@@ -304,28 +146,7 @@ export const updateConversation = catchAsync(async (req, res) => {
   const { title } = req.body;
   const userId = getUserId(req);
 
-  if (!title || title.trim().length === 0) {
-    return sendError(res, 400, 'Title is required');
-  }
-
-  const existingConversation = await Conversation.findById(id);
-  if (!existingConversation) {
-    return sendError(res, 404, 'Conversation not found');
-  }
-
-  if (!verifyOwnership(existingConversation.userId, userId)) {
-    return sendError(res, 403, 'Access denied');
-  }
-
-  const conversation = await Conversation.findByIdAndUpdate(
-    id,
-    { title: title.trim() },
-    { new: true, runValidators: true }
-  );
-
-  if (!conversation) {
-    return sendError(res, 404, 'Conversation not found');
-  }
+  const conversation = await conversationService.updateConversation(id, userId, { title });
 
   logger.info('Updated conversation', {
     service: 'conversation',
@@ -351,79 +172,20 @@ export const deleteConversation = catchAsync(async (req, res) => {
   const { id } = req.params;
   const userId = getUserId(req);
 
-  const conversation = await Conversation.findById(id);
-  if (!conversation) {
-    return sendError(res, 404, 'Conversation not found');
-  }
+  await conversationService.deleteConversation(id, userId);
 
-  if (!verifyOwnership(conversation.userId, userId)) {
-    return sendError(res, 403, 'Access denied');
-  }
-
-  // Delete all messages in the conversation
-  await Message.deleteMany({ conversationId: id });
-
-  // Delete the conversation
-  await Conversation.findByIdAndDelete(id);
-
-  logger.info('Deleted conversation and all messages', {
-    service: 'conversation',
-    conversationId: id,
-  });
-
-  sendSuccess(res, 200, 'Conversation deleted successfully', {
-    deletedId: id,
-  });
+  sendSuccess(res, 200, 'Conversation deleted successfully', { deletedId: id });
 });
 
 /**
  * Bulk delete multiple conversations and their messages
  * POST /api/v1/conversations/bulk-delete
- * Body: { ids: ["id1", "id2", ...] }
  */
 export const bulkDeleteConversations = catchAsync(async (req, res) => {
   const { ids } = req.body;
   const userId = getUserId(req);
 
-  if (!ids || !Array.isArray(ids) || ids.length === 0) {
-    return sendError(res, 400, 'ids array is required');
-  }
+  const result = await conversationService.bulkDelete(ids, userId);
 
-  if (ids.length > 100) {
-    return sendError(res, 400, 'Cannot delete more than 100 conversations at once');
-  }
-
-  // Verify all conversations belong to the user
-  // ISSUE #22 FIX: Use .lean() for read-only query
-  const conversations = await Conversation.find({
-    _id: { $in: ids },
-    userId: userId,
-  }).lean();
-
-  if (conversations.length === 0) {
-    return sendError(res, 404, 'No conversations found');
-  }
-
-  const validIds = conversations.map((c) => c._id);
-  const invalidCount = ids.length - validIds.length;
-
-  // Delete all messages for these conversations
-  await Message.deleteMany({ conversationId: { $in: validIds } });
-
-  // Delete the conversations
-  const deleteResult = await Conversation.deleteMany({ _id: { $in: validIds } });
-
-  logger.info('Bulk deleted conversations', {
-    service: 'conversation',
-    requestedCount: ids.length,
-    deletedCount: deleteResult.deletedCount,
-    invalidCount,
-    userId,
-  });
-
-  sendSuccess(res, 200, 'Conversations deleted successfully', {
-    deletedCount: deleteResult.deletedCount,
-    deletedIds: validIds,
-    invalidCount,
-  });
+  sendSuccess(res, 200, 'Conversations deleted successfully', result);
 });

--- a/backend/services/ConversationService.js
+++ b/backend/services/ConversationService.js
@@ -1,0 +1,222 @@
+import { AppError } from '../utils/index.js';
+import { verifyOwnership } from '../utils/index.js';
+import { conversationRepository } from '../repositories/ConversationRepository.js';
+import { messageRepository } from '../repositories/MessageRepository.js';
+import { workspaceMemberRepository } from '../repositories/WorkspaceMemberRepository.js';
+import { ragService } from './rag.js';
+import logger from '../config/logger.js';
+
+class ConversationService {
+  constructor(deps = {}) {
+    this.conversationRepo = deps.conversationRepo || conversationRepository;
+    this.messageRepo = deps.messageRepo || messageRepository;
+    this.workspaceMemberRepo = deps.workspaceMemberRepo || workspaceMemberRepository;
+    this.ragService = deps.ragService || ragService;
+    this.logger = deps.logger || logger;
+  }
+
+  async getUserPrimaryWorkspace(userId) {
+    const membership = await this.workspaceMemberRepo.findOne(
+      { userId, status: 'active' },
+      { populate: { path: 'workspaceId', select: '_id' } }
+    );
+    return membership?.workspaceId?._id?.toString() || null;
+  }
+
+  async createConversation({ userId, title, workspaceId, idempotencyKey }) {
+    let resolvedWorkspaceId = workspaceId;
+    if (!resolvedWorkspaceId) {
+      resolvedWorkspaceId = await this.getUserPrimaryWorkspace(userId);
+      if (resolvedWorkspaceId) {
+        this.logger.info('Auto-assigned user workspace', {
+          service: 'conversation',
+          userId,
+          workspaceId: resolvedWorkspaceId,
+        });
+      }
+    }
+
+    const conversationData = {
+      title: title || 'New Conversation',
+      userId,
+      workspaceId: resolvedWorkspaceId || 'default',
+    };
+
+    if (idempotencyKey) {
+      const result = await this.conversationRepo.updateOne(
+        {
+          userId,
+          workspaceId: conversationData.workspaceId,
+          'metadata.idempotencyKey': idempotencyKey,
+        },
+        {
+          $setOnInsert: {
+            ...conversationData,
+            metadata: { idempotencyKey },
+          },
+        },
+        { upsert: true, setDefaultsOnInsert: true, rawResult: true }
+      );
+
+      const conversation = result.value;
+      const wasCreated = result.lastErrorObject?.upserted !== undefined;
+
+      if (!wasCreated) {
+        this.logger.info('Returning existing conversation (idempotent request)', {
+          service: 'conversation',
+          conversationId: conversation._id,
+          idempotencyKey,
+        });
+      }
+      return { conversation, wasCreated };
+    }
+
+    const conversation = await this.conversationRepo.create(conversationData);
+    return { conversation, wasCreated: true };
+  }
+
+  async listConversations(userId, { workspaceId, limit, skip }) {
+    const query = { userId };
+    if (workspaceId) query.workspaceId = workspaceId;
+
+    const [conversations, total] = await Promise.all([
+      this.conversationRepo.find(query, {
+        sort: { updatedAt: -1 },
+        limit,
+        skip,
+        select: 'title userId workspaceId messageCount lastMessageAt createdAt updatedAt',
+        lean: true,
+      }),
+      this.conversationRepo.count(query),
+    ]);
+
+    return { conversations, total };
+  }
+
+  async getConversation(id, userId, { limit, skip }) {
+    const conversation = await this.conversationRepo.findById(id, { lean: true });
+    if (!conversation) throw new AppError('Conversation not found', 404);
+
+    if (!verifyOwnership(conversation.userId, userId)) {
+      this.logger.warn('Unauthorized conversation access attempt', {
+        service: 'conversation',
+        conversationId: id,
+        requestUserId: userId,
+        ownerUserId: conversation.userId,
+      });
+      throw new AppError('Access denied', 403);
+    }
+
+    const [messages, totalMessages] = await Promise.all([
+      this.messageRepo.findByConversation(id, {
+        limit,
+        skip,
+        select: 'role content sources timestamp',
+        lean: true,
+      }),
+      this.messageRepo.count({ conversationId: id }),
+    ]);
+
+    return { conversation, messages, totalMessages };
+  }
+
+  async askQuestion(id, userId, { question, filters }) {
+    if (!question || question.trim().length === 0) {
+      throw new AppError('Question is required', 400);
+    }
+    if (question.length > 5000) {
+      throw new AppError('Question is too long (max 5000 characters)', 400);
+    }
+
+    const conversation = await this.conversationRepo.findById(id);
+    if (!conversation) throw new AppError('Conversation not found', 404);
+    if (!verifyOwnership(conversation.userId, userId)) {
+      throw new AppError('Access denied', 403);
+    }
+
+    this.logger.info('Processing question in conversation', {
+      service: 'conversation',
+      conversationId: id,
+      questionLength: question.length,
+      filters: filters || 'none',
+    });
+
+    return this.ragService.askWithConversation(question, {
+      conversationId: id,
+      filters: filters || null,
+    });
+  }
+
+  async updateConversation(id, userId, { title }) {
+    if (!title || title.trim().length === 0) {
+      throw new AppError('Title is required', 400);
+    }
+
+    const existing = await this.conversationRepo.findById(id);
+    if (!existing) throw new AppError('Conversation not found', 404);
+    if (!verifyOwnership(existing.userId, userId)) {
+      throw new AppError('Access denied', 403);
+    }
+
+    const conversation = await this.conversationRepo.updateById(id, { title: title.trim() });
+    if (!conversation) throw new AppError('Conversation not found', 404);
+    return conversation;
+  }
+
+  async deleteConversation(id, userId) {
+    const conversation = await this.conversationRepo.findById(id);
+    if (!conversation) throw new AppError('Conversation not found', 404);
+    if (!verifyOwnership(conversation.userId, userId)) {
+      throw new AppError('Access denied', 403);
+    }
+
+    await this.messageRepo.deleteMany({ conversationId: id });
+    await this.conversationRepo.deleteById(id);
+
+    this.logger.info('Deleted conversation and all messages', {
+      service: 'conversation',
+      conversationId: id,
+    });
+  }
+
+  async bulkDelete(ids, userId) {
+    if (!ids || !Array.isArray(ids) || ids.length === 0) {
+      throw new AppError('ids array is required', 400);
+    }
+    if (ids.length > 100) {
+      throw new AppError('Cannot delete more than 100 conversations at once', 400);
+    }
+
+    const conversations = await this.conversationRepo.find(
+      { _id: { $in: ids }, userId },
+      { lean: true }
+    );
+
+    if (conversations.length === 0) {
+      throw new AppError('No conversations found', 404);
+    }
+
+    const validIds = conversations.map((c) => c._id);
+    const invalidCount = ids.length - validIds.length;
+
+    await this.messageRepo.deleteMany({ conversationId: { $in: validIds } });
+    const deleteResult = await this.conversationRepo.deleteMany({ _id: { $in: validIds } });
+
+    this.logger.info('Bulk deleted conversations', {
+      service: 'conversation',
+      requestedCount: ids.length,
+      deletedCount: deleteResult.deletedCount,
+      invalidCount,
+      userId,
+    });
+
+    return {
+      deletedCount: deleteResult.deletedCount,
+      deletedIds: validIds,
+      invalidCount,
+    };
+  }
+}
+
+export const conversationService = new ConversationService();
+export { ConversationService };

--- a/backend/tests/integrationtest/rag.integration.test.js
+++ b/backend/tests/integrationtest/rag.integration.test.js
@@ -81,6 +81,15 @@ vi.mock('../../services/rag.js', () => ({
     requestId: 'test-request-id',
   }),
   prewarmRAG: vi.fn().mockResolvedValue(true),
+  // ConversationService consumes ragService as a default dep — provide a stub
+  // so it can be constructed at module-load time without throwing.
+  ragService: {
+    askWithConversation: vi.fn().mockResolvedValue({
+      answer: 'This is a test answer.',
+      sources: [],
+      confidence: 0.8,
+    }),
+  },
 }));
 
 // Mock auth audit service - include all methods used by auth controller


### PR DESCRIPTION
## Summary

P3 from the backend architecture audit, **first slice**. Extracts the conversation business logic from `conversationController.js` into a new `ConversationService`, and routes all data access through repositories instead of importing mongoose models directly.

**Diff:** 2 files, +245 / -261. Controller shrinks 429 → 191 LOC (-55%).

## What moved

The controller was doing:
- `WorkspaceMember.findOne(...).populate(...)` workspace lookup
- `Conversation.findOneAndUpdate(...)` with upsert/idempotency
- `Conversation.create()`, `.find()`, `.countDocuments()`, `.findById()`, `.findByIdAndUpdate()`, `.findByIdAndDelete()`, `.deleteMany()`
- `Message.find()`, `.countDocuments()`, `.deleteMany()`
- Ownership checks, validation, RAG orchestration for `askQuestion`

All of this is now in `services/ConversationService.js`. The controller is thin: parse request → call service → format response.

### Service surface (8 methods)
- `createConversation({ userId, title, workspaceId, idempotencyKey })` → `{ conversation, wasCreated }`
- `listConversations(userId, { workspaceId, limit, skip })` → `{ conversations, total }`
- `getConversation(id, userId, { limit, skip })` → `{ conversation, messages, totalMessages }`
- `askQuestion(id, userId, { question, filters })` → answer
- `updateConversation(id, userId, { title })` → updated conversation
- `deleteConversation(id, userId)` → void
- `bulkDelete(ids, userId)` → `{ deletedCount, deletedIds, invalidCount }`
- `getUserPrimaryWorkspace(userId)` → workspace id

### Repositories used (all already exist)
- `ConversationRepository` — pre-existing
- `MessageRepository` — pre-existing
- `WorkspaceMemberRepository` — added in PR #257 (P2)

## Behavior change (minor)

Error handling moves from controller-level `sendError(res, statusCode, message)` to service-level `throw new AppError(message, statusCode)`, which `catchAsync` passes to `globalErrorHandler`. The HTTP status code and `message` field are unchanged, but **4xx response bodies now report `status: "fail"` instead of `status: "error"`** (per `AppError`'s convention from `utils/core/errorHandler.js`).

The existing integration suite (`tests/integrationtest/conversation.integration.test.js`) only asserts on `status: "success"`, so it remains valid. If any frontend code branches on `body.status === 'error'` for 4xx, it'll need to also accept `'fail'` — but the canonical signal is the HTTP status code.

## Test plan

- [x] `node --check` passes on both files
- [x] `docker compose up -d --build backend` boots cleanly: workers active, queues initialized, zero module-load errors, `/health` returns success
- [ ] CI to run full backend + frontend test suite, including the conversation integration tests

## What this doesn't do

- No frontend changes
- Remaining P3 chunks (Auth, Organization, Questionnaire, Billing services) come in separate PRs