### PR TITLE
feat(rbac): enforce source-view permission and document authorize scope (B1, B3)

### DIFF
--- a/backend/controllers/conversationController.js
+++ b/backend/controllers/conversationController.js
@@ -1,5 +1,6 @@
 import { conversationService } from '../services/ConversationService.js';
 import { catchAsync, sendSuccess, getUserId, parsePagination } from '../utils/index.js';
+import { userCanViewSources } from '../utils/security/sourceVisibility.js';
 import logger from '../config/logger.js';
 
 /**
@@ -94,6 +95,9 @@ export const getConversation = catchAsync(async (req, res) => {
     { limit, skip }
   );
 
+  // B1: strip per-message sources when the member can't view sources.
+  const allowSources = await userCanViewSources(req, conversation.workspaceId);
+
   sendSuccess(res, 200, 'Conversation retrieved successfully', {
     conversation: {
       id: conversation._id,
@@ -108,7 +112,7 @@ export const getConversation = catchAsync(async (req, res) => {
       id: m._id,
       role: m.role,
       content: m.content,
-      sources: m.sources || [],
+      sources: allowSources ? m.sources || [] : [],
       timestamp: m.timestamp,
     })),
     pagination: {
@@ -130,6 +134,12 @@ export const askQuestion = catchAsync(async (req, res) => {
   const userId = getUserId(req);
 
   const answer = await conversationService.askQuestion(id, userId, { question, filters });
+
+  // B1: honor the workspace canViewSources permission before returning sources.
+  const workspaceId = req.headers?.['x-workspace-id'] || req.body?.workspaceId;
+  if (answer?.sources?.length && !(await userCanViewSources(req, workspaceId))) {
+    answer.sources = [];
+  }
 
   sendSuccess(res, 200, 'Question answered successfully', {
     answer,

--- a/backend/controllers/ragController.js
+++ b/backend/controllers/ragController.js
@@ -1,5 +1,6 @@
 import { executeRAG, InputGuardrailError } from '../services/ragExecutor.js';
 import { catchAsync, sendSuccess, sendError } from '../utils/index.js';
+import { userCanViewSources } from '../utils/security/sourceVisibility.js';
 import logger from '../config/logger.js';
 
 /**
@@ -17,6 +18,8 @@ export const askQuestion = catchAsync(async (req, res) => {
     return sendError(res, 400, 'conversationId is required');
   }
 
+  const workspaceId = req.headers?.['x-workspace-id'] || req.body?.workspaceId;
+
   try {
     const result = await executeRAG({
       question,
@@ -26,6 +29,11 @@ export const askQuestion = catchAsync(async (req, res) => {
       forceIntent: forceIntent || null,
       useIntentAware,
     });
+
+    // B1: honor the workspace canViewSources permission before returning sources.
+    if (result?.sources?.length && !(await userCanViewSources(req, workspaceId))) {
+      result.sources = [];
+    }
 
     sendSuccess(res, 200, 'Question answered successfully', result);
   } catch (error) {
@@ -51,6 +59,11 @@ export const askQuestionStream = catchAsync(async (req, res) => {
     return sendError(res, 400, 'conversationId is required');
   }
 
+  // B1: resolve once up-front so the synchronous SSE writer can drop the
+  // `sources` event when this member is not allowed to see sources.
+  const workspaceId = req.headers?.['x-workspace-id'] || req.body?.workspaceId;
+  const allowSources = await userCanViewSources(req, workspaceId);
+
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache, no-transform');
   res.setHeader('Connection', 'keep-alive');
@@ -60,6 +73,7 @@ export const askQuestionStream = catchAsync(async (req, res) => {
   let closed = false;
   const send = (event, data) => {
     if (closed || res.writableEnded) return;
+    if (event === 'sources' && !allowSources) return;
     res.write(`event: ${event}\n`);
     res.write(`data: ${JSON.stringify(data)}\n\n`);
   };

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -111,10 +111,18 @@ export const authenticate = async (req, res, next) => {
 };
 
 /**
- * Authorization middleware factory - checks if user has required role
- * Must be used after authenticate middleware
+ * Authorization middleware factory — checks the **global** `User.role`
+ * (`user` | `admin`). Must run after `authenticate`.
  *
- * @param {...('user'|'admin')} roles - Allowed roles for this route
+ * SCOPE (audit gap B3): this gates routes on the platform-wide role only.
+ * Tenant-scoped access (the common case) is NOT handled here — use
+ * `requireWorkspaceAccess` / workspace membership permissions in
+ * `middleware/workspaceAuth.js` instead. This factory is intended for the
+ * narrow set of admin-only / platform routes and is intentionally kept (not
+ * deprecated) for that purpose. If you reach for it on a workspace resource,
+ * you almost certainly want `requireWorkspaceAccess`.
+ *
+ * @param {...('user'|'admin')} roles - Allowed global roles for this route
  * @returns {function(Request, Response, NextFunction): void} Express middleware
  */
 export const authorize = (...roles) => {

--- a/backend/tests/unittest/sourceVisibility.test.js
+++ b/backend/tests/unittest/sourceVisibility.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the repository the helper depends on.
+const findMembership = vi.fn();
+vi.mock('../../repositories/WorkspaceMemberRepository.js', () => ({
+  workspaceMemberRepository: {
+    findMembership: (...args) => findMembership(...args),
+  },
+}));
+
+const { userCanViewSources } = await import('../../utils/security/sourceVisibility.js');
+
+const WS = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+
+describe('userCanViewSources (B1)', () => {
+  beforeEach(() => {
+    findMembership.mockReset();
+  });
+
+  it('fails open (true) when no workspaceId can be resolved', async () => {
+    expect(await userCanViewSources({}, undefined)).toBe(true);
+    expect(findMembership).not.toHaveBeenCalled();
+  });
+
+  it('uses already-loaded authorizedWorkspaces and denies on explicit false', async () => {
+    const req = {
+      authorizedWorkspaces: [{ workspaceId: WS, permissions: { canViewSources: false } }],
+    };
+    expect(await userCanViewSources(req, WS)).toBe(false);
+    expect(findMembership).not.toHaveBeenCalled(); // no extra DB hit
+  });
+
+  it('allows when loaded permission is true', async () => {
+    const req = {
+      authorizedWorkspaces: [{ workspaceId: WS, permissions: { canViewSources: true } }],
+    };
+    expect(await userCanViewSources(req, WS)).toBe(true);
+  });
+
+  it('looks up membership when not preloaded and denies on explicit false', async () => {
+    findMembership.mockResolvedValue({ permissions: { canViewSources: false } });
+    const req = { user: { userId: 'u1' } };
+    expect(await userCanViewSources(req, WS)).toBe(false);
+    expect(findMembership).toHaveBeenCalledWith(WS, 'u1');
+  });
+
+  it('fails open when no membership row is found', async () => {
+    findMembership.mockResolvedValue(null);
+    const req = { user: { userId: 'u1' } };
+    expect(await userCanViewSources(req, WS)).toBe(true);
+  });
+
+  it('fails open when unauthenticated and not preloaded', async () => {
+    expect(await userCanViewSources({}, WS)).toBe(true);
+    expect(findMembership).not.toHaveBeenCalled();
+  });
+});

--- a/backend/utils/security/sourceVisibility.js
+++ b/backend/utils/security/sourceVisibility.js
@@ -1,0 +1,35 @@
+/**
+ * Source visibility (audit gap B1)
+ *
+ * WorkspaceMember carries a fine-grained `permissions.canViewSources` flag, but
+ * it was never enforced — retrieval sources were always returned. This helper
+ * resolves the flag for the current request so controllers can strip sources
+ * when a member is not allowed to see them.
+ *
+ * Fail-open: when the workspace can't be resolved, or no membership row is
+ * found, we return true — matching the WorkspaceMember model default
+ * (canViewSources: true). Only an explicit `false` strips sources.
+ */
+
+import { workspaceMemberRepository } from '../../repositories/WorkspaceMemberRepository.js';
+
+/**
+ * @param {import('express').Request} req - request (may carry req.authorizedWorkspaces)
+ * @param {string|import('mongoose').Types.ObjectId} workspaceId - target workspace
+ * @returns {Promise<boolean>} whether sources may be returned to this user
+ */
+export async function userCanViewSources(req, workspaceId) {
+  if (!workspaceId) return true;
+  const wsId = workspaceId.toString();
+
+  // requireWorkspaceAccess (RAG routes) already loaded memberships + permissions.
+  const loaded = req.authorizedWorkspaces?.find((w) => w.workspaceId === wsId);
+  if (loaded) return loaded.permissions?.canViewSources !== false;
+
+  // Conversation routes only run `authenticate`, so look the membership up.
+  const userId = req.user?.userId;
+  if (!userId) return true;
+
+  const membership = await workspaceMemberRepository.findMembership(wsId, userId);
+  return membership ? membership.permissions?.canViewSources !== false : true;
+}


### PR DESCRIPTION
## Summary

Closes RBAC audit gaps B1 and B3.

### B1 — enforce `canViewSources`
`WorkspaceMember.permissions.canViewSources` was defined and settable but **never enforced** — retrieval sources were returned regardless. Added `utils/security/sourceVisibility.js` (`userCanViewSources`) and gated every place sources are returned:
- `POST /rag` JSON response (`result.sources`)
- `POST /rag/stream` SSE — the `sources` event is dropped
- `GET /conversations/:id` — per-message `sources`
- `POST /conversations/:id/ask` — `answer.sources`

Resolution: prefer the memberships already loaded by `requireWorkspaceAccess` (no extra query); otherwise look up the membership via `WorkspaceMemberRepository`. **Fail-open** (sources shown) when the workspace can't be resolved or no membership row exists — matching the model default `canViewSources: true`. Only an explicit `false` strips sources.

### B3 — document `authorize()`
Documented that the global `authorize()` factory gates on the platform-wide `User.role` only and is intentionally kept for admin/platform routes; workspace-scoped access must use `requireWorkspaceAccess`.

## Verification
- New unit test `sourceVisibility.test.js` (6 cases: fail-open paths, preloaded vs lookup, explicit-false denial)
- Backend unit suite: 56 files / 1244 tests passed
- Backend integration: 132 passed; lint clean; pre-push hook (backend + frontend) passed