### PR TITLE
refactor: route residual service/worker model calls through repositories (P4)

### DIFF
--- a/backend/repositories/UserRepository.js
+++ b/backend/repositories/UserRepository.js
@@ -13,6 +13,17 @@ class UserRepository extends BaseRepository {
   async updateLastLogin(userId) {
     return this.model.updateOne({ _id: userId }, { $set: { lastLogin: new Date() } });
   }
+
+  /**
+   * Flip the onboarding "assessment created" checklist flag (idempotent —
+   * only writes when still false). Best-effort, fire-and-forget at call sites.
+   */
+  async markAssessmentCreated(userId) {
+    return this.model.updateOne(
+      { _id: userId, 'onboardingChecklist.assessmentCreated': false },
+      { $set: { 'onboardingChecklist.assessmentCreated': true } }
+    );
+  }
 }
 
 export const userRepository = new UserRepository();

--- a/backend/services/AssessmentService.js
+++ b/backend/services/AssessmentService.js
@@ -1,9 +1,9 @@
 import path from 'path';
 import mongoose from 'mongoose';
 import { AppError } from '../utils/index.js';
-import { User } from '../models/User.js';
 import { assessmentRepository } from '../repositories/AssessmentRepository.js';
 import { workspaceRepository } from '../repositories/WorkspaceRepository.js';
+import { userRepository } from '../repositories/UserRepository.js';
 import { assessmentQueue, monitoringQueue } from '../config/queue.js';
 import * as storageModule from '../config/storage.js';
 import { generateReport } from './reportGenerator.js';
