### PR TITLE
refactor: extract BillingService from billingController (P3b)

### DIFF
--- a/backend/controllers/billingController.js
+++ b/backend/controllers/billingController.js
@@ -1,157 +1,30 @@
 /**
  * Billing Controller
  *
- * Handles Stripe webhook events and syncs subscription state to MongoDB.
- *
- * Supported events:
- *   customer.subscription.updated   → sync plan, planStatus, trialEndsAt
- *   customer.subscription.deleted   → set planStatus = 'canceled'
- *   customer.subscription.trial_will_end → send "3 days left" email
- *   invoice.payment_succeeded       → set planStatus = 'active'
- *   invoice.payment_failed          → set planStatus = 'past_due'
+ * Verifies Stripe webhook signatures and dispatches events to BillingService.
+ * Also exposes the customer-portal session endpoint.
  *
  * @module controllers/billingController
  */
 
-import { getStripe, PRICE_TO_PLAN, STRIPE_STATUS_MAP } from '../config/stripe.js';
-import { Organization } from '../models/Organization.js';
-import { emailService } from '../services/emailService.js';
+import { getStripe } from '../config/stripe.js';
+import { billingService } from '../services/BillingService.js';
 import { catchAsync, sendError, sendSuccess } from '../utils/index.js';
 import logger from '../config/logger.js';
 
 const WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET;
 
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-async function findOrgByCustomerId(customerId) {
-  const customer = await getStripe().customers.retrieve(customerId);
-  if (!customer || customer.deleted) return null;
-
-  const orgId = customer.metadata?.organizationId;
-  if (!orgId) return null;
-
-  return Organization.findById(orgId);
-}
-
-function resolvePlan(subscription) {
-  const priceId = subscription.items?.data?.[0]?.price?.id;
-  return PRICE_TO_PLAN[priceId] || 'starter';
-}
-
-// ---------------------------------------------------------------------------
-// Event handlers
-// ---------------------------------------------------------------------------
-
-async function handleSubscriptionUpdated(subscription) {
-  const org = await findOrgByCustomerId(subscription.customer);
-  if (!org) return;
-
-  const plan = resolvePlan(subscription);
-  const planStatus = STRIPE_STATUS_MAP[subscription.status] || 'past_due';
-  const trialEndsAt = subscription.trial_end ? new Date(subscription.trial_end * 1000) : null;
-
-  await Organization.findByIdAndUpdate(org._id, { plan, planStatus, trialEndsAt });
-
-  logger.info('Subscription updated', {
-    service: 'billing',
-    orgId: org._id,
-    plan,
-    planStatus,
-    trialEndsAt,
-  });
-}
-
-async function handleSubscriptionDeleted(subscription) {
-  const org = await findOrgByCustomerId(subscription.customer);
-  if (!org) return;
-
-  await Organization.findByIdAndUpdate(org._id, { planStatus: 'canceled' });
-
-  logger.info('Subscription canceled', { service: 'billing', orgId: org._id });
-}
-
-async function handleTrialWillEnd(subscription) {
-  const org = await findOrgByCustomerId(subscription.customer);
-  if (!org) return;
-
-  const trialEndsAt = subscription.trial_end ? new Date(subscription.trial_end * 1000) : null;
-
-  // Best-effort email — do not block webhook response
-  emailService
-    .sendEmail({
-      to: subscription.customer_email || org.email,
-      subject: 'Your Retrieva trial ends in 3 days',
-      html: `
-        <p>Your 20-day free trial on <strong>Retrieva</strong> will end on
-        <strong>${trialEndsAt ? trialEndsAt.toDateString() : 'soon'}</strong>.</p>
-        <p>Add a payment method in your billing settings to continue using Retrieva
-        without interruption.</p>
-        <p><a href="${process.env.FRONTEND_URL}/settings/billing">Manage billing</a></p>
-      `,
-    })
-    .catch((err) => {
-      logger.warn('Failed to send trial_will_end email', {
-        service: 'billing',
-        orgId: org._id,
-        error: err.message,
-      });
-    });
-
-  logger.info('Trial will end event received', {
-    service: 'billing',
-    orgId: org._id,
-    trialEndsAt,
-  });
-}
-
-async function handlePaymentSucceeded(invoice) {
-  if (!invoice.subscription) return;
-
-  const org = await findOrgByCustomerId(invoice.customer);
-  if (!org) return;
-
-  await Organization.findByIdAndUpdate(org._id, { planStatus: 'active' });
-
-  logger.info('Payment succeeded — plan activated', { service: 'billing', orgId: org._id });
-}
-
-async function handlePaymentFailed(invoice) {
-  if (!invoice.subscription) return;
-
-  const org = await findOrgByCustomerId(invoice.customer);
-  if (!org) return;
-
-  await Organization.findByIdAndUpdate(org._id, { planStatus: 'past_due' });
-
-  logger.info('Payment failed — plan set to past_due', { service: 'billing', orgId: org._id });
-}
-
-// ---------------------------------------------------------------------------
-// Webhook entry point (raw body required — mounted before express.json())
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// POST /api/v1/billing/portal — create Stripe Customer Portal session
-// ---------------------------------------------------------------------------
-
+/**
+ * POST /api/v1/billing/portal — create Stripe Customer Portal session
+ */
 export const createPortalSession = catchAsync(async (req, res) => {
-  const org = await Organization.findById(req.user.organizationId).select('stripeCustomerId');
-  if (!org?.stripeCustomerId) {
-    return sendError(res, 400, 'Billing not yet provisioned for this organization');
-  }
-  const session = await getStripe().billingPortal.sessions.create({
-    customer: org.stripeCustomerId,
-    return_url: `${process.env.FRONTEND_URL}/settings/billing`,
-  });
-  sendSuccess(res, 200, 'Portal session created', { url: session.url });
+  const { url } = await billingService.createPortalSession(req.user.organizationId);
+  sendSuccess(res, 200, 'Portal session created', { url });
 });
 
