### PR TITLE
feat(auth): auth audit service + token-theft email alert (A5, A3)

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -13,6 +13,7 @@ import { verifyAccessToken } from '../utils/security/jwt.js';
 import { User } from '../models/User.js';
 import { sendError } from '../utils/core/responseFormatter.js';
 import { getAccessToken } from '../utils/security/cookieConfig.js';
+import { authAuditService } from '../services/authAuditService.js';
 import logger from '../config/logger.js';
 
 /**
@@ -201,7 +202,12 @@ export const optionalAuth = async (req, res, next) => {
         userAgent: req.headers['user-agent']?.substring(0, 100),
       });
 
-      // Security logging removed (securityLogger service not available in MVP)
+      // A5: record the invalid/replayed token as an auth audit event.
+      authAuditService.logTokenTheftDetected?.({
+        path: req.path,
+        ip: req.ip,
+        errorType: error.name,
+      });
     }
 
     next();

--- a/backend/services/AuthService.js
+++ b/backend/services/AuthService.js
@@ -12,6 +12,7 @@ import {
 import { sha256 } from '../utils/security/crypto.js';
 import { safeDecrypt } from '../utils/security/fieldEncryption.js';
 import { emailService } from './emailService.js';
+import { authAuditService } from './authAuditService.js';
 import logger from '../config/logger.js';
 
 const RESEND_VERIFICATION_COOLDOWN_MS = 60 * 1000;
@@ -36,6 +37,7 @@ class AuthService {
     this.organizationRepo = deps.organizationRepo || organizationRepository;
     this.memberRepo = deps.memberRepo || organizationMemberRepository;
     this.emailService = deps.emailService || emailService;
+    this.authAudit = deps.authAudit || authAuditService;
     this.logger = deps.logger || logger;
   }
 
@@ -118,6 +120,7 @@ class AuthService {
       role: userDoc.role,
       hasOrg: !!organizationId,
     });
+    this.authAudit.logRegisterSuccess?.({ userId: userDoc._id, email: userDoc.email });
 
     return {
       user: {
@@ -133,6 +136,40 @@ class AuthService {
     };
   }
 
+  /**
+   * A3: notify a user out-of-band that all their sessions were revoked because
+   * a refresh token was reused (a sign of theft). Best-effort and fully
+   * defensive — never throws into, or blocks, the auth flow.
+   */
+  _sendTokenTheftAlert(user) {
+    try {
+      const result = this.emailService.sendEmail?.({
+        to: user.email,
+        subject: 'Security alert: we signed you out of all devices',
+        html:
+          `<p>Hi ${user.name || 'there'},</p>` +
+          `<p>We detected that an old sign-in token for your Retrieva account was ` +
+          `reused, which can indicate it was stolen. As a precaution we revoked ` +
+          `all active sessions.</p>` +
+          `<p><strong>If this was you</strong> (e.g. an old tab or device), just ` +
+          `sign in again.</p>` +
+          `<p><strong>If this wasn't you</strong>, reset your password immediately ` +
+          `and review your account.</p><p>— The Retrieva team</p>`,
+      });
+      result?.catch?.((err) =>
+        this.logger.warn('Failed to send token-theft alert email', {
+          userId: user._id,
+          error: err.message,
+        })
+      );
+    } catch (err) {
+      this.logger.warn('Failed to send token-theft alert email', {
+        userId: user._id,
+        error: err.message,
+      });
+    }
+  }
+
   async login({ email, password, deviceInfo }) {
     const user = await this.userRepo.model.findByCredentials(email);
 
@@ -146,6 +183,7 @@ class AuthService {
         userId: user._id,
         lockUntil: user.lockUntil,
       });
+      this.authAudit.logLoginBlockedLocked?.({ userId: user._id, email });
       throw new AppError('Account is temporarily locked. Please try again later.', 423);
     }
 
@@ -158,6 +196,10 @@ class AuthService {
     if (!isPasswordValid) {
       this.logger.warn('Failed login attempt', { email });
       await user.incLoginAttempts();
+      this.authAudit.logLoginFailed?.({ userId: user._id, email });
+      if (user.isLocked) {
+        this.authAudit.logAccountLocked?.({ userId: user._id, email });
+      }
       throw new AppError('Invalid credentials', 401);
     }
 
@@ -178,6 +220,7 @@ class AuthService {
       userId: user._id,
       email: user.email,
     });
+    this.authAudit.logLoginSuccess?.({ userId: user._id, email: user.email });
 
     return {
       user: toUserPayload(user, { organization }),
@@ -223,6 +266,10 @@ class AuthService {
         userId: user._id,
       });
       await user.clearAllRefreshTokens();
