### PR TITLE
chore: gitignore local claude session dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ CLAUDE.md
 # Local test process materials (PDFs, templates, test runs)
 testprocess/
 .playwright-mcp/
+
+# Local Claude Code session data (memory, settings)
+.claude/


### PR DESCRIPTION
## Summary

Adds `.claude/` to the root `.gitignore`. The directory holds local Claude Code session data (memory, settings) and shouldn't be tracked.

One line, no code impact.