-// ---------------------------------------------------------------------------
-// Webhook entry point (raw body required — mounted before express.json())
-// ---------------------------------------------------------------------------
-
+/**
+ * Webhook entry point (raw body required — mounted before express.json())
+ */
 export async function handleStripeWebhook(req, res) {
   const sig = req.headers['stripe-signature'];
 
@@ -167,27 +40,7 @@ export async function handleStripeWebhook(req, res) {
   }
 
   try {
-    switch (event.type) {
-      case 'customer.subscription.updated':
-        await handleSubscriptionUpdated(event.data.object);
-        break;
-      case 'customer.subscription.deleted':
-        await handleSubscriptionDeleted(event.data.object);
-        break;
-      case 'customer.subscription.trial_will_end':
-        await handleTrialWillEnd(event.data.object);
-        break;
-      case 'invoice.payment_succeeded':
-        await handlePaymentSucceeded(event.data.object);
-        break;
-      case 'invoice.payment_failed':
-        await handlePaymentFailed(event.data.object);
-        break;
-      default:
-        // Silently ignore unhandled event types
-        break;
-    }
-
+    await billingService.dispatchWebhookEvent(event);
     res.json({ received: true });
   } catch (err) {
     logger.error('Stripe webhook handler error', {

--- a/backend/services/BillingService.js
+++ b/backend/services/BillingService.js
@@ -1,0 +1,156 @@
+import { getStripe, PRICE_TO_PLAN, STRIPE_STATUS_MAP } from '../config/stripe.js';
+import { AppError } from '../utils/index.js';
+import { organizationRepository } from '../repositories/OrganizationRepository.js';
+import { emailService } from './emailService.js';
+import logger from '../config/logger.js';
+
+function resolvePlan(subscription) {
+  const priceId = subscription.items?.data?.[0]?.price?.id;
+  return PRICE_TO_PLAN[priceId] || 'starter';
+}
+
+class BillingService {
+  constructor(deps = {}) {
+    this.organizationRepo = deps.organizationRepo || organizationRepository;
+    this.emailService = deps.emailService || emailService;
+    this.stripeFactory = deps.stripeFactory || getStripe;
+    this.logger = deps.logger || logger;
+  }
+
+  async findOrgByCustomerId(customerId) {
+    const customer = await this.stripeFactory().customers.retrieve(customerId);
+    if (!customer || customer.deleted) return null;
+
+    const orgId = customer.metadata?.organizationId;
+    if (!orgId) return null;
+
+    return this.organizationRepo.findById(orgId);
+  }
+
+  async handleSubscriptionUpdated(subscription) {
+    const org = await this.findOrgByCustomerId(subscription.customer);
+    if (!org) return;
+
+    const plan = resolvePlan(subscription);
+    const planStatus = STRIPE_STATUS_MAP[subscription.status] || 'past_due';
+    const trialEndsAt = subscription.trial_end ? new Date(subscription.trial_end * 1000) : null;
+
+    await this.organizationRepo.updateById(org._id, { plan, planStatus, trialEndsAt });
+
+    this.logger.info('Subscription updated', {
+      service: 'billing',
+      orgId: org._id,
+      plan,
+      planStatus,
+      trialEndsAt,
+    });
+  }
+
+  async handleSubscriptionDeleted(subscription) {
+    const org = await this.findOrgByCustomerId(subscription.customer);
+    if (!org) return;
+
+    await this.organizationRepo.updateById(org._id, { planStatus: 'canceled' });
+
+    this.logger.info('Subscription canceled', { service: 'billing', orgId: org._id });
+  }
+
+  async handleTrialWillEnd(subscription) {
+    const org = await this.findOrgByCustomerId(subscription.customer);
+    if (!org) return;
+
+    const trialEndsAt = subscription.trial_end ? new Date(subscription.trial_end * 1000) : null;
+
+    // Best-effort email — do not block webhook response
+    this.emailService
+      .sendEmail({
+        to: subscription.customer_email || org.email,
+        subject: 'Your Retrieva trial ends in 3 days',
+        html: `
+        <p>Your 20-day free trial on <strong>Retrieva</strong> will end on
+        <strong>${trialEndsAt ? trialEndsAt.toDateString() : 'soon'}</strong>.</p>
+        <p>Add a payment method in your billing settings to continue using Retrieva
+        without interruption.</p>
+        <p><a href="${process.env.FRONTEND_URL}/settings/billing">Manage billing</a></p>
+      `,
+      })
+      .catch((err) => {
+        this.logger.warn('Failed to send trial_will_end email', {
+          service: 'billing',
+          orgId: org._id,
+          error: err.message,
+        });
+      });
+
+    this.logger.info('Trial will end event received', {
+      service: 'billing',
+      orgId: org._id,
+      trialEndsAt,
+    });
+  }
+
+  async handlePaymentSucceeded(invoice) {
+    if (!invoice.subscription) return;
+
+    const org = await this.findOrgByCustomerId(invoice.customer);
+    if (!org) return;
+
+    await this.organizationRepo.updateById(org._id, { planStatus: 'active' });
+
+    this.logger.info('Payment succeeded — plan activated', {
+      service: 'billing',
+      orgId: org._id,
+    });
+  }
+
+  async handlePaymentFailed(invoice) {
+    if (!invoice.subscription) return;
+
+    const org = await this.findOrgByCustomerId(invoice.customer);
+    if (!org) return;
+
+    await this.organizationRepo.updateById(org._id, { planStatus: 'past_due' });
+
+    this.logger.info('Payment failed — plan set to past_due', {
+      service: 'billing',
+      orgId: org._id,
+    });
+  }
+
+  async dispatchWebhookEvent(event) {
+    switch (event.type) {
+      case 'customer.subscription.updated':
+        return this.handleSubscriptionUpdated(event.data.object);
+      case 'customer.subscription.deleted':
+        return this.handleSubscriptionDeleted(event.data.object);
+      case 'customer.subscription.trial_will_end':
+        return this.handleTrialWillEnd(event.data.object);
+      case 'invoice.payment_succeeded':
+        return this.handlePaymentSucceeded(event.data.object);
+      case 'invoice.payment_failed':
+        return this.handlePaymentFailed(event.data.object);
+      default:
+        // Silently ignore unhandled event types
+        return undefined;
+    }
+  }
+
+  async createPortalSession(organizationId) {
+    const org = await this.organizationRepo.findById(organizationId, {
+      select: 'stripeCustomerId',
+    });
+    if (!org?.stripeCustomerId) {
+      throw new AppError('Billing not yet provisioned for this organization', 400);
+    }
+
+    const session = await this.stripeFactory().billingPortal.sessions.create({
+      customer: org.stripeCustomerId,
+      return_url: `${process.env.FRONTEND_URL}/settings/billing`,
+    });
+
+    return { url: session.url };
+  }
+}
+
+export const billingService = new BillingService();
+export { BillingService };


### PR DESCRIPTION
## Summary

P3 second slice. Moves all Stripe-webhook business logic and the customer-portal helper out of `billingController.js` into a new `BillingService`, with data access through `OrganizationRepository` (added in PR #257).

**Diff:** 2 files, +169 / -160. Controller shrinks **201 → 54 LOC (-73%)**.

## What moved

Webhook event handlers + Stripe-customer-to-org lookup, all of which were previously module-level functions in the controller, now live on `BillingService`:

- `findOrgByCustomerId(customerId)` — Stripe → org lookup
- `handleSubscriptionUpdated(subscription)`
- `handleSubscriptionDeleted(subscription)`
- `handleTrialWillEnd(subscription)` — best-effort trial-ending email
- `handlePaymentSucceeded(invoice)`
- `handlePaymentFailed(invoice)`
- `dispatchWebhookEvent(event)` — `switch` over `event.type`
- `createPortalSession(organizationId)` — throws `AppError(400)` if `stripeCustomerId` missing

All `Organization.findById/findByIdAndUpdate` calls now go through `organizationRepository.findById / updateById`. No mongoose model imported by the service or controller.

## What stays in the controller

The webhook endpoint still has to:

1. **Verify the Stripe signature** itself, because a signature failure must reply with HTTP 400 to *Stripe* (not to a logged-in user) — that's a Stripe-protocol concern, not a business concern. Kept as `sendError(res, 400, ...)`.
2. **Always reply 200 on handler failures** so Stripe doesn't retry transient internal errors. Kept as an explicit `try/catch` around `dispatchWebhookEvent`.

## Behavior change (minor)

`createPortalSession`'s "no stripeCustomerId" path moves from `sendError(res, 400)` to `throw new AppError(..., 400)`, so the response body's `status` field changes from `"error"` to `"fail"` (per `AppError`). HTTP status code and message are unchanged. Same pattern as PR #258 (P3a).

## Test plan

- [x] `node --check` on both files
- [x] `docker compose up -d --build backend` boots cleanly: workers active, no module-load errors, `/health` returns success
- [ ] CI to run the full backend + frontend test suite