### PR TITLE
feat(security): per-endpoint auth rate limiter

### DIFF
--- a/backend/middleware/authRateLimiter.js
+++ b/backend/middleware/authRateLimiter.js
@@ -1,0 +1,97 @@
+/**
+ * Auth-specific rate limiting middleware
+ *
+ * The global limiter in app.js (1000 req/hr) is too loose for credential
+ * surfaces. These limiters apply per IP per endpoint with tighter caps
+ * so credential stuffing / spray attacks can't blow past the global cap.
+ *
+ * Layering with existing protections:
+ *   - User.incLoginAttempts → 2-hour account lock after 5 password failures
+ *     (applies regardless of IP rotation)
+ *   - This middleware → per-IP cap (applies even before a user exists)
+ *
+ * Disabled when AUTH_RATE_LIMIT_DISABLED=true so integration tests can run
+ * without inflating counters or hitting limits.
+ */
+
+import rateLimit from 'express-rate-limit';
+import logger from '../config/logger.js';
+
+const DISABLED = process.env.AUTH_RATE_LIMIT_DISABLED === 'true';
+
+function makeLimiter({ name, windowMs, max, message }) {
+  return rateLimit({
+    windowMs,
+    max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: () => DISABLED,
+    // Key by IP. We deliberately do NOT key by user — the point is to
+    // protect endpoints that establish identity, before a user is known.
+    keyGenerator: (req) => `auth:${name}:${req.ip || 'unknown'}`,
+    validate: { ip: false, trustProxy: false },
+    message: { status: 'fail', message },
+    handler: (req, res, _next, options) => {
+      logger.warn('Auth rate limit exceeded', {
+        service: 'auth-rate-limiter',
+        limiter: name,
+        ip: req.ip,
+        path: req.path,
+        method: req.method,
+      });
+      res.status(options.statusCode).json(options.message);
+    },
+  });
+}
+
+// Login: legit users retry after typos. Allow 10 attempts in 15 min per IP.
+export const loginLimiter = makeLimiter({
+  name: 'login',
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  message: 'Too many login attempts. Please try again in 15 minutes.',
+});
+
+// Register: rare event. 5 per hour per IP is plenty for genuine users
+// and slows down account-creation spam.
+export const registerLimiter = makeLimiter({
+  name: 'register',
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  message: 'Too many registration attempts. Please try again in an hour.',
+});
+
+// Forgot/reset password: 5 per hour per IP. Higher than register because
+// a user typing a wrong email isn't necessarily abusive, but enumeration
+// loops should still be cut off.
+export const passwordResetLimiter = makeLimiter({
+  name: 'password-reset',
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  message: 'Too many password reset attempts. Please try again in an hour.',
+});
+
+// Email verify: hash-token endpoint, 10/hour is generous.
+export const emailVerifyLimiter = makeLimiter({
+  name: 'email-verify',
+  windowMs: 60 * 60 * 1000,
+  max: 10,
+  message: 'Too many email verification attempts. Please try again in an hour.',
+});
+
+// Resend verification: stacks on top of the controller-side 60s cooldown.
+export const resendVerifyLimiter = makeLimiter({
+  name: 'resend-verify',
+  windowMs: 60 * 60 * 1000,
+  max: 10,
+  message: 'Too many verification email requests. Please try again in an hour.',
+});
+
+// Refresh: legit clients hit this every ~15 min. 60/hour leaves wide headroom
+// for multi-tab usage while bounding token-replay attempts.
+export const refreshLimiter = makeLimiter({
+  name: 'refresh',
+  windowMs: 60 * 60 * 1000,
+  max: 60,
+  message: 'Too many refresh attempts. Please try again later.',
+});

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -16,6 +16,14 @@ import {
 import { validateBody } from '../middleware/validate.js';
 import { authenticate } from '../middleware/auth.js';
 import {
+  loginLimiter,
+  registerLimiter,
+  passwordResetLimiter,
+  emailVerifyLimiter,
+  resendVerifyLimiter,
+  refreshLimiter,
+} from '../middleware/authRateLimiter.js';
+import {
   registerSchema,
   loginSchema,
   refreshTokenSchema,
@@ -34,21 +42,21 @@ const router = express.Router();
  * @desc    Register a new user (sends verification email)
  * @access  Public
  */
-router.post('/register', validateBody(registerSchema), register);
+router.post('/register', registerLimiter, validateBody(registerSchema), register);
 
 /**
  * @route   POST /api/v1/auth/login
  * @desc    Login user
  * @access  Public
  */
-router.post('/login', validateBody(loginSchema), login);
+router.post('/login', loginLimiter, validateBody(loginSchema), login);
 
 /**
  * @route   POST /api/v1/auth/refresh
  * @desc    Refresh access token (with token rotation)
  * @access  Public
  */
-router.post('/refresh', validateBody(refreshTokenSchema), refreshToken);
+router.post('/refresh', refreshLimiter, validateBody(refreshTokenSchema), refreshToken);
 
 /**
  * @route   POST /api/v1/auth/logout
@@ -77,28 +85,38 @@ router.patch('/profile', authenticate, validateBody(updateProfileSchema), update
  * @desc    Request password reset email
  * @access  Public
  */
-router.post('/forgot-password', validateBody(forgotPasswordSchema), forgotPassword);
+router.post(
+  '/forgot-password',
+  passwordResetLimiter,
+  validateBody(forgotPasswordSchema),
+  forgotPassword
+);
 
 /**
  * @route   POST /api/v1/auth/reset-password
  * @desc    Reset password with token from email
  * @access  Public
  */
-router.post('/reset-password', validateBody(resetPasswordSchema), resetPassword);
+router.post(
+  '/reset-password',
+  passwordResetLimiter,
+  validateBody(resetPasswordSchema),
+  resetPassword
+);
 
 /**
  * @route   POST /api/v1/auth/verify-email
  * @desc    Verify email address with token
  * @access  Public
  */
-router.post('/verify-email', validateBody(verifyEmailSchema), verifyEmail);
+router.post('/verify-email', emailVerifyLimiter, validateBody(verifyEmailSchema), verifyEmail);
 
 /**
  * @route   POST /api/v1/auth/resend-verification
  * @desc    Resend email verification
  * @access  Private
  */
-router.post('/resend-verification', authenticate, resendVerification);
+router.post('/resend-verification', resendVerifyLimiter, authenticate, resendVerification);
 
 /**
  * @route   POST /api/v1/auth/change-password
@@ -112,11 +130,6 @@ router.post('/change-password', authenticate, validateBody(changePasswordSchema)
  * @desc    Update onboarding state (welcome screen dismissed, checklist flags)
  * @access  Private
  */
-router.patch(
-  '/onboarding',
-  authenticate,
-  validateBody(updateOnboardingSchema),
-  updateOnboarding
-);
+router.patch('/onboarding', authenticate, validateBody(updateOnboardingSchema), updateOnboarding);
 
 export default router;

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -60,6 +60,9 @@ export default defineConfig({
       RESEND_FROM_EMAIL: 'noreply@retrieva.online',
       SMTP_FROM_NAME: 'Retrieva',
       FRONTEND_URL: 'http://localhost:3000',
+      // PR-L: disable auth rate limits in unit + integration tests so a single
+      // test suite doesn't blow past per-IP caps and start getting 429s.
+      AUTH_RATE_LIMIT_DISABLED: 'true',
     },
   },
 });


### PR DESCRIPTION
## Summary

Closes audit gap **A2** (Section 2 — Strong Authentication): the only protection on credential surfaces was the global 1000-req/hr limiter in `app.js`, too loose for credential stuffing / spray attacks.

Adds dedicated per-IP, per-endpoint `express-rate-limit` instances to the auth routes, layered with — not replacing — the existing per-user account lockout in `User.js`.

## Limits (per IP, per endpoint)

| Endpoint | Limit |
|---|---|
| `POST /register` | 5 / hour |
| `POST /login` | 10 / 15 min |
| `POST /forgot-password` | 5 / hour |
| `POST /reset-password` | 5 / hour |
| `POST /verify-email` | 10 / hour |
| `POST /resend-verification` | 10 / hour |
| `POST /refresh` | 60 / hour |

Each limiter logs throttled requests and returns `{ status: 'fail', message }` at HTTP 429.

## Test env

`AUTH_RATE_LIMIT_DISABLED=true` is set in `vitest.config.js` so an auth-heavy test suite doesn't trip the per-IP caps; the flag short-circuits all limiters via express-rate-limit's `skip()` hook.

## Base

Rebased onto `dev` so this branch carries **only** the rate limiter — the input-validation backfill it previously also contained is already on `dev` via #265 (PR-V).

## Verification

- Backend unit suite: 55 files / 1238 tests passed
- Frontend suite: 21 files / 506 tests passed (pre-push hook)