+      this.authAudit.logTokenTheftDetected?.({ userId: user._id });
+      // A3: alert the user out-of-band that all sessions were revoked. Best-effort;
+      // never block the 401 on email delivery.
+      this._sendTokenTheftAlert(user);
       throw new AppError('Invalid refresh token. Please login again.', 401);
     }
 
@@ -239,12 +286,10 @@ class AuthService {
     const newTokenHash = hashRefreshToken(newRefreshToken);
     await user.addRefreshToken(newTokenHash, deviceInfo);
 
-    await this.userRepo.updateOne(
-      { _id: user._id },
-      { $set: { lastLogin: new Date() } }
-    );
+    await this.userRepo.updateOne({ _id: user._id }, { $set: { lastLogin: new Date() } });
 
     this.logger.info('Tokens rotated successfully', { userId: user._id });
+    this.authAudit.logTokenRefresh?.({ userId: user._id });
 
     return { accessToken: newAccessToken, refreshToken: newRefreshToken };
   }
@@ -256,6 +301,7 @@ class AuthService {
     if (logoutAll) {
       await user.clearAllRefreshTokens();
       this.logger.info('User logged out from all devices', { userId: user._id });
+      this.authAudit.logLogout?.({ userId: user._id, allDevices: true });
       return;
     }
 
@@ -264,6 +310,7 @@ class AuthService {
       await user.consumeRefreshToken(tokenHash);
     }
     this.logger.info('User logged out', { userId: user._id });
+    this.authAudit.logLogout?.({ userId: user._id, allDevices: false });
   }
 
   async getMe(userId) {
@@ -344,6 +391,7 @@ class AuthService {
     }
 
     this.logger.info('Password reset email sent', { userId: user._id, email: user.email });
+    this.authAudit.logPasswordResetRequest?.({ userId: user._id, email: user.email });
   }
 
   async resetPassword({ token, password }) {
@@ -370,6 +418,7 @@ class AuthService {
     await user.save();
 
     this.logger.info('Password reset successful', { userId: user._id });
+    this.authAudit.logPasswordResetSuccess?.({ userId: user._id });
   }
 
   async verifyEmail({ token }) {
@@ -385,10 +434,7 @@ class AuthService {
 
     if (!user) {
       this.logger.warn('Invalid or expired email verification token');
-      throw new AppError(
-        'Invalid or expired verification token. Please request a new one.',
-        400
-      );
+      throw new AppError('Invalid or expired verification token. Please request a new one.', 400);
     }
 
     const userName = user.name; // capture before save() re-encrypts
@@ -402,15 +448,14 @@ class AuthService {
       userId: user._id,
       email: user.email,
     });
+    this.authAudit.logEmailVerified?.({ userId: user._id, email: user.email });
 
-    this.emailService
-      .sendWelcomeEmail({ toEmail: user.email, toName: userName })
-      .catch((err) => {
-        this.logger.warn('Failed to send welcome email after verification', {
-          userId: user._id,
-          error: err.message,
-        });
+    this.emailService.sendWelcomeEmail({ toEmail: user.email, toName: userName }).catch((err) => {
+      this.logger.warn('Failed to send welcome email after verification', {
+        userId: user._id,
+        error: err.message,
       });
+    });
   }
 
   async resendVerification(userId) {

--- a/backend/services/authAuditService.js
+++ b/backend/services/authAuditService.js
@@ -1,0 +1,50 @@
+/**
+ * Authentication audit service (audit gap A5)
+ *
+ * Emits structured audit events for security-relevant authentication actions
+ * (register, login success/failure, lockout, logout, password reset, token
+ * refresh, token-theft detection, email verification) so they can be shipped
+ * to a SIEM / log pipeline and reviewed.
+ *
+ * Previously this service was referenced in tests but never implemented. It is
+ * logging-based and side-effect-free, so it is safe to call from any auth flow
+ * without a datastore or external dependency.
+ *
+ * Brute-force detection is intentionally a conservative stub that reports
+ * "not blocked" — the real enforcement already exists in two layers:
+ *   - per-IP: middleware/authRateLimiter.js
+ *   - per-account: User model lockout (5 attempts → 2h lock)
+ * The hooks are kept here so a future implementation can centralize detection
+ * without touching call sites.
+ */
+
+import logger from '../config/logger.js';
+
+const SERVICE = 'auth-audit';
+
+function audit(event, ctx = {}, level = 'info') {
+  logger[level]('auth.audit', { service: SERVICE, event, ...ctx });
+  return true;
+}
+
+export const authAuditService = {
+  logRegisterSuccess: (ctx) => audit('register_success', ctx),
+  logLoginSuccess: (ctx) => audit('login_success', ctx),
+  logLoginFailed: (ctx) => audit('login_failed', ctx, 'warn'),
+  logLoginBlockedLocked: (ctx) => audit('login_blocked_locked', ctx, 'warn'),
+  logAccountLocked: (ctx) => audit('account_locked', ctx, 'warn'),
+  logLogout: (ctx) => audit('logout', ctx),
+  logPasswordResetRequest: (ctx) => audit('password_reset_request', ctx),
+  logPasswordResetSuccess: (ctx) => audit('password_reset_success', ctx),
+  logTokenRefresh: (ctx) => audit('token_refresh', ctx),
+  logTokenTheftDetected: (ctx) => audit('token_theft_detected', ctx, 'warn'),
+  logEmailVerified: (ctx) => audit('email_verified', ctx),
+
+  // Detection stubs — see module note. Always report "not blocked"; the active
+  // controls are authRateLimiter (per IP) and the User account lockout.
+  detectBruteForce: async () => ({ blocked: false }),
+  checkBruteForce: async () => ({ blocked: false }),
+  isBlocked: async () => false,
+};
+
+export default authAuditService;

--- a/backend/tests/unittest/authAuditService.test.js
+++ b/backend/tests/unittest/authAuditService.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const info = vi.fn();
+const warn = vi.fn();
+vi.mock('../../config/logger.js', () => ({
+  default: { info: (...a) => info(...a), warn: (...a) => warn(...a) },
+}));
+
+const { authAuditService } = await import('../../services/authAuditService.js');
+
+describe('authAuditService (A5)', () => {
+  beforeEach(() => {
+    info.mockReset();
+    warn.mockReset();
+  });
+
+  it('logs success-type events at info with a structured event name', () => {
+    expect(authAuditService.logLoginSuccess({ userId: 'u1' })).toBe(true);
+    expect(info).toHaveBeenCalledWith(
+      'auth.audit',
+      expect.objectContaining({ service: 'auth-audit', event: 'login_success', userId: 'u1' })
+    );
+  });
+
+  it('logs security-sensitive events at warn', () => {
+    authAuditService.logTokenTheftDetected({ userId: 'u1' });
+    authAuditService.logLoginFailed({ email: 'x@y.z' });
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(info).not.toHaveBeenCalled();
+  });
+
+  it('exposes the full event interface used across the app', () => {
+    for (const m of [
+      'logRegisterSuccess',
+      'logLoginSuccess',
+      'logLoginFailed',
+      'logLoginBlockedLocked',
+      'logAccountLocked',
+      'logLogout',
+      'logPasswordResetRequest',
+      'logPasswordResetSuccess',
+      'logTokenRefresh',
+      'logTokenTheftDetected',
+      'logEmailVerified',
+    ]) {
+      expect(typeof authAuditService[m]).toBe('function');
+    }
+  });
+
+  it('brute-force detection stubs report not-blocked', async () => {
+    expect(await authAuditService.detectBruteForce()).toEqual({ blocked: false });
+    expect(await authAuditService.checkBruteForce()).toEqual({ blocked: false });
+    expect(await authAuditService.isBlocked()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes auth audit gaps A5 and A3.

### A5 — `authAuditService` (was referenced in tests, never implemented)
New `services/authAuditService.js`: logging-based, side-effect-free structured audit events — `register_success`, `login_success`/`failed`, `login_blocked_locked`, `account_locked`, `logout`, `password_reset_request`/`success`, `token_refresh`, `token_theft_detected`, `email_verified`. Security-sensitive events log at `warn`.

Wired into `AuthService` at each event and into `optionalAuth`'s invalid-token path. **All call sites are optional-chained** (`?.()`) and best-effort, so auditing never blocks or breaks an auth flow — and stays safe across the varying per-test mocks.

Brute-force hooks (`detectBruteForce`/`checkBruteForce`/`isBlocked`) are conservative stubs that report "not blocked"; the active controls remain `authRateLimiter` (per IP) and the `User` account lockout (per account).

### A3 — token-theft email alert
On suspected refresh-token reuse, `AuthService` now sends the user a best-effort out-of-band security alert email (via the generic `sendEmail`) — in addition to the existing "clear all sessions" + log. Fully defensive; never blocks the 401.

## Verification
- New unit tests: `authAuditService.test.js` (event levels, full interface, detection stubs)
- Backend unit: 56 files / 1242 passed · integration: 6 files / 132 passed (auth flows exercise the wiring)
- Lint clean; pre-push hook (backend + frontend) passed