### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+# =============================================================================
+# Release Workflow
+# =============================================================================
+# Fires when a semver-shaped tag is pushed (v1.2.3, v1.2.3-rc.1, etc.).
+# Creates a GitHub Release with auto-generated notes from PR titles + commits
+# since the previous tag.
+#
+# Decoupled from CD: deployment still happens on push to main (cd.yml).
+# This workflow is purely about marking + documenting a release.
+#
+# Usage:
+#   git tag v1.0.0
+#   git push origin v1.0.0
+#
+# Or via the Actions UI: Run workflow → choose tag.
+# =============================================================================
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to publish a release for (e.g. v1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
+          PUSHED_REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$DISPATCH_TAG"
+          else
+            tag="${PUSHED_REF#refs/tags/}"
+          fi
+          # Allow only the same shape we trigger on, so a malformed input can't
+          # become a shell argument later.
+          if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$'; then
+            echo "Refusing to release: tag '$tag' is not a clean semver tag." >&2
+            exit 1
+          fi
+          echo "name=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.name }}
+          fetch-depth: 0
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          set -euo pipefail
+          # Idempotency: if a release already exists for this tag, exit cleanly.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — nothing to do."
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --verify-tag


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` so pushing a semver tag (`vX.Y.Z` or `vX.Y.Z-prerelease`) creates a GitHub Release with auto-generated notes from PR titles + commits since the previous tag.

Single file, +81 lines.

## Why a separate workflow

`cd.yml` already auto-deploys on push to `main`. Adding the release creation directly there would couple deployment with the release record, which makes rolling back a deploy harder. Keeping them separate:

- Push to `main` → CD deploys (existing behavior, unchanged)
- Push a tag → release workflow marks + documents the release

## Triggers

- `push` on `v[0-9]+.[0-9]+.[0-9]+` and `v[0-9]+.[0-9]+.[0-9]+-*` tags
- `workflow_dispatch` with an `inputs.tag` for publishing historical or missed releases from the Actions UI

## Safety notes

- `permissions: contents: write` (the minimum to create a release).
- Tag value is passed via `env:` rather than direct `${{ }}` interpolation inside `run:` blocks (avoids the standard GitHub Actions injection footgun).
- Tag is regex-validated against the same semver shape the workflow triggers on, so a malformed `workflow_dispatch` input can't reach the shell.
- Idempotent — `gh release view` is checked first, so re-running for the same tag exits cleanly instead of failing.

## Usage

```bash
git tag v1.0.0
git push origin v1.0.0
```

Or `Actions → Release → Run workflow → tag: v1.0.0`.