@@ -14,7 +14,7 @@ class AssessmentService {
   constructor(deps = {}) {
     this.assessmentRepo = deps.assessmentRepo || assessmentRepository;
     this.workspaceRepo = deps.workspaceRepo || workspaceRepository;
-    this.User = deps.User || User;
+    this.userRepo = deps.userRepo || userRepository;
     this.assessmentQueue = deps.assessmentQueue || assessmentQueue;
     this.monitoringQueue = deps.monitoringQueue || monitoringQueue;
     this.storage = deps.storage || storageModule;
@@ -51,10 +51,7 @@ class AssessmentService {
       fileCount: files.length,
     });
 
-    this.User.updateOne(
-      { _id: userId, 'onboardingChecklist.assessmentCreated': false },
-      { $set: { 'onboardingChecklist.assessmentCreated': true } }
-    ).catch(() => {});
+    this.userRepo.markAssessmentCreated(userId).catch(() => {});
 
     if (this.storage.isStorageConfigured() && organizationId) {
       await Promise.all(

--- a/backend/services/roiExportService.js
+++ b/backend/services/roiExportService.js
@@ -12,10 +12,10 @@
  */
 
 import XLSX from 'xlsx';
-import { WorkspaceMember } from '../models/WorkspaceMember.js';
-import { VendorQuestionnaire } from '../models/VendorQuestionnaire.js';
 import { assessmentRepository } from '../repositories/AssessmentRepository.js';
 import { workspaceRepository } from '../repositories/WorkspaceRepository.js';
+import { workspaceMemberRepository } from '../repositories/WorkspaceMemberRepository.js';
+import { vendorQuestionnaireRepository } from '../repositories/VendorQuestionnaireRepository.js';
 
 const INSTITUTION_NAME = process.env.INSTITUTION_NAME || 'Financial Entity';
 
@@ -28,7 +28,7 @@ function fmtDate(d) {
 
 export async function generateRoiWorkbook(userId) {
   // 1. Collect all workspaces the user has access to
-  const memberships = await WorkspaceMember.find({ userId, status: 'active' });
+  const memberships = await workspaceMemberRepository.findActiveByUserId(userId);
   const workspaceIds = memberships.map((m) => m.workspaceId);
   const workspaces = await workspaceRepository.find({ _id: { $in: workspaceIds } });
 
@@ -40,7 +40,7 @@ export async function generateRoiWorkbook(userId) {
   ]);
 
   // 3. Latest complete questionnaire per workspace
-  const latestQuestionnaires = await VendorQuestionnaire.aggregate([
+  const latestQuestionnaires = await vendorQuestionnaireRepository.aggregate([
     { $match: { workspaceId: { $in: workspaceIds }, status: 'complete' } },
     { $sort: { createdAt: -1 } },
     { $group: { _id: '$workspaceId', doc: { $first: '$$ROOT' } } },

--- a/backend/tests/unittest/assessmentService.unit.test.js
+++ b/backend/tests/unittest/assessmentService.unit.test.js
@@ -7,7 +7,7 @@ import { AssessmentService } from '../../services/AssessmentService.js';
 // ---------------------------------------------------------------------------
 vi.mock('../../models/Assessment.js', () => ({ Assessment: {} }));
 vi.mock('../../models/Workspace.js', () => ({ Workspace: {} }));
-vi.mock('../../models/User.js', () => ({ User: {} }));
+vi.mock('../../repositories/UserRepository.js', () => ({ userRepository: {} }));
 vi.mock('../../config/queue.js', () => ({
   assessmentQueue: { add: vi.fn() },
   monitoringQueue: { getJob: vi.fn(), add: vi.fn() },
@@ -83,14 +83,14 @@ function makeDeps(overrides = {}) {
     count: vi.fn(),
   };
   const workspaceRepo = { updateById: vi.fn().mockResolvedValue(undefined) };
-  const User = { updateOne: vi.fn().mockReturnValue({ catch: vi.fn() }) };
+  const userRepo = { markAssessmentCreated: vi.fn().mockReturnValue({ catch: vi.fn() }) };
   const generateReport = vi.fn().mockResolvedValue(Buffer.from('docx'));
   const deleteAssessmentCollection = vi.fn().mockResolvedValue(undefined);
 
   return {
     assessmentRepo,
     workspaceRepo,
-    User,
+    userRepo,
     assessmentQueue,
     monitoringQueue,
     storage,
@@ -175,7 +175,7 @@ describe('AssessmentService.createAssessment', () => {
       [makeFile()]
     );
 
-    expect(deps.User.updateOne).toHaveBeenCalled();
+    expect(deps.userRepo.markAssessmentCreated).toHaveBeenCalled();
   });
 });
 

--- a/backend/workers/questionnaireWorker.js
+++ b/backend/workers/questionnaireWorker.js
@@ -7,7 +7,7 @@
 
 import { Worker } from 'bullmq';
 import { redisConnection } from '../config/redis.js';
-import { VendorQuestionnaire } from '../models/VendorQuestionnaire.js';
+import { vendorQuestionnaireRepository } from '../repositories/VendorQuestionnaireRepository.js';
 import { runScoring } from '../services/questionnaireScorer.js';
 import logger from '../config/logger.js';
 import { connectDB } from '../config/database.js';
@@ -76,7 +76,7 @@ worker.on('failed', async (job, err) => {
 
   if (job?.data?.questionnaireId) {
     try {
-      await VendorQuestionnaire.findByIdAndUpdate(job.data.questionnaireId, {
+      await vendorQuestionnaireRepository.updateById(job.data.questionnaireId, {
         status: 'failed',
         statusMessage: err.message,
       });


### PR DESCRIPTION
## Summary

Closes the remaining **P4** direct-model call sites flagged by the backend architecture audit. The services and workers explicitly named in the audit's P4 list now route all data access through repositories and no longer import mongoose models.

## Changes

| Call site | Before | After |
|---|---|---|
| `workers/questionnaireWorker.js:79` | `VendorQuestionnaire.findByIdAndUpdate` | `vendorQuestionnaireRepository.updateById` |
| `services/roiExportService.js:31` | `WorkspaceMember.find({userId, status})` | `workspaceMemberRepository.findActiveByUserId` |
| `services/roiExportService.js:43` | `VendorQuestionnaire.aggregate` | `vendorQuestionnaireRepository.aggregate` |
| `services/AssessmentService.js:54` | `this.User.updateOne` | `userRepository.markAssessmentCreated` |

- Adds `UserRepository.markAssessmentCreated()` — idempotent onboarding-flag flip, follows the existing `updateLastLogin` raw-`updateOne` convention.
- Updates `assessmentService.unit.test.js` to inject `userRepo` instead of the `User` model.
- All three target files now have zero direct model imports/calls.

## Scope

Intentionally out of scope (not in the audit's named P4 list): `questionnaireScorer.js`, `alertMonitorService.js`, and `WorkspaceService.js` (the latter uses injected models per the documented testability pattern).

## Verification

- `assessmentService.unit.test.js`: 22/22
- Full backend unit suite: 55 files / 1238 tests passed
- Frontend suite: 21 files / 506 tests passed (pre-push hook)
- Lint clean on edited files