### PR TITLE
refactor: extract AuthService from authController (P3e)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -1,29 +1,8 @@
-import { User } from '../models/User.js';
-import { Organization } from '../models/Organization.js';
-import { OrganizationMember } from '../models/OrganizationMember.js';
-import {
-  generateTokenPair,
-  verifyRefreshToken,
-  generateAccessToken,
-  generateRefreshToken,
-  hashRefreshToken,
-} from '../utils/security/jwt.js';
-import { sha256 } from '../utils/security/crypto.js';
-import { safeDecrypt } from '../utils/security/fieldEncryption.js';
-import { sendSuccess, sendError } from '../utils/core/responseFormatter.js';
-import {
-  setAuthCookies,
-  clearAuthCookies,
-  getRefreshToken,
-} from '../utils/security/cookieConfig.js';
-import { emailService } from '../services/emailService.js';
+import { authService } from '../services/AuthService.js';
+import { catchAsync, sendSuccess } from '../utils/index.js';
+import { setAuthCookies, clearAuthCookies, getRefreshToken } from '../utils/security/cookieConfig.js';
 import logger from '../config/logger.js';
 
-const RESEND_VERIFICATION_COOLDOWN_MS = 60 * 1000;
-
-/**
- * Get device info from request for token tracking
- */
 const getDeviceInfo = (req) => {
   const userAgent = req.headers['user-agent'] || 'unknown';
   const ip = req.ip || req.connection?.remoteAddress || 'unknown';
@@ -31,801 +10,179 @@ const getDeviceInfo = (req) => {
 };
 
 /**
- * Register a new user
  * POST /api/v1/auth/register
  */
-export const register = async (req, res) => {
-  try {
-    const { email, password, name, role, inviteToken } = req.body;
+export const register = catchAsync(async (req, res) => {
+  const { email, password, name, role, inviteToken } = req.body;
 
-    // Check if user already exists
-    const existingUser = await User.findOne({ email });
-    if (existingUser) {
-      logger.warn('Registration attempt with existing email', { email });
-      return sendError(res, 409, 'Email already registered');
+  const { user, needsOrganization, tokens } = await authService.register({
+    email,
+    password,
+    name,
+    role,
+    inviteToken,
+    deviceInfo: getDeviceInfo(req),
+  });
+
+  setAuthCookies(res, tokens);
+
+  sendSuccess(
+    res,
+    201,
+    'User registered successfully. Please check your email to verify your account.',
+    {
+      user,
+      needsOrganization,
+      ...tokens,
     }
-
-    // Create new user
-    const user = new User({
-      email,
-      password, // Will be hashed by pre-save hook
-      name,
-      role: role || 'user', // Default to 'user' if not provided
-    });
-
-    await user.save();
-
-    // Generate tokens
-    const tokens = generateTokenPair({
-      userId: user._id,
-      email: user.email,
-      role: user.role,
-    });
-
-    // Hash and save refresh token
-    const tokenHash = hashRefreshToken(tokens.refreshToken);
-    const deviceInfo = getDeviceInfo(req);
-    await user.addRefreshToken(tokenHash, deviceInfo);
-
-    // Process org invite token if provided
-    let organizationId = null;
-    if (inviteToken) {
-      try {
-        const member = await OrganizationMember.findByToken(inviteToken);
-        if (member && member.email === email.toLowerCase()) {
-          await OrganizationMember.activate(member._id, user._id);
-          await User.findByIdAndUpdate(user._id, { organizationId: member.organizationId });
-          organizationId = member.organizationId;
-        }
-      } catch (err) {
-        logger.warn('Invite token processing failed during registration', {
-          userId: user._id,
-          error: err.message,
-        });
-      }
-    }
-
-    // Generate email verification token and send email
-    const verificationToken = await user.createEmailVerificationToken();
-    emailService
-      .sendEmailVerification({
-        toEmail: user.email,
-        toName: name, // Use original name from request (user.name is encrypted after save)
-        verificationToken,
-      })
-      .catch((err) => {
-        logger.warn('Failed to send verification email', {
-          userId: user._id,
-          error: err.message,
-        });
-      });
-
-    logger.info('New user registered', {
-      userId: user._id,
-      email: user.email,
-      role: user.role,
-      hasOrg: !!organizationId,
-    });
-
-    // Set HTTP-only cookies for secure token storage
-    setAuthCookies(res, tokens);
-
-    sendSuccess(
-      res,
-      201,
-      'User registered successfully. Please check your email to verify your account.',
-      {
-        user: {
-          id: user._id,
-          email: user.email,
-          name, // Use original name from request (user.name is encrypted after save)
-          role: user.role,
-          isEmailVerified: false,
-          organizationId: organizationId ? organizationId.toString() : null,
-        },
-        needsOrganization: !organizationId,
-        // Tokens also returned in body for API clients (mobile apps, etc.)
-        ...tokens,
-      }
-    );
-  } catch (error) {
-    logger.error('Registration failed', {
-      error: error.message,
-      stack: error.stack,
-    });
-    // ISSUE #30 FIX: Use logger instead of console.error
-    if (process.env.NODE_ENV === 'test') {
-      logger.debug('Registration error details', {
-        error: error.message,
-        stack: error.stack,
-      });
-    }
-    sendError(res, 500, 'Registration failed');
-  }
-};
+  );
+});
 
 /**
- * Login user
  * POST /api/v1/auth/login
  */
-export const login = async (req, res) => {
-  try {
-    const { email, password } = req.body;
+export const login = catchAsync(async (req, res) => {
+  const { email, password } = req.body;
 
-    // Find user with password field
-    const user = await User.findByCredentials(email);
+  const { user, tokens } = await authService.login({
+    email,
+    password,
+    deviceInfo: getDeviceInfo(req),
+  });
 
-    if (!user) {
-      logger.warn('Login attempt with non-existent email', { email });
-      return sendError(res, 401, 'Invalid credentials');
-    }
+  setAuthCookies(res, tokens);
 
-    // Check if account is locked
-    if (user.isLocked) {
-      logger.warn('Login attempt on locked account', {
-        userId: user._id,
-        lockUntil: user.lockUntil,
-      });
-      return sendError(res, 423, 'Account is temporarily locked. Please try again later.');
-    }
-
-    // Check if account is active
-    if (!user.isActive) {
-      logger.warn('Login attempt on inactive account', { userId: user._id });
-      return sendError(res, 401, 'Account is inactive');
-    }
-
-    // Verify password
-    const isPasswordValid = await user.comparePassword(password);
-
-    if (!isPasswordValid) {
-      logger.warn('Failed login attempt', { email });
-      await user.incLoginAttempts();
-      return sendError(res, 401, 'Invalid credentials');
-    }
-
-    // Reset login attempts on successful login
-    await user.resetLoginAttempts();
-
-    // Generate tokens
-    const tokens = generateTokenPair({
-      userId: user._id,
-      email: user.email,
-      role: user.role,
-    });
-
-    // Hash and save refresh token
-    const tokenHash = hashRefreshToken(tokens.refreshToken);
-    const deviceInfo = getDeviceInfo(req);
-    await user.addRefreshToken(tokenHash, deviceInfo);
-
-    // Populate organization data so the frontend skips the onboarding gate
-    let organization = null;
-    if (user.organizationId) {
-      const org = await Organization.findById(user.organizationId).select('name industry country');
-      if (org) {
-        organization = {
-          id: org._id,
-          name: org.name,
-          industry: org.industry,
-          country: org.country,
-        };
-      }
-    }
-
-    logger.info('User logged in', {
-      userId: user._id,
-      email: user.email,
-    });
-
-    // Set HTTP-only cookies for secure token storage
-    setAuthCookies(res, tokens);
-
-    sendSuccess(res, 200, 'Login successful', {
-      user: {
-        id: user._id,
-        email: user.email,
-        name: safeDecrypt(user.name),
-        role: user.role,
-        isEmailVerified: user.isEmailVerified,
-        organizationId: user.organizationId ? user.organizationId.toString() : null,
-        organization,
-        onboardingCompleted: user.onboardingCompleted,
-        onboardingChecklist: user.onboardingChecklist,
-      },
-      // Tokens also returned in body for API clients (mobile apps, etc.)
-      ...tokens,
-    });
-  } catch (error) {
-    logger.error('Login failed', {
-      error: error.message,
-      stack: error.stack,
-    });
-    sendError(res, 500, 'Login failed');
-  }
-};
+  sendSuccess(res, 200, 'Login successful', {
+    user,
+    ...tokens,
+  });
+});
 
 /**
- * Refresh access token with token rotation
  * POST /api/v1/auth/refresh
  *
- * SECURITY: Implements refresh token rotation
- * - Old refresh token is consumed (invalidated)
- * - New refresh token is issued
- * - If old token is reused after rotation, all tokens are invalidated (theft detection)
- *
- * Accepts refresh token from:
- * 1. HTTP-only cookie (primary, secure)
- * 2. Request body (fallback for API clients)
+ * SECURITY: Implements refresh token rotation. On any rejection, also clears
+ * the HTTP-only auth cookies so the client retreats to a clean state.
  */
-export const refreshToken = async (req, res) => {
+export const refreshToken = async (req, res, next) => {
   try {
-    // Get refresh token from cookie or body
-    const refreshTokenValue = getRefreshToken(req);
-
-    if (!refreshTokenValue) {
-      return sendError(res, 401, 'Refresh token required');
-    }
-
-    // Verify refresh token signature
-    let decoded;
-    try {
-      decoded = verifyRefreshToken(refreshTokenValue);
-    } catch (error) {
-      logger.warn('Invalid refresh token signature', { error: error.message });
-      clearAuthCookies(res);
-      return sendError(res, 401, error.message || 'Invalid refresh token');
-    }
-
-    // Find user with refresh tokens
-    const user = await User.findById(decoded.userId).select('+refreshTokens');
-
-    if (!user) {
-      logger.warn('User not found for refresh token', { userId: decoded.userId });
-      clearAuthCookies(res);
-      return sendError(res, 401, 'Invalid refresh token');
-    }
-
-    if (!user.isActive) {
-      clearAuthCookies(res);
-      return sendError(res, 401, 'Account is inactive');
-    }
-
-    // Hash the incoming token to compare with stored hashes
-    const incomingTokenHash = hashRefreshToken(refreshTokenValue);
-
-    // Consume the old token (rotation) - this removes it from valid tokens
-    const tokenValid = await user.consumeRefreshToken(incomingTokenHash);
-
-    if (!tokenValid) {
-      // Token not found or expired - possible token reuse attack
-      logger.warn('Refresh token not found or already used - possible token theft', {
-        userId: user._id,
-      });
-
-      // Security: Clear all tokens on suspected theft
-      await user.clearAllRefreshTokens();
-      clearAuthCookies(res);
-
-      return sendError(res, 401, 'Invalid refresh token. Please login again.');
-    }
-
-    // Generate new token pair (rotation)
-    const newAccessToken = generateAccessToken({
-      userId: user._id,
-      email: user.email,
-      role: user.role,
+    const { accessToken, refreshToken: newRefreshToken } = await authService.refreshTokens({
+      refreshTokenValue: getRefreshToken(req),
+      deviceInfo: getDeviceInfo(req),
     });
 
-    const newRefreshToken = generateRefreshToken({
-      userId: user._id,
-      email: user.email,
-    });
-
-    // Store the new refresh token (hashed)
-    const newTokenHash = hashRefreshToken(newRefreshToken);
-    const deviceInfo = getDeviceInfo(req);
-    await user.addRefreshToken(newTokenHash, deviceInfo);
-
-    // Update lastLogin to reflect active session
-    await User.updateOne({ _id: user._id }, { $set: { lastLogin: new Date() } });
-
-    // Set new cookies
-    setAuthCookies(res, {
-      accessToken: newAccessToken,
-      refreshToken: newRefreshToken,
-    });
-
-    logger.info('Tokens rotated successfully', { userId: user._id });
+    setAuthCookies(res, { accessToken, refreshToken: newRefreshToken });
 
     sendSuccess(res, 200, 'Token refreshed', {
-      accessToken: newAccessToken,
+      accessToken,
       refreshToken: newRefreshToken,
     });
-  } catch (error) {
-    logger.error('Token refresh failed', {
-      error: error.message,
-      stack: error.stack,
-    });
-    sendError(res, 500, 'Token refresh failed');
+  } catch (err) {
+    // Any refresh failure must also clear cookies so the client doesn't keep
+    // retrying with a now-stale cookie.
+    clearAuthCookies(res);
+    next(err);
   }
 };
 
 /**
- * Logout user (invalidate current refresh token and clear cookies)
  * POST /api/v1/auth/logout
- *
- * Query params:
- * - all=true: Logout from all devices (clear all refresh tokens)
+ * ?all=true logs out from all devices.
  */
-export const logout = async (req, res) => {
+export const logout = async (req, res, next) => {
   try {
-    const logoutAll = req.query.all === 'true';
-    const user = await User.findById(req.user.userId).select('+refreshTokens');
-
-    if (user) {
-      if (logoutAll) {
-        // Clear all refresh tokens (logout from all devices)
-        await user.clearAllRefreshTokens();
-        logger.info('User logged out from all devices', { userId: user._id });
-      } else {
-        // Clear only current session's token
-        const currentRefreshToken = getRefreshToken(req);
-        if (currentRefreshToken) {
-          const tokenHash = hashRefreshToken(currentRefreshToken);
-          await user.consumeRefreshToken(tokenHash);
-        }
-        logger.info('User logged out', { userId: user._id });
-      }
-    }
-
-    // Clear HTTP-only cookies
-    clearAuthCookies(res);
-
-    sendSuccess(res, 200, logoutAll ? 'Logged out from all devices' : 'Logout successful');
-  } catch (error) {
+    await authService.logout({
+      userId: req.user?.userId,
+      refreshTokenValue: getRefreshToken(req),
+      logoutAll: req.query.all === 'true',
+    });
+  } catch (err) {
     logger.error('Logout failed', {
-      error: error.message,
+      error: err.message,
       userId: req.user?.userId,
     });
-    // Still clear cookies even on error
-    clearAuthCookies(res);
-    sendError(res, 500, 'Logout failed');
+    // fall through — we still want to clear cookies and respond
   }
+
+  clearAuthCookies(res);
+  sendSuccess(res, 200, req.query.all === 'true' ? 'Logged out from all devices' : 'Logout successful');
+  if (typeof next === 'function') return;
 };
 
 /**
- * Get current user profile
  * GET /api/v1/auth/me
  */
-export const getMe = async (req, res) => {
-  try {
-    const user = await User.findById(req.user.userId);
-
-    if (!user) {
-      return sendError(res, 404, 'User not found');
-    }
-
-    // Populate organization data if user belongs to one
-    let organization = null;
-    if (user.organizationId) {
-      const org = await Organization.findById(user.organizationId).select('name industry country');
-      if (org) {
-        organization = {
-          id: org._id,
-          name: org.name,
-          industry: org.industry,
-          country: org.country,
-        };
-      }
-    }
-
-    sendSuccess(res, 200, 'User profile retrieved', {
-      user: {
-        id: user._id,
-        email: user.email,
-        name: safeDecrypt(user.name),
-        role: user.role,
-        isEmailVerified: user.isEmailVerified,
-        createdAt: user.createdAt,
-        lastLogin: user.lastLogin,
-        organizationId: user.organizationId ? user.organizationId.toString() : null,
-        organization,
-        onboardingCompleted: user.onboardingCompleted,
-        onboardingChecklist: user.onboardingChecklist,
-      },
-    });
-  } catch (error) {
-    logger.error('Failed to get user profile', {
-      error: error.message,
-      userId: req.user?.userId,
-    });
-    sendError(res, 500, 'Failed to get user profile');
-  }
-};
+export const getMe = catchAsync(async (req, res) => {
+  const { user } = await authService.getMe(req.user.userId);
+  sendSuccess(res, 200, 'User profile retrieved', { user });
+});
 
 /**
- * Update current user profile (name only)
  * PATCH /api/v1/auth/profile
  */
-export const updateProfile = async (req, res) => {
-  try {
-    const user = await User.findById(req.user.userId);
-
-    if (!user) {
-      return sendError(res, 404, 'User not found');
-    }
-
-    const { name, email } = req.body;
-
-    if (!name && !email) {
-      return sendError(res, 400, 'No profile changes provided');
-    }
-
-    if (email && email !== user.email) {
-      return sendError(res, 400, 'Email cannot be changed via profile update');
-    }
-
-    if (name) {
-      user.name = name;
-    }
-
-    await user.save();
-
-    logger.info('User profile updated', { userId: user._id });
-
-    // Manually decrypt name field if it's encrypted (after save hook encrypts it)
-    const displayName = user.decryptField ? user.decryptField('name') : user.name;
-
-    sendSuccess(res, 200, 'Profile updated successfully', {
-      user: {
-        id: user._id,
-        email: user.email,
-        name: displayName,
-        role: user.role,
-        isEmailVerified: user.isEmailVerified,
-        createdAt: user.createdAt,
-        lastLogin: user.lastLogin,
-      },
-    });
-  } catch (error) {
-    logger.error('Failed to update user profile', {
-      error: error.message,
-      userId: req.user?.userId,
-    });
-    sendError(res, 500, 'Failed to update profile');
-  }
-};
+export const updateProfile = catchAsync(async (req, res) => {
+  const { user } = await authService.updateProfile(req.user.userId, req.body);
+  sendSuccess(res, 200, 'Profile updated successfully', { user });
+});
 
 /**
- * Request password reset
  * POST /api/v1/auth/forgot-password
  */
-export const forgotPassword = async (req, res) => {
-  try {
-    const { email } = req.body;
-
-    const user = await User.findOne({ email: email.toLowerCase() });
-
-    // Always return success to prevent email enumeration
-    if (!user) {
-      logger.info('Password reset requested for non-existent email', { email });
-      return sendSuccess(
-        res,
-        200,
-        'If an account with that email exists, a password reset link has been sent.'
-      );
-    }
-
-    // Generate reset token
-    const resetToken = await user.createPasswordResetToken();
-
-    // Send password reset email
-    const emailResult = await emailService.sendPasswordResetEmail({
-      toEmail: user.email,
-      toName: user.name,
-      resetToken,
-    });
-
-    if (!emailResult.success) {
-      logger.error('Failed to send password reset email', {
-        userId: user._id,
-        error: emailResult.error || emailResult.reason,
-        reason: emailResult.reason,
-      });
-      // Clear the token since email failed
-      await user.clearPasswordResetToken();
-      return sendError(
-        res,
-        503,
-        'Email service is temporarily unavailable. Please try again later or contact support.'
-      );
-    }
-
-    logger.info('Password reset email sent', { userId: user._id, email: user.email });
-
-    sendSuccess(
-      res,
-      200,
-      'If an account with that email exists, a password reset link has been sent.'
-    );
-  } catch (error) {
-    logger.error('Forgot password failed', {
-      error: error.message,
-      stack: error.stack,
-    });
-    sendError(res, 500, 'Failed to process password reset request');
-  }
-};
+export const forgotPassword = catchAsync(async (req, res) => {
+  await authService.forgotPassword({ email: req.body.email });
+  sendSuccess(
+    res,
+    200,
+    'If an account with that email exists, a password reset link has been sent.'
+  );
+});
 
 /**
- * Reset password with token
  * POST /api/v1/auth/reset-password
  */
-export const resetPassword = async (req, res) => {
-  try {
-    const { token, password } = req.body;
-
-    // Hash the token to compare with stored hash
-    const hashedToken = sha256(token);
-
-    // Find user with valid reset token
-    const user = await User.findOne({
-      passwordResetToken: hashedToken,
-      passwordResetExpires: { $gt: Date.now() },
-    }).select('+passwordResetToken +passwordResetExpires +refreshTokens');
-
-    if (!user) {
-      logger.warn('Invalid or expired password reset token');
-      return sendError(res, 400, 'Invalid or expired reset token. Please request a new one.');
-    }
-
-    // Update password
-    user.password = password;
-
-    // Clear reset token
-    user.passwordResetToken = undefined;
-    user.passwordResetExpires = undefined;
-
-    // Invalidate all refresh tokens (security: force re-login on all devices)
-    user.refreshTokens = [];
-
-    await user.save();
-
-    logger.info('Password reset successful', { userId: user._id });
-
-    sendSuccess(
-      res,
-      200,
-      'Password has been reset successfully. Please login with your new password.'
-    );
-  } catch (error) {
-    logger.error('Password reset failed', {
-      error: error.message,
-      stack: error.stack,
-    });
-    sendError(res, 500, 'Failed to reset password');
-  }
-};
+export const resetPassword = catchAsync(async (req, res) => {
+  await authService.resetPassword(req.body);
+  sendSuccess(
+    res,
+    200,
+    'Password has been reset successfully. Please login with your new password.'
+  );
+});
 
 /**
- * Verify email address
  * POST /api/v1/auth/verify-email
  */
-export const verifyEmail = async (req, res) => {
-  try {
-    const { token } = req.body;
-
-    // Hash the token to compare with stored hash
-    const hashedToken = sha256(token);
-
-    // Find user with valid verification token
-    const user = await User.findOne({
-      emailVerificationToken: hashedToken,
-      emailVerificationExpires: { $gt: Date.now() },
-    }).select('+emailVerificationToken +emailVerificationExpires');
-
-    if (!user) {
-      logger.warn('Invalid or expired email verification token');
-      return sendError(
-        res,
-        400,
-        'Invalid or expired verification token. Please request a new one.'
-      );
-    }
-
-    // Capture name before save() re-encrypts it in memory
-    const userName = user.name;
-
-    // Mark email as verified
-    user.isEmailVerified = true;
-    user.emailVerificationToken = undefined;
-    user.emailVerificationExpires = undefined;
-    await user.save({ validateBeforeSave: false });
-
-    logger.info('Email verified successfully', { userId: user._id, email: user.email });
-
-    // Send welcome email (non-blocking)
-    emailService.sendWelcomeEmail({ toEmail: user.email, toName: userName }).catch((err) => {
-      logger.warn('Failed to send welcome email after verification', {
-        userId: user._id,
-        error: err.message,
-      });
-    });
-
-    sendSuccess(res, 200, 'Email verified successfully.');
-  } catch (error) {
-    logger.error('Email verification failed', {
-      error: error.message,
-      stack: error.stack,
-    });
-    sendError(res, 500, 'Failed to verify email');
-  }
-};
+export const verifyEmail = catchAsync(async (req, res) => {
+  await authService.verifyEmail({ token: req.body.token });
+  sendSuccess(res, 200, 'Email verified successfully.');
+});
 
 /**
- * Resend email verification
  * POST /api/v1/auth/resend-verification
  */
-export const resendVerification = async (req, res) => {
-  try {
-    const user = await User.findById(req.user.userId);
-
-    if (!user) {
-      return sendError(res, 404, 'User not found');
-    }
-
-    if (user.isEmailVerified) {
-      return sendError(res, 400, 'Email is already verified');
-    }
-
-    if (user.emailVerificationLastSentAt) {
-      const elapsedMs = Date.now() - user.emailVerificationLastSentAt.getTime();
-      if (elapsedMs < RESEND_VERIFICATION_COOLDOWN_MS) {
-        logger.warn('Resend verification blocked due to cooldown', {
-          userId: user._id,
-        });
-        const waitSeconds = Math.ceil((RESEND_VERIFICATION_COOLDOWN_MS - elapsedMs) / 1000);
-        return sendError(
-          res,
-          429,
-          `Please wait ${waitSeconds}s before requesting another verification email.`
-        );
-      }
-    }
-
-    // Generate new verification token
-    const verificationToken = await user.createEmailVerificationToken();
-
-    // Send verification email
-    const emailResult = await emailService.sendEmailVerification({
-      toEmail: user.email,
-      toName: user.name,
-      verificationToken,
-    });
-
-    if (!emailResult.success) {
-      logger.error('Failed to resend verification email', {
-        userId: user._id,
-        error: emailResult.error || emailResult.reason,
-        reason: emailResult.reason,
-      });
-      return sendError(
-        res,
-        503,
-        'Email service is temporarily unavailable. Please try again later or contact support.'
-      );
-    }
-
-    logger.info('Verification email resent', { userId: user._id, email: user.email });
-
-    sendSuccess(res, 200, 'Verification email sent. Please check your inbox.');
-  } catch (error) {
-    logger.error('Resend verification failed', {
-      error: error.message,
-      stack: error.stack,
-    });
-    sendError(res, 500, 'Failed to resend verification email');
-  }
-};
+export const resendVerification = catchAsync(async (req, res) => {
+  await authService.resendVerification(req.user.userId);
+  sendSuccess(res, 200, 'Verification email sent. Please check your inbox.');
+});
 
 /**
- * Change password (with session invalidation)
  * POST /api/v1/auth/change-password
- *
- * SECURITY: Invalidates ALL refresh tokens after password change
- * This forces re-login on all devices
+ * SECURITY: Invalidates ALL refresh tokens after password change.
  */
-export const changePassword = async (req, res) => {
-  try {
-    const { currentPassword, newPassword } = req.body;
-
-    // Get user with password and refresh tokens
-    const user = await User.findById(req.user.userId).select('+password +refreshTokens');
-
-    if (!user) {
-      return sendError(res, 404, 'User not found');
-    }
-
-    // Verify current password
-    const isPasswordValid = await user.comparePassword(currentPassword);
-    if (!isPasswordValid) {
-      logger.warn('Change password failed - incorrect current password', {
-        userId: user._id,
-      });
-      return sendError(res, 401, 'Current password is incorrect');
-    }
-
-    // Update password (will be hashed by pre-save hook)
-    user.password = newPassword;
-
-    // SECURITY: Invalidate ALL refresh tokens (force re-login on all devices)
-    user.refreshTokens = [];
-
-    await user.save();
-
-    // Clear current session cookies
-    clearAuthCookies(res);
-
-    logger.info('Password changed successfully - all sessions invalidated', {
-      userId: user._id,
-    });
-
-    sendSuccess(
-      res,
-      200,
-      'Password changed successfully. Please login again with your new password.'
-    );
-  } catch (error) {
-    logger.error('Change password failed', {
-      error: error.message,
-      stack: error.stack,
-      userId: req.user?.userId,
-    });
-    sendError(res, 500, 'Failed to change password');
-  }
-};
+export const changePassword = catchAsync(async (req, res) => {
+  await authService.changePassword(req.user.userId, req.body);
+  clearAuthCookies(res);
+  sendSuccess(
+    res,
+    200,
+    'Password changed successfully. Please login again with your new password.'
+  );
+});
 
 /**
- * Update onboarding state
  * PATCH /api/v1/auth/onboarding
  */
-export const updateOnboarding = async (req, res) => {
-  try {
-    const { completed, checklist } = req.body;
-    const update = {};
-
-    if (completed !== undefined) {
-      update.onboardingCompleted = completed;
-    }
-
-    if (checklist && typeof checklist === 'object') {
-      const allowed = [
-        'vendorCreated',
-        'assessmentCreated',
-        'memberInvited',
-        'monitoringSetup',
-        'dismissed',
-      ];
-      for (const key of allowed) {
-        if (checklist[key] !== undefined) {
-          update[`onboardingChecklist.${key}`] = checklist[key];
-        }
-      }
-    }
-
-    if (Object.keys(update).length === 0) {
-      return sendError(res, 400, 'No valid fields to update');
-    }
-
-    await User.updateOne({ _id: req.user.userId }, { $set: update });
-
-    sendSuccess(res, 200, 'Onboarding state updated');
-  } catch (error) {
-    logger.error('Failed to update onboarding state', {
-      error: error.message,
-      userId: req.user?.userId,
-    });
-    sendError(res, 500, 'Failed to update onboarding state');
-  }
-};
+export const updateOnboarding = catchAsync(async (req, res) => {
+  await authService.updateOnboarding(req.user.userId, req.body);
+  sendSuccess(res, 200, 'Onboarding state updated');
+});

--- a/backend/services/AuthService.js
+++ b/backend/services/AuthService.js
@@ -1,0 +1,515 @@
+import { AppError } from '../utils/index.js';
+import { userRepository } from '../repositories/UserRepository.js';
+import { organizationRepository } from '../repositories/OrganizationRepository.js';
+import { organizationMemberRepository } from '../repositories/OrganizationMemberRepository.js';
+import {
+  generateTokenPair,
+  verifyRefreshToken,
+  generateAccessToken,
+  generateRefreshToken,
+  hashRefreshToken,
+} from '../utils/security/jwt.js';
+import { sha256 } from '../utils/security/crypto.js';
+import { safeDecrypt } from '../utils/security/fieldEncryption.js';
+import { emailService } from './emailService.js';
+import logger from '../config/logger.js';
+
+const RESEND_VERIFICATION_COOLDOWN_MS = 60 * 1000;
+
+function toUserPayload(user, overrides = {}) {
+  return {
+    id: user._id,
+    email: user.email,
+    name: safeDecrypt(user.name),
+    role: user.role,
+    isEmailVerified: user.isEmailVerified,
+    organizationId: user.organizationId ? user.organizationId.toString() : null,
+    onboardingCompleted: user.onboardingCompleted,
+    onboardingChecklist: user.onboardingChecklist,
+    ...overrides,
+  };
+}
+
+class AuthService {
+  constructor(deps = {}) {
+    this.userRepo = deps.userRepo || userRepository;
+    this.organizationRepo = deps.organizationRepo || organizationRepository;
+    this.memberRepo = deps.memberRepo || organizationMemberRepository;
+    this.emailService = deps.emailService || emailService;
+    this.logger = deps.logger || logger;
+  }
+
+  /**
+   * Resolve an organization summary for inclusion in /me + login responses.
+   */
+  async _resolveOrganizationSummary(organizationId) {
+    if (!organizationId) return null;
+    const org = await this.organizationRepo.findById(organizationId, {
+      select: 'name industry country',
+    });
+    if (!org) return null;
+    return {
+      id: org._id,
+      name: org.name,
+      industry: org.industry,
+      country: org.country,
+    };
+  }
+
+  async register({ email, password, name, role, inviteToken, deviceInfo }) {
+    const existingUser = await this.userRepo.findByEmail(email);
+    if (existingUser) {
+      this.logger.warn('Registration attempt with existing email', { email });
+      throw new AppError('Email already registered', 409);
+    }
+
+    // Hand-build the doc so pre-save hooks (password hash, name encrypt) run.
+    const userDoc = new this.userRepo.model({
+      email,
+      password,
+      name,
+      role: role || 'user',
+    });
+    await userDoc.save();
+
+    const tokens = generateTokenPair({
+      userId: userDoc._id,
+      email: userDoc.email,
+      role: userDoc.role,
+    });
+
+    const tokenHash = hashRefreshToken(tokens.refreshToken);
+    await userDoc.addRefreshToken(tokenHash, deviceInfo);
+
+    let organizationId = null;
+    if (inviteToken) {
+      try {
+        const member = await this.memberRepo.findByToken(inviteToken);
+        if (member && member.email === email.toLowerCase()) {
+          await this.memberRepo.activate(member._id, userDoc._id);
+          await this.userRepo.updateById(userDoc._id, { organizationId: member.organizationId });
+          organizationId = member.organizationId;
+        }
+      } catch (err) {
+        this.logger.warn('Invite token processing failed during registration', {
+          userId: userDoc._id,
+          error: err.message,
+        });
+      }
+    }
+
+    const verificationToken = await userDoc.createEmailVerificationToken();
+    this.emailService
+      .sendEmailVerification({
+        toEmail: userDoc.email,
+        toName: name, // original from request (user.name is encrypted post-save)
+        verificationToken,
+      })
+      .catch((err) => {
+        this.logger.warn('Failed to send verification email', {
+          userId: userDoc._id,
+          error: err.message,
+        });
+      });
+
+    this.logger.info('New user registered', {
+      userId: userDoc._id,
+      email: userDoc.email,
+      role: userDoc.role,
+      hasOrg: !!organizationId,
+    });
+
+    return {
+      user: {
+        id: userDoc._id,
+        email: userDoc.email,
+        name,
+        role: userDoc.role,
+        isEmailVerified: false,
+        organizationId: organizationId ? organizationId.toString() : null,
+      },
+      needsOrganization: !organizationId,
+      tokens,
+    };
+  }
+
+  async login({ email, password, deviceInfo }) {
+    const user = await this.userRepo.model.findByCredentials(email);
+
+    if (!user) {
+      this.logger.warn('Login attempt with non-existent email', { email });
+      throw new AppError('Invalid credentials', 401);
+    }
+
+    if (user.isLocked) {
+      this.logger.warn('Login attempt on locked account', {
+        userId: user._id,
+        lockUntil: user.lockUntil,
+      });
+      throw new AppError('Account is temporarily locked. Please try again later.', 423);
+    }
+
+    if (!user.isActive) {
+      this.logger.warn('Login attempt on inactive account', { userId: user._id });
+      throw new AppError('Account is inactive', 401);
+    }
+
+    const isPasswordValid = await user.comparePassword(password);
+    if (!isPasswordValid) {
+      this.logger.warn('Failed login attempt', { email });
+      await user.incLoginAttempts();
+      throw new AppError('Invalid credentials', 401);
+    }
+
+    await user.resetLoginAttempts();
+
+    const tokens = generateTokenPair({
+      userId: user._id,
+      email: user.email,
+      role: user.role,
+    });
+
+    const tokenHash = hashRefreshToken(tokens.refreshToken);
+    await user.addRefreshToken(tokenHash, deviceInfo);
+
+    const organization = await this._resolveOrganizationSummary(user.organizationId);
+
+    this.logger.info('User logged in', {
+      userId: user._id,
+      email: user.email,
+    });
+
+    return {
+      user: toUserPayload(user, { organization }),
+      tokens,
+    };
+  }
+
+  /**
+   * Result conventions:
+   *   throws AppError 401 — caller should also clearAuthCookies(res)
+   *   returns { accessToken, refreshToken } on success
+   */
+  async refreshTokens({ refreshTokenValue, deviceInfo }) {
+    if (!refreshTokenValue) {
+      throw new AppError('Refresh token required', 401);
+    }
+
+    let decoded;
+    try {
+      decoded = verifyRefreshToken(refreshTokenValue);
+    } catch (error) {
+      this.logger.warn('Invalid refresh token signature', { error: error.message });
+      throw new AppError(error.message || 'Invalid refresh token', 401);
+    }
+
+    const user = await this.userRepo.findById(decoded.userId, { select: '+refreshTokens' });
+
+    if (!user) {
+      this.logger.warn('User not found for refresh token', { userId: decoded.userId });
+      throw new AppError('Invalid refresh token', 401);
+    }
+
+    if (!user.isActive) {
+      throw new AppError('Account is inactive', 401);
+    }
+
+    const incomingTokenHash = hashRefreshToken(refreshTokenValue);
+    const tokenValid = await user.consumeRefreshToken(incomingTokenHash);
+
+    if (!tokenValid) {
+      // Possible theft — clear all refresh tokens
+      this.logger.warn('Refresh token not found or already used - possible token theft', {
+        userId: user._id,
+      });
+      await user.clearAllRefreshTokens();
+      throw new AppError('Invalid refresh token. Please login again.', 401);
+    }
+
+    const newAccessToken = generateAccessToken({
+      userId: user._id,
+      email: user.email,
+      role: user.role,
+    });
+    const newRefreshToken = generateRefreshToken({
+      userId: user._id,
+      email: user.email,
+    });
+
+    const newTokenHash = hashRefreshToken(newRefreshToken);
+    await user.addRefreshToken(newTokenHash, deviceInfo);
+
+    await this.userRepo.updateOne(
+      { _id: user._id },
+      { $set: { lastLogin: new Date() } }
+    );
+
+    this.logger.info('Tokens rotated successfully', { userId: user._id });
+
+    return { accessToken: newAccessToken, refreshToken: newRefreshToken };
+  }
+
+  async logout({ userId, refreshTokenValue, logoutAll }) {
+    const user = await this.userRepo.findById(userId, { select: '+refreshTokens' });
+    if (!user) return;
+
+    if (logoutAll) {
+      await user.clearAllRefreshTokens();
+      this.logger.info('User logged out from all devices', { userId: user._id });
+      return;
+    }
+
+    if (refreshTokenValue) {
+      const tokenHash = hashRefreshToken(refreshTokenValue);
+      await user.consumeRefreshToken(tokenHash);
+    }
+    this.logger.info('User logged out', { userId: user._id });
+  }
+
+  async getMe(userId) {
+    const user = await this.userRepo.findById(userId);
+    if (!user) throw new AppError('User not found', 404);
+
+    const organization = await this._resolveOrganizationSummary(user.organizationId);
+
+    return {
+      user: toUserPayload(user, {
+        createdAt: user.createdAt,
+        lastLogin: user.lastLogin,
+        organization,
+      }),
+    };
+  }
+
+  async updateProfile(userId, { name, email }) {
+    const user = await this.userRepo.findById(userId);
+    if (!user) throw new AppError('User not found', 404);
+
+    if (!name && !email) {
+      throw new AppError('No profile changes provided', 400);
+    }
+    if (email && email !== user.email) {
+      throw new AppError('Email cannot be changed via profile update', 400);
+    }
+
+    if (name) user.name = name;
+
+    await user.save();
+
+    this.logger.info('User profile updated', { userId: user._id });
+
+    const displayName = user.decryptField ? user.decryptField('name') : user.name;
+
+    return {
+      user: {
+        id: user._id,
+        email: user.email,
+        name: displayName,
+        role: user.role,
+        isEmailVerified: user.isEmailVerified,
+        createdAt: user.createdAt,
+        lastLogin: user.lastLogin,
+      },
+    };
+  }
+
+  async forgotPassword({ email }) {
+    const user = await this.userRepo.findByEmail(email);
+
+    // Always return success to prevent email enumeration
+    if (!user) {
+      this.logger.info('Password reset requested for non-existent email', { email });
+      return;
+    }
+
+    const resetToken = await user.createPasswordResetToken();
+
+    const emailResult = await this.emailService.sendPasswordResetEmail({
+      toEmail: user.email,
+      toName: user.name,
+      resetToken,
+    });
+
+    if (!emailResult.success) {
+      this.logger.error('Failed to send password reset email', {
+        userId: user._id,
+        error: emailResult.error || emailResult.reason,
+        reason: emailResult.reason,
+      });
+      await user.clearPasswordResetToken();
+      throw new AppError(
+        'Email service is temporarily unavailable. Please try again later or contact support.',
+        503
+      );
+    }
+
+    this.logger.info('Password reset email sent', { userId: user._id, email: user.email });
+  }
+
+  async resetPassword({ token, password }) {
+    const hashedToken = sha256(token);
+
+    const user = await this.userRepo.findOne(
+      {
+        passwordResetToken: hashedToken,
+        passwordResetExpires: { $gt: Date.now() },
+      },
+      { select: '+passwordResetToken +passwordResetExpires +refreshTokens' }
+    );
+
+    if (!user) {
+      this.logger.warn('Invalid or expired password reset token');
+      throw new AppError('Invalid or expired reset token. Please request a new one.', 400);
+    }
+
+    user.password = password;
+    user.passwordResetToken = undefined;
+    user.passwordResetExpires = undefined;
+    user.refreshTokens = []; // force re-login on all devices
+
+    await user.save();
+
+    this.logger.info('Password reset successful', { userId: user._id });
+  }
+
+  async verifyEmail({ token }) {
+    const hashedToken = sha256(token);
+
+    const user = await this.userRepo.findOne(
+      {
+        emailVerificationToken: hashedToken,
+        emailVerificationExpires: { $gt: Date.now() },
+      },
+      { select: '+emailVerificationToken +emailVerificationExpires' }
+    );
+
+    if (!user) {
+      this.logger.warn('Invalid or expired email verification token');
+      throw new AppError(
+        'Invalid or expired verification token. Please request a new one.',
+        400
+      );
+    }
+
+    const userName = user.name; // capture before save() re-encrypts
+
+    user.isEmailVerified = true;
+    user.emailVerificationToken = undefined;
+    user.emailVerificationExpires = undefined;
+    await user.save({ validateBeforeSave: false });
+
+    this.logger.info('Email verified successfully', {
+      userId: user._id,
+      email: user.email,
+    });
+
+    this.emailService
+      .sendWelcomeEmail({ toEmail: user.email, toName: userName })
+      .catch((err) => {
+        this.logger.warn('Failed to send welcome email after verification', {
+          userId: user._id,
+          error: err.message,
+        });
+      });
+  }
+
+  async resendVerification(userId) {
+    const user = await this.userRepo.findById(userId);
+    if (!user) throw new AppError('User not found', 404);
+
+    if (user.isEmailVerified) {
+      throw new AppError('Email is already verified', 400);
+    }
+
+    if (user.emailVerificationLastSentAt) {
+      const elapsedMs = Date.now() - user.emailVerificationLastSentAt.getTime();
+      if (elapsedMs < RESEND_VERIFICATION_COOLDOWN_MS) {
+        this.logger.warn('Resend verification blocked due to cooldown', { userId: user._id });
+        const waitSeconds = Math.ceil((RESEND_VERIFICATION_COOLDOWN_MS - elapsedMs) / 1000);
+        throw new AppError(
+          `Please wait ${waitSeconds}s before requesting another verification email.`,
+          429
+        );
+      }
+    }
+
+    const verificationToken = await user.createEmailVerificationToken();
+
+    const emailResult = await this.emailService.sendEmailVerification({
+      toEmail: user.email,
+      toName: user.name,
+      verificationToken,
+    });
+
+    if (!emailResult.success) {
+      this.logger.error('Failed to resend verification email', {
+        userId: user._id,
+        error: emailResult.error || emailResult.reason,
+        reason: emailResult.reason,
+      });
+      throw new AppError(
+        'Email service is temporarily unavailable. Please try again later or contact support.',
+        503
+      );
+    }
+
+    this.logger.info('Verification email resent', {
+      userId: user._id,
+      email: user.email,
+    });
+  }
+
+  async changePassword(userId, { currentPassword, newPassword }) {
+    const user = await this.userRepo.findById(userId, { select: '+password +refreshTokens' });
+    if (!user) throw new AppError('User not found', 404);
+
+    const isPasswordValid = await user.comparePassword(currentPassword);
+    if (!isPasswordValid) {
+      this.logger.warn('Change password failed - incorrect current password', {
+        userId: user._id,
+      });
+      throw new AppError('Current password is incorrect', 401);
+    }
+
+    user.password = newPassword;
+    user.refreshTokens = []; // force re-login on all devices
+
+    await user.save();
+
+    this.logger.info('Password changed successfully - all sessions invalidated', {
+      userId: user._id,
+    });
+  }
+
+  async updateOnboarding(userId, { completed, checklist }) {
+    const update = {};
+
+    if (completed !== undefined) {
+      update.onboardingCompleted = completed;
+    }
+
+    if (checklist && typeof checklist === 'object') {
+      const allowed = [
+        'vendorCreated',
+        'assessmentCreated',
+        'memberInvited',
+        'monitoringSetup',
+        'dismissed',
+      ];
+      for (const key of allowed) {
+        if (checklist[key] !== undefined) {
+          update[`onboardingChecklist.${key}`] = checklist[key];
+        }
+      }
+    }
+
+    if (Object.keys(update).length === 0) {
+      throw new AppError('No valid fields to update', 400);
+    }
+
+    await this.userRepo.updateOne({ _id: userId }, { $set: update });
+  }
+}
+
+export const authService = new AuthService();
+export { AuthService };


### PR DESCRIPTION
## Summary

**Final P3 slice.** `authController.js` was the largest controller in the codebase at 831 LOC, with ~15 direct `User`/`Organization`/`OrganizationMember` calls and the entire auth lifecycle (register, login, refresh, logout, profile, password reset, email verify, onboarding) inline.

**Controller shrinks 831 → 188 LOC (-77%).**

Net diff: 2 files, +628 / -756.

## Service surface (12 methods — one per endpoint)

- `register({ email, password, name, role, inviteToken, deviceInfo })` → `{ user, needsOrganization, tokens }`
- `login({ email, password, deviceInfo })` → `{ user, tokens }`
- `refreshTokens({ refreshTokenValue, deviceInfo })` → `{ accessToken, refreshToken }`
- `logout({ userId, refreshTokenValue, logoutAll })`
- `getMe(userId)` → `{ user }`
- `updateProfile(userId, { name, email })` → `{ user }`
- `forgotPassword({ email })` (returns void; controller always sends generic success to prevent enumeration)
- `resetPassword({ token, password })`
- `verifyEmail({ token })`
- `resendVerification(userId)`
- `changePassword(userId, { currentPassword, newPassword })`
- `updateOnboarding(userId, { completed, checklist })`

All data access goes through `UserRepository`, `OrganizationRepository`, `OrganizationMemberRepository` (all added in PR #257). The two cases that need raw model access — `User.findByCredentials` (custom static for login) and `new User(...)` to trigger pre-save hooks during register — reach the model via `this.userRepo.model` rather than re-importing.

## Style change: catchAsync everywhere

Every auth endpoint previously did its own `try/catch + sendError(res, 500, 'X failed')` boilerplate. They now run under `catchAsync`; the service throws `AppError(message, statusCode)` and `globalErrorHandler` serializes the response. The HTTP status codes (401, 403, 404, 409, 423, 429, 503, …) and message text are preserved.

Two endpoints keep explicit error handling because they must always clear/set HTTP-only cookies regardless of outcome:

- **`refreshToken`** — on any rejection clears auth cookies before `next(err)` (otherwise the client keeps retrying with a stale cookie)
- **`logout`** — best-effort, always clears cookies and returns 200

Cookie helpers (`setAuthCookies` / `clearAuthCookies` / `getRefreshToken`) stay at the controller boundary — HTTP transport concerns, not business logic.

## Behavior change (same as prior P3 slices)

4xx response bodies' `status` field switches from `"error"` to `"fail"` (per `AppError`'s convention). HTTP status code and `message` field unchanged.

## Test plan

- [x] `node --check` on both files
- [x] `docker compose up -d --build backend` boots cleanly: workers active, queues initialized, no module-load errors, `/health` returns success
- [ ] CI to run the full backend + frontend test suite

## What this completes

This is the last P-item from the backend architecture audit:

- ✅ P0 — wire orphan workers + drop memoryDecay queue (#254)
- ✅ P1 — delete confirmed dead code, 3,741 LOC (#255)
- ✅ P2 — add six missing repositories (#257)
- ✅ P3a — ConversationService (#258)
- ✅ P3b — BillingService (#259)
- ✅ P3c — QuestionnaireService (#260)
- ✅ P3d — OrganizationService (#261)
- 🟢 P3e — **this PR**: AuthService
- ✅ P4 — services + assessment worker routed through repositories (#256)