### PR TITLE
refactor: extract OrganizationService from organizationController (P3d)

### DIFF
--- a/backend/controllers/organizationController.js
+++ b/backend/controllers/organizationController.js
@@ -1,85 +1,25 @@
 /**
  * Organization Controller
  *
- * Handles org creation, membership, and invite flows for the
- * organization-first onboarding model.
+ * Thin HTTP layer for org creation, membership, and invite flows.
+ * All business logic lives in services/OrganizationService.js.
  */
 
-import { Organization } from '../models/Organization.js';
-import { OrganizationMember } from '../models/OrganizationMember.js';
-import { User } from '../models/User.js';
-import { emailService } from '../services/emailService.js';
-import { setupOrgBilling } from '../services/stripeService.js';
-import { catchAsync, sendSuccess, sendError } from '../utils/index.js';
+import { organizationService } from '../services/OrganizationService.js';
+import { catchAsync, sendSuccess } from '../utils/index.js';
 import { safeDecrypt } from '../utils/security/fieldEncryption.js';
-import logger from '../config/logger.js';
 
-// ---------------------------------------------------------------------------
-// POST /api/v1/organizations
-// ---------------------------------------------------------------------------
+/**
+ * POST /api/v1/organizations
+ */
 export const createOrganization = catchAsync(async (req, res) => {
   const userId = req.user.userId;
   const { name, industry, country } = req.body;
 
-  if (!name?.trim()) {
-    return sendError(res, 400, 'Organization name is required');
-  }
-
-  // Prevent duplicate org membership
-  const existing = await OrganizationMember.findOne({ userId, status: 'active' });
-  if (existing) {
-    return sendError(res, 409, 'You already belong to an organization');
-  }
-
-  const org = await Organization.create({
-    name: name.trim(),
-    industry: industry || 'other',
-    country: country?.trim() || '',
-    ownerId: userId,
-  });
-
-  const user = await User.findById(userId);
-
-  await OrganizationMember.create({
-    organizationId: org._id,
-    userId,
-    email: user.email,
-    role: 'org_admin',
-    status: 'active',
-    joinedAt: new Date(),
-  });
-
-  await User.findByIdAndUpdate(userId, { organizationId: org._id });
-
-  // Provision Stripe billing — failure must never block org creation
-  let billingFields = {
-    plan: 'starter',
-    planStatus: 'trialing',
-    trialEndsAt: new Date(Date.now() + 20 * 24 * 60 * 60 * 1000),
-  };
-  try {
-    const billing = await setupOrgBilling(org._id, user.email, org.name);
-    billingFields = {
-      stripeCustomerId: billing.customerId,
-      stripeSubscriptionId: billing.subscriptionId,
-      plan: 'starter',
-      planStatus: 'trialing',
-      trialEndsAt: billing.trialEndsAt,
-    };
-  } catch (err) {
-    logger.error('Stripe billing provisioning failed — using local fallback', {
-      service: 'organization',
-      orgId: org._id,
-      error: err.message,
-    });
-  }
-
-  await Organization.findByIdAndUpdate(org._id, billingFields);
-
-  logger.info('Organization created', {
-    service: 'organization',
-    orgId: org._id,
-    userId,
+  const { org, billingFields } = await organizationService.createOrganization(userId, {
+    name,
+    industry,
+    country,
   });
 
   sendSuccess(res, 201, 'Organization created', {
@@ -95,151 +35,48 @@ export const createOrganization = catchAsync(async (req, res) => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// GET /api/v1/organizations/me
-// ---------------------------------------------------------------------------
+/**
+ * GET /api/v1/organizations/me
+ */
 export const getMyOrganization = catchAsync(async (req, res) => {
-  const userId = req.user.userId;
+  const { organization, role } = await organizationService.getMyOrganization(
+    req.user.userId
+  );
 
-  const membership = await OrganizationMember.findOne({
-    userId,
-    status: 'active',
-  }).populate('organizationId');
-
-  if (!membership || !membership.organizationId) {
+  if (!organization) {
     return sendSuccess(res, 200, 'No organization', { organization: null, role: null });
   }
 
-  const org = membership.organizationId;
-
   sendSuccess(res, 200, 'Organization retrieved', {
     organization: {
-      id: org._id,
-      name: org.name,
-      industry: org.industry,
-      country: org.country,
-      plan: org.plan || 'starter',
-      planStatus: org.planStatus || 'trialing',
-      trialEndsAt: org.trialEndsAt || null,
+      id: organization._id,
+      name: organization.name,
+      industry: organization.industry,
+      country: organization.country,
+      plan: organization.plan || 'starter',
+      planStatus: organization.planStatus || 'trialing',
+      trialEndsAt: organization.trialEndsAt || null,
     },
-    role: membership.role,
+    role,
   });
 });
 
-// ---------------------------------------------------------------------------
-// GET /api/v1/organizations/invite-info?token=XXX  (PUBLIC — no auth)
-// ---------------------------------------------------------------------------
+/**
+ * GET /api/v1/organizations/invite-info?token=XXX  (PUBLIC — no auth)
+ */
 export const getInviteInfo = catchAsync(async (req, res) => {
-  const { token } = req.query;
-
-  if (!token) {
-    return sendError(res, 400, 'Token is required');
-  }
-
-  const member = await OrganizationMember.findByToken(token);
-
-  if (!member) {
-    return sendError(res, 404, 'Invalid or expired invite link');
-  }
-
-  const org = await Organization.findById(member.organizationId);
-  if (!org) {
-    return sendError(res, 404, 'Organization not found');
-  }
-
-  let inviterName = null;
-  if (member.invitedBy) {
-    const inviter = await User.findById(member.invitedBy).select('name email');
-    if (inviter) {
-      inviterName = safeDecrypt(inviter.name) || inviter.email;
-    }
-  }
-
-  sendSuccess(res, 200, 'Invite info retrieved', {
-    organizationName: org.name,
-    inviterName,
-    role: member.role,
-    email: member.email,
-  });
+  const info = await organizationService.getInviteInfo(req.query.token);
+  sendSuccess(res, 200, 'Invite info retrieved', info);
 });
 
-// ---------------------------------------------------------------------------
-// POST /api/v1/organizations/invite
-// ---------------------------------------------------------------------------
+/**
+ * POST /api/v1/organizations/invite
+ */
 export const inviteMember = catchAsync(async (req, res) => {
   const inviterId = req.user.userId;
   const { email, role = 'analyst' } = req.body;
 
-  if (!email) {
-    return sendError(res, 400, 'Email is required');
-  }
-
-  if (!['org_admin', 'analyst', 'viewer'].includes(role)) {
-    return sendError(res, 400, 'Invalid role');
-  }
-
-  // Verify caller is org_admin
-  const callerMembership = await OrganizationMember.findOne({
-    userId: inviterId,
-    status: 'active',
-  });
-
-  if (!callerMembership) {
-    return sendError(res, 403, 'You do not belong to an organization');
-  }
-
-  if (callerMembership.role !== 'org_admin') {
-    return sendError(res, 403, 'Only org admins can invite members');
-  }
-
-  const orgId = callerMembership.organizationId;
-
-  // Check if already active
-  const existingActive = await OrganizationMember.findOne({
-    organizationId: orgId,
-    email: email.toLowerCase(),
-    status: 'active',
-  });
-
-  if (existingActive) {
-    return sendError(res, 409, 'This user is already an active member');
-  }
-
-  // Create or refresh invite
-  const { member, rawToken } = await OrganizationMember.createInvite(orgId, email, role, inviterId);
-
-  const org = await Organization.findById(orgId);
-  const inviter = await User.findById(inviterId).select('name email');
-  const inviterName = safeDecrypt(inviter?.name) || inviter?.email || 'A team member';
-
-  emailService
-    .sendOrganizationInvitation({
-      toEmail: email,
-      inviterName,
-      organizationName: org.name,
-      role,
-      inviteToken: rawToken,
-    })
-    .catch((err) => {
-      logger.warn('Failed to send org invitation email', {
-        service: 'organization',
-        error: err.message,
-      });
-    });
-
-  // Mark checklist item — fire and forget, non-critical
-  User.updateOne(
-    { _id: inviterId, 'onboardingChecklist.memberInvited': false },
-    { $set: { 'onboardingChecklist.memberInvited': true } }
-  ).catch(() => {});
-
-  logger.info('Org invite sent', {
-    service: 'organization',
-    orgId,
-    email,
-    role,
-    inviterId,
-  });
+  const member = await organizationService.inviteMember(inviterId, { email, role });
 
   sendSuccess(res, 201, 'Invitation sent', {
     member: {
@@ -251,73 +88,19 @@ export const inviteMember = catchAsync(async (req, res) => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// POST /api/v1/organizations/accept-invite  (authenticated)
-// ---------------------------------------------------------------------------
+/**
+ * POST /api/v1/organizations/accept-invite  (authenticated)
+ */
 export const acceptInvite = catchAsync(async (req, res) => {
-  const userId = req.user.userId;
-  const { token } = req.body;
-
-  if (!token) {
-    return sendError(res, 400, 'Token is required');
-  }
-
-  const member = await OrganizationMember.findByToken(token);
-
-  if (!member) {
-    return sendError(res, 404, 'Invalid or expired invite token');
-  }
-
-  const user = await User.findById(userId);
-  if (!user) {
-    return sendError(res, 404, 'User not found');
-  }
-
-  if (member.email !== user.email.toLowerCase()) {
-    return sendError(res, 403, 'This invite was sent to a different email address');
-  }
-
-  // Already in an org?
-  const existingMembership = await OrganizationMember.findOne({
-    userId,
-    status: 'active',
-  });
-
-  if (existingMembership) {
-    return sendError(res, 409, 'You already belong to an organization');
-  }
-
-  await OrganizationMember.activate(member._id, userId);
-  await User.findByIdAndUpdate(userId, { organizationId: member.organizationId });
-
-  logger.info('Org invite accepted', {
-    service: 'organization',
-    orgId: member.organizationId,
-    userId,
-  });
-
+  await organizationService.acceptInvite(req.user.userId, req.body.token);
   sendSuccess(res, 200, 'Invitation accepted');
 });
 
-// ---------------------------------------------------------------------------
-// GET /api/v1/organizations/members
-// ---------------------------------------------------------------------------
+/**
+ * GET /api/v1/organizations/members
+ */
 export const getMembers = catchAsync(async (req, res) => {
-  const userId = req.user.userId;
-
-  const callerMembership = await OrganizationMember.findOne({
-    userId,
-    status: 'active',
-  });
-
-  if (!callerMembership) {
-    return sendError(res, 403, 'You do not belong to an organization');
-  }
-
-  const members = await OrganizationMember.find({
-    organizationId: callerMembership.organizationId,
-    status: { $ne: 'revoked' },
-  }).populate('userId', 'name email');
+  const members = await organizationService.getMembers(req.user.userId);
 
   const memberList = members.map((m) => ({
     id: m._id.toString(),
@@ -337,47 +120,10 @@ export const getMembers = catchAsync(async (req, res) => {
   sendSuccess(res, 200, 'Members retrieved', { members: memberList });
 });
 
-// ---------------------------------------------------------------------------
-// DELETE /api/v1/organizations/members/:memberId
-// ---------------------------------------------------------------------------
+/**
+ * DELETE /api/v1/organizations/members/:memberId
+ */
 export const removeMember = catchAsync(async (req, res) => {
-  const userId = req.user.userId;
-  const { memberId } = req.params;
-
-  const callerMembership = await OrganizationMember.findOne({
-    userId,
-    status: 'active',
-  });
-
-  if (!callerMembership || callerMembership.role !== 'org_admin') {
-    return sendError(res, 403, 'Only org admins can remove members');
-  }
-
-  const target = await OrganizationMember.findById(memberId);
-
-  if (!target || target.organizationId.toString() !== callerMembership.organizationId.toString()) {
-    return sendError(res, 404, 'Member not found');
-  }
-
-  if (target.userId?.toString() === userId) {
-    // Check that there is at least one other admin before allowing self-removal
-    const adminCount = await OrganizationMember.countDocuments({
-      organizationId: callerMembership.organizationId,
-      role: 'org_admin',
-      status: 'active',
-    });
-    if (adminCount <= 1) {
-      return sendError(res, 400, 'Cannot remove the only org admin');
-    }
-  }
-
-  await OrganizationMember.findByIdAndUpdate(memberId, { status: 'revoked' });
-
-  logger.info('Org member removed', {
-    service: 'organization',
-    memberId,
-    removedBy: userId,
-  });
-
+  await organizationService.removeMember(req.user.userId, req.params.memberId);
   sendSuccess(res, 200, 'Member removed');
 });

--- a/backend/repositories/OrganizationMemberRepository.js
+++ b/backend/repositories/OrganizationMemberRepository.js
@@ -21,6 +21,22 @@ class OrganizationMemberRepository extends BaseRepository {
   async countAdmins(organizationId) {
     return this.count({ organizationId, role: 'admin', status: 'active' });
   }
+
+  // ── Model-static delegations ───────────────────────────────────────────────
+  // These wrap statics declared on the OrganizationMember schema so callers
+  // can stay at the repository boundary instead of importing the model.
+
+  async findByToken(rawToken) {
+    return this.model.findByToken(rawToken);
+  }
+
+  async createInvite(organizationId, email, role, invitedBy) {
+    return this.model.createInvite(organizationId, email, role, invitedBy);
+  }
+
+  async activate(memberId, userId) {
+    return this.model.activate(memberId, userId);
+  }
 }
 
 export const organizationMemberRepository = new OrganizationMemberRepository();

--- a/backend/services/OrganizationService.js
+++ b/backend/services/OrganizationService.js
@@ -1,0 +1,269 @@
+import { AppError } from '../utils/index.js';
+import { safeDecrypt } from '../utils/security/fieldEncryption.js';
+import { organizationRepository } from '../repositories/OrganizationRepository.js';
+import { organizationMemberRepository } from '../repositories/OrganizationMemberRepository.js';
+import { userRepository } from '../repositories/UserRepository.js';
+import { emailService } from './emailService.js';
+import { setupOrgBilling } from './stripeService.js';
+import logger from '../config/logger.js';
+
+const VALID_ROLES = ['org_admin', 'analyst', 'viewer'];
+const TRIAL_DAYS = 20;
+
+class OrganizationService {
+  constructor(deps = {}) {
+    this.organizationRepo = deps.organizationRepo || organizationRepository;
+    this.memberRepo = deps.memberRepo || organizationMemberRepository;
+    this.userRepo = deps.userRepo || userRepository;
+    this.emailService = deps.emailService || emailService;
+    this.setupOrgBilling = deps.setupOrgBilling || setupOrgBilling;
+    this.logger = deps.logger || logger;
+  }
+
+  async createOrganization(userId, { name, industry, country }) {
+    if (!name?.trim()) throw new AppError('Organization name is required', 400);
+
+    const existing = await this.memberRepo.findActiveByUserId(userId);
+    if (existing) throw new AppError('You already belong to an organization', 409);
+
+    const org = await this.organizationRepo.create({
+      name: name.trim(),
+      industry: industry || 'other',
+      country: country?.trim() || '',
+      ownerId: userId,
+    });
+
+    const user = await this.userRepo.findById(userId);
+
+    await this.memberRepo.create({
+      organizationId: org._id,
+      userId,
+      email: user.email,
+      role: 'org_admin',
+      status: 'active',
+      joinedAt: new Date(),
+    });
+
+    await this.userRepo.updateById(userId, { organizationId: org._id });
+
+    // Provision Stripe billing — failure must never block org creation
+    let billingFields = {
+      plan: 'starter',
+      planStatus: 'trialing',
+      trialEndsAt: new Date(Date.now() + TRIAL_DAYS * 24 * 60 * 60 * 1000),
+    };
+    try {
+      const billing = await this.setupOrgBilling(org._id, user.email, org.name);
+      billingFields = {
+        stripeCustomerId: billing.customerId,
+        stripeSubscriptionId: billing.subscriptionId,
+        plan: 'starter',
+        planStatus: 'trialing',
+        trialEndsAt: billing.trialEndsAt,
+      };
+    } catch (err) {
+      this.logger.error('Stripe billing provisioning failed — using local fallback', {
+        service: 'organization',
+        orgId: org._id,
+        error: err.message,
+      });
+    }
+
+    await this.organizationRepo.updateById(org._id, billingFields);
+
+    this.logger.info('Organization created', {
+      service: 'organization',
+      orgId: org._id,
+      userId,
+    });
+
+    return { org, billingFields };
+  }
+
+  async getMyOrganization(userId) {
+    const membership = await this.memberRepo.findOne(
+      { userId, status: 'active' },
+      { populate: 'organizationId' }
+    );
+
+    if (!membership || !membership.organizationId) {
+      return { organization: null, role: null };
+    }
+
+    const org = membership.organizationId;
+    return { organization: org, role: membership.role };
+  }
+
+  async getInviteInfo(token) {
+    if (!token) throw new AppError('Token is required', 400);
+
+    const member = await this.memberRepo.findByToken(token);
+    if (!member) throw new AppError('Invalid or expired invite link', 404);
+
+    const org = await this.organizationRepo.findById(member.organizationId);
+    if (!org) throw new AppError('Organization not found', 404);
+
+    let inviterName = null;
+    if (member.invitedBy) {
+      const inviter = await this.userRepo.findById(member.invitedBy, {
+        select: 'name email',
+      });
+      if (inviter) {
+        inviterName = safeDecrypt(inviter.name) || inviter.email;
+      }
+    }
+
+    return {
+      organizationName: org.name,
+      inviterName,
+      role: member.role,
+      email: member.email,
+    };
+  }
+
+  async inviteMember(inviterId, { email, role = 'analyst' }) {
+    if (!email) throw new AppError('Email is required', 400);
+    if (!VALID_ROLES.includes(role)) throw new AppError('Invalid role', 400);
+
+    const callerMembership = await this.memberRepo.findActiveByUserId(inviterId);
+    if (!callerMembership) throw new AppError('You do not belong to an organization', 403);
+    if (callerMembership.role !== 'org_admin') {
+      throw new AppError('Only org admins can invite members', 403);
+    }
+
+    const orgId = callerMembership.organizationId;
+
+    const existingActive = await this.memberRepo.findOne({
+      organizationId: orgId,
+      email: email.toLowerCase(),
+      status: 'active',
+    });
+    if (existingActive) {
+      throw new AppError('This user is already an active member', 409);
+    }
+
+    const { member, rawToken } = await this.memberRepo.createInvite(
+      orgId,
+      email,
+      role,
+      inviterId
+    );
+
+    const org = await this.organizationRepo.findById(orgId);
+    const inviter = await this.userRepo.findById(inviterId, { select: 'name email' });
+    const inviterName = safeDecrypt(inviter?.name) || inviter?.email || 'A team member';
+
+    this.emailService
+      .sendOrganizationInvitation({
+        toEmail: email,
+        inviterName,
+        organizationName: org.name,
+        role,
+        inviteToken: rawToken,
+      })
+      .catch((err) => {
+        this.logger.warn('Failed to send org invitation email', {
+          service: 'organization',
+          error: err.message,
+        });
+      });
+
+    // Mark checklist item — fire and forget, non-critical
+    this.userRepo
+      .updateOne(
+        { _id: inviterId, 'onboardingChecklist.memberInvited': false },
+        { $set: { 'onboardingChecklist.memberInvited': true } }
+      )
+      .catch(() => {});
+
+    this.logger.info('Org invite sent', {
+      service: 'organization',
+      orgId,
+      email,
+      role,
+      inviterId,
+    });
+
+    return member;
+  }
+
+  async acceptInvite(userId, token) {
+    if (!token) throw new AppError('Token is required', 400);
+
+    const member = await this.memberRepo.findByToken(token);
+    if (!member) throw new AppError('Invalid or expired invite token', 404);
+
+    const user = await this.userRepo.findById(userId);
+    if (!user) throw new AppError('User not found', 404);
+
+    if (member.email !== user.email.toLowerCase()) {
+      throw new AppError('This invite was sent to a different email address', 403);
+    }
+
+    const existingMembership = await this.memberRepo.findActiveByUserId(userId);
+    if (existingMembership) {
+      throw new AppError('You already belong to an organization', 409);
+    }
+
+    await this.memberRepo.activate(member._id, userId);
+    await this.userRepo.updateById(userId, { organizationId: member.organizationId });
+
+    this.logger.info('Org invite accepted', {
+      service: 'organization',
+      orgId: member.organizationId,
+      userId,
+    });
+  }
+
+  async getMembers(userId) {
+    const callerMembership = await this.memberRepo.findActiveByUserId(userId);
+    if (!callerMembership) throw new AppError('You do not belong to an organization', 403);
+
+    const members = await this.memberRepo.find(
+      {
+        organizationId: callerMembership.organizationId,
+        status: { $ne: 'revoked' },
+      },
+      { populate: { path: 'userId', select: 'name email' } }
+    );
+
+    return members;
+  }
+
+  async removeMember(userId, memberId) {
+    const callerMembership = await this.memberRepo.findActiveByUserId(userId);
+    if (!callerMembership || callerMembership.role !== 'org_admin') {
+      throw new AppError('Only org admins can remove members', 403);
+    }
+
+    const target = await this.memberRepo.findById(memberId);
+    if (
+      !target ||
+      target.organizationId.toString() !== callerMembership.organizationId.toString()
+    ) {
+      throw new AppError('Member not found', 404);
+    }
+
+    if (target.userId?.toString() === userId) {
+      const adminCount = await this.memberRepo.count({
+        organizationId: callerMembership.organizationId,
+        role: 'org_admin',
+        status: 'active',
+      });
+      if (adminCount <= 1) {
+        throw new AppError('Cannot remove the only org admin', 400);
+      }
+    }
+
+    await this.memberRepo.revokeMembership(memberId);
+
+    this.logger.info('Org member removed', {
+      service: 'organization',
+      memberId,
+      removedBy: userId,
+    });
+  }
+}
+
+export const organizationService = new OrganizationService();
+export { OrganizationService };

--- a/backend/tests/unittest/organization-controller.unit.test.js
+++ b/backend/tests/unittest/organization-controller.unit.test.js
@@ -81,32 +81,36 @@ const mockActiveMembership = {
   populate: vi.fn().mockReturnThis(),
 };
 
-vi.mock('../../models/Organization.js', () => ({
-  Organization: {
+// OrganizationService (added in P3d) uses the repositories, not the models
+// directly. Mock the repository singletons that the service constructs at
+// import time.
+vi.mock('../../repositories/OrganizationRepository.js', () => ({
+  organizationRepository: {
     create: vi.fn(),
     findById: vi.fn(),
-    findByIdAndUpdate: vi.fn(),
+    updateById: vi.fn(),
   },
 }));
 
-vi.mock('../../models/OrganizationMember.js', () => ({
-  OrganizationMember: {
+vi.mock('../../repositories/OrganizationMemberRepository.js', () => ({
+  organizationMemberRepository: {
     findOne: vi.fn(),
     find: vi.fn(),
     findById: vi.fn(),
-    findByIdAndUpdate: vi.fn(),
     create: vi.fn(),
-    countDocuments: vi.fn(),
-    createInvite: vi.fn(),
+    count: vi.fn(),
+    findActiveByUserId: vi.fn(),
+    revokeMembership: vi.fn(),
     findByToken: vi.fn(),
+    createInvite: vi.fn(),
     activate: vi.fn(),
   },
 }));
 
-vi.mock('../../models/User.js', () => ({
-  User: {
+vi.mock('../../repositories/UserRepository.js', () => ({
+  userRepository: {
     findById: vi.fn(),
-    findByIdAndUpdate: vi.fn(),
+    updateById: vi.fn(),
     updateOne: vi.fn().mockResolvedValue({ modifiedCount: 1 }),
   },
 }));
@@ -123,9 +127,9 @@ import {
   removeMember,
   getInviteInfo,
 } from '../../controllers/organizationController.js';
-import { Organization } from '../../models/Organization.js';
-import { OrganizationMember } from '../../models/OrganizationMember.js';
-import { User } from '../../models/User.js';
+import { organizationRepository as Organization } from '../../repositories/OrganizationRepository.js';
+import { organizationMemberRepository as OrganizationMember } from '../../repositories/OrganizationMemberRepository.js';
+import { userRepository as User } from '../../repositories/UserRepository.js';
 import { emailService } from '../../services/emailService.js';
 import { safeDecrypt } from '../../utils/security/fieldEncryption.js';
 
@@ -168,22 +172,22 @@ describe('createOrganization', () => {
   it('returns 400 when name is missing', async () => {
     const { req, res, next } = makeCtx({ industry: 'banking' });
     await createOrganization(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
   });
 
   it('returns 409 when user already belongs to an org', async () => {
-    OrganizationMember.findOne.mockResolvedValue(mockActiveMembership);
+    OrganizationMember.findActiveByUserId.mockResolvedValue(mockActiveMembership);
     const { req, res, next } = makeCtx({ name: 'HDI Global SE' });
     await createOrganization(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(409);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 409 }));
   });
 
   it('creates org, member and updates user, returns 201', async () => {
-    OrganizationMember.findOne.mockResolvedValue(null);
+    OrganizationMember.findActiveByUserId.mockResolvedValue(null);
     Organization.create.mockResolvedValue(mockOrg);
     User.findById.mockResolvedValue(mockUser);
     OrganizationMember.create.mockResolvedValue({});
-    User.findByIdAndUpdate.mockResolvedValue({});
+    User.updateById.mockResolvedValue({});
 
     const { req, res, next } = makeCtx({
       name: 'HDI Global SE',
@@ -198,16 +202,16 @@ describe('createOrganization', () => {
     expect(OrganizationMember.create).toHaveBeenCalledWith(
       expect.objectContaining({ role: 'org_admin', status: 'active' })
     );
-    expect(User.findByIdAndUpdate).toHaveBeenCalled();
+    expect(User.updateById).toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(201);
   });
 
   it('returns org object in response', async () => {
-    OrganizationMember.findOne.mockResolvedValue(null);
+    OrganizationMember.findActiveByUserId.mockResolvedValue(null);
     Organization.create.mockResolvedValue(mockOrg);
     User.findById.mockResolvedValue(mockUser);
     OrganizationMember.create.mockResolvedValue({});
-    User.findByIdAndUpdate.mockResolvedValue({});
+    User.updateById.mockResolvedValue({});
 
     const { req, res, next } = makeCtx({ name: 'HDI Global SE' });
     await createOrganization(req, res, next);
@@ -223,9 +227,7 @@ describe('createOrganization', () => {
 
 describe('getMyOrganization', () => {
   it('returns organization: null when user has no membership', async () => {
-    OrganizationMember.findOne.mockReturnValue({
-      populate: vi.fn().mockResolvedValue(null),
-    });
+    OrganizationMember.findOne.mockResolvedValue(null);
     const { req, res, next } = makeCtx();
     await getMyOrganization(req, res, next);
     const body = res.json.mock.calls[0][0];
@@ -238,9 +240,7 @@ describe('getMyOrganization', () => {
       ...mockActiveMembership,
       organizationId: { _id: ORG_OID, name: 'HDI', industry: 'insurance', country: 'DE' },
     };
-    OrganizationMember.findOne.mockReturnValue({
-      populate: vi.fn().mockResolvedValue(populated),
-    });
+    OrganizationMember.findOne.mockResolvedValue(populated);
 
     const { req, res, next } = makeCtx();
     await getMyOrganization(req, res, next);
@@ -258,49 +258,50 @@ describe('inviteMember', () => {
   it('returns 400 when email is missing', async () => {
     const { req, res, next } = makeCtx({ role: 'analyst' });
     await inviteMember(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
   });
 
   it('returns 400 for invalid role', async () => {
     const { req, res, next } = makeCtx({ email: 'bob@hdi.de', role: 'superuser' });
     await inviteMember(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
   });
 
   it('returns 403 when caller is not an org member', async () => {
-    OrganizationMember.findOne.mockResolvedValue(null);
+    OrganizationMember.findActiveByUserId.mockResolvedValue(null);
     const { req, res, next } = makeCtx({ email: 'bob@hdi.de', role: 'analyst' });
     await inviteMember(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
   });
 
   it('returns 403 when caller is not org_admin', async () => {
-    OrganizationMember.findOne.mockResolvedValue({ ...mockActiveMembership, role: 'analyst' });
+    OrganizationMember.findActiveByUserId.mockResolvedValue({
+      ...mockActiveMembership,
+      role: 'analyst',
+    });
     const { req, res, next } = makeCtx({ email: 'bob@hdi.de', role: 'viewer' });
     await inviteMember(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
   });
 
   it('returns 409 when email is already an active member', async () => {
-    OrganizationMember.findOne
-      .mockResolvedValueOnce(mockActiveMembership) // caller lookup
-      .mockResolvedValueOnce({ email: 'bob@hdi.de', status: 'active' }); // existing check
+    OrganizationMember.findActiveByUserId.mockResolvedValue(mockActiveMembership);
+    OrganizationMember.findOne.mockResolvedValue({ email: 'bob@hdi.de', status: 'active' });
 
     const { req, res, next } = makeCtx({ email: 'bob@hdi.de', role: 'analyst' });
     await inviteMember(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(409);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 409 }));
   });
 
   it('creates invite and returns 201', async () => {
     const newMember = { _id: MBR_OID, email: 'bob@hdi.de', role: 'analyst', status: 'pending' };
 
-    OrganizationMember.findOne
-      .mockResolvedValueOnce(mockActiveMembership)
-      .mockResolvedValueOnce(null);
+    OrganizationMember.findActiveByUserId.mockResolvedValue(mockActiveMembership);
+    OrganizationMember.findOne.mockResolvedValue(null);
 
     OrganizationMember.createInvite.mockResolvedValue({ member: newMember, rawToken: 'tok123' });
     Organization.findById.mockResolvedValue(mockOrg);
-    User.findById.mockReturnValue({ select: vi.fn().mockResolvedValue(mockUser) });
+    User.findById.mockResolvedValue(mockUser);
 
     const { req, res, next } = makeCtx({ email: 'bob@hdi.de', role: 'analyst' });
     await inviteMember(req, res, next);
@@ -319,26 +320,24 @@ describe('inviteMember', () => {
 
 describe('getMembers', () => {
   it('returns 403 when caller has no membership', async () => {
-    OrganizationMember.findOne.mockResolvedValue(null);
+    OrganizationMember.findActiveByUserId.mockResolvedValue(null);
     const { req, res, next } = makeCtx();
     await getMembers(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
   });
 
   it('returns member list with id, email, role, status', async () => {
-    OrganizationMember.findOne.mockResolvedValue(mockActiveMembership);
-    OrganizationMember.find.mockReturnValue({
-      populate: vi.fn().mockResolvedValue([
-        {
-          _id: MBR_OID,
-          email: 'alice@hdi.de',
-          role: 'org_admin',
-          status: 'active',
-          joinedAt: new Date(),
-          userId: { _id: USER_OID, name: 'Alice', email: 'alice@hdi.de' },
-        },
-      ]),
-    });
+    OrganizationMember.findActiveByUserId.mockResolvedValue(mockActiveMembership);
+    OrganizationMember.find.mockResolvedValue([
+      {
+        _id: MBR_OID,
+        email: 'alice@hdi.de',
+        role: 'org_admin',
+        status: 'active',
+        joinedAt: new Date(),
+        userId: { _id: USER_OID, name: 'Alice', email: 'alice@hdi.de' },
+      },
+    ]);
 
     const { req, res, next } = makeCtx();
     await getMembers(req, res, next);
@@ -357,50 +356,51 @@ describe('getMembers', () => {
 
 describe('removeMember', () => {
   it('returns 403 when caller is not org_admin', async () => {
-    OrganizationMember.findOne.mockResolvedValue({ ...mockActiveMembership, role: 'analyst' });
+    OrganizationMember.findActiveByUserId.mockResolvedValue({
+      ...mockActiveMembership,
+      role: 'analyst',
+    });
     const { req, res, next } = makeCtx({}, { memberId: MBR_OID.toString() });
     await removeMember(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
   });
 
   it('returns 404 when target member not found', async () => {
-    OrganizationMember.findOne.mockResolvedValue(mockActiveMembership);
+    OrganizationMember.findActiveByUserId.mockResolvedValue(mockActiveMembership);
     OrganizationMember.findById.mockResolvedValue(null);
     const { req, res, next } = makeCtx({}, { memberId: MBR_OID.toString() });
     await removeMember(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 404 }));
   });
 
   it('returns 400 when attempting to remove the only org admin', async () => {
     const callerMembership = { ...mockActiveMembership, userId: USER_OID.toString() };
-    OrganizationMember.findOne.mockResolvedValue(callerMembership);
+    OrganizationMember.findActiveByUserId.mockResolvedValue(callerMembership);
     OrganizationMember.findById.mockResolvedValue({
       ...callerMembership,
       userId: USER_OID.toString(),
     });
-    OrganizationMember.countDocuments.mockResolvedValue(1); // only one admin
+    OrganizationMember.count.mockResolvedValue(1); // only one admin
 
     const { req, res, next } = makeCtx({}, { memberId: MBR_OID.toString() });
     await removeMember(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
   });
 
   it('revokes membership and returns 200', async () => {
     const targetOID = new mongoose.Types.ObjectId('ffffffffffffffffffffffff');
-    OrganizationMember.findOne.mockResolvedValue(mockActiveMembership);
+    OrganizationMember.findActiveByUserId.mockResolvedValue(mockActiveMembership);
     OrganizationMember.findById.mockResolvedValue({
       _id: targetOID,
       organizationId: ORG_OID,
       userId: new mongoose.Types.ObjectId('111111111111111111111111'),
     });
-    OrganizationMember.findByIdAndUpdate.mockResolvedValue({});
+    OrganizationMember.revokeMembership.mockResolvedValue({});
 
     const { req, res, next } = makeCtx({}, { memberId: targetOID.toString() });
     await removeMember(req, res, next);
 
-    expect(OrganizationMember.findByIdAndUpdate).toHaveBeenCalledWith(targetOID.toString(), {
-      status: 'revoked',
-    });
+    expect(OrganizationMember.revokeMembership).toHaveBeenCalledWith(targetOID.toString());
     expect(res.status).toHaveBeenCalledWith(200);
   });
 });
@@ -413,14 +413,14 @@ describe('getInviteInfo', () => {
   it('returns 400 when token is missing', async () => {
     const { req, res, next } = makeCtx({}, {}, {});
     await getInviteInfo(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
   });
 
   it('returns 404 when token is invalid/expired', async () => {
     OrganizationMember.findByToken.mockResolvedValue(null);
     const { req, res, next } = makeCtx({}, {}, { token: 'badtoken' });
     await getInviteInfo(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 404 }));
   });
 
   it('returns invite info when token is valid', async () => {
@@ -431,7 +431,7 @@ describe('getInviteInfo', () => {
       invitedBy: USER_OID,
     });
     Organization.findById.mockResolvedValue(mockOrg);
-    User.findById.mockReturnValue({ select: vi.fn().mockResolvedValue(mockUser) });
+    User.findById.mockResolvedValue(mockUser);
 
     const { req, res, next } = makeCtx({}, {}, { token: 'validtoken' });
     await getInviteInfo(req, res, next);


### PR DESCRIPTION
## Summary

P3 fourth slice. Moves org-creation, membership, and invite flows out of `organizationController.js` into a new `OrganizationService`, with data access through `OrganizationRepository`, `OrganizationMemberRepository`, and `UserRepository` (all added in PR #257 / P2).

**Controller shrinks 383 → 129 LOC (-66%).**

## Service surface (7 methods)

- `createOrganization(userId, { name, industry, country })` → `{ org, billingFields }`
- `getMyOrganization(userId)` → `{ organization, role }`
- `getInviteInfo(token)` → `{ organizationName, inviterName, role, email }`
- `inviteMember(inviterId, { email, role })` → member doc
- `acceptInvite(userId, token)`
- `getMembers(userId)` → member docs (controller maps to wire format)
- `removeMember(userId, memberId)`

All `Organization.* / OrganizationMember.* / User.*` calls now go through the repositories. `safeDecrypt` mapping for `getMembers` response stays at the controller — that's presentation glue, not business logic.

## OrganizationMemberRepository additions

The model declares three statics that the service needs. Adding thin wrappers on the repo so callers stay at the repository boundary:

```js
async findByToken(rawToken)
async createInvite(organizationId, email, role, invitedBy)
async activate(memberId, userId)
```

Each delegates to `this.model.<static>(…)`.

## Behavior change

Same pattern as PR #258 / #259 / #260: validation/auth errors move from `sendError(res, statusCode)` to `throw new AppError(…, statusCode)` → `catchAsync` → `globalErrorHandler`. HTTP status code and `message` field unchanged; 4xx body's `status` field switches from `"error"` to `"fail"` (per `AppError`'s convention).

## Test plan

- [x] `node --check` on all three files
- [x] `docker compose up -d --build backend` boots cleanly: workers active, queues initialized, no module-load errors, `/health` returns success
- [ ] CI to run the full backend + frontend test suite