### PR TITLE
feat(auth): jwt secret rotation with previous-key verification (A4)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -120,6 +120,11 @@ JWT_ACCESS_SECRET=
 JWT_REFRESH_SECRET=
 JWT_ACCESS_EXPIRY=15m
 JWT_REFRESH_EXPIRY=7d
+# Secret rotation (optional): when rotating a signing secret, move the old one
+# here so in-flight tokens keep verifying until they expire, then remove it.
+# Comma-separated to overlap multiple keys. Used for VERIFICATION only.
+JWT_ACCESS_SECRET_PREVIOUS=
+JWT_REFRESH_SECRET_PREVIOUS=
 
 # =============================================================================
 # Encryption Key (for storing access tokens)

--- a/backend/tests/unittest/jwtRotation.test.js
+++ b/backend/tests/unittest/jwtRotation.test.js
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for JWT secret rotation (audit gap A4).
+ *
+ * The jwt module reads its secrets from env at import time, so each test sets
+ * the rotation env vars and re-imports via vi.resetModules().
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import jwt from 'jsonwebtoken';
+
+vi.mock('../../config/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const OLD = 'old-access-secret-key-that-is-at-least-32-chars';
+const NEW = 'new-access-secret-key-that-is-at-least-32-chars';
+const REFRESH = 'rotation-refresh-secret-at-least-32-characters!!';
+const OPTS = { issuer: 'rag-backend', audience: 'rag-api' };
+
+const signWith = (secret, opts = {}) =>
+  jwt.sign({ userId: 'u1', email: 'e@x.io', role: 'user' }, secret, {
+    ...OPTS,
+    expiresIn: '15m',
+    ...opts,
+  });
+
+async function loadJwt({ primary = NEW, previous } = {}) {
+  vi.resetModules();
+  process.env.JWT_ACCESS_SECRET = primary;
+  process.env.JWT_REFRESH_SECRET = REFRESH;
+  if (previous === undefined) delete process.env.JWT_ACCESS_SECRET_PREVIOUS;
+  else process.env.JWT_ACCESS_SECRET_PREVIOUS = previous;
+  return import('../../utils/security/jwt.js');
+}
+
+describe('JWT secret rotation (A4)', () => {
+  beforeEach(() => {
+    delete process.env.JWT_ACCESS_SECRET_PREVIOUS;
+  });
+
+  it('verifies tokens signed with the primary secret', async () => {
+    const { generateAccessToken, verifyAccessToken } = await loadJwt();
+    const token = generateAccessToken({ userId: 'u1', email: 'e', role: 'user' });
+    expect(verifyAccessToken(token).userId).toBe('u1');
+  });
+
+  it('still verifies tokens signed with a PREVIOUS secret during rotation', async () => {
+    const tokenFromOldKey = signWith(OLD);
+    const { verifyAccessToken } = await loadJwt({ primary: NEW, previous: OLD });
+    expect(verifyAccessToken(tokenFromOldKey).userId).toBe('u1');
+  });
+
+  it('signs new tokens with the primary key, not a previous one', async () => {
+    const { generateAccessToken } = await loadJwt({ primary: NEW, previous: OLD });
+    const token = generateAccessToken({ userId: 'u1', email: 'e', role: 'user' });
+    expect(() => jwt.verify(token, NEW, OPTS)).not.toThrow();
+    expect(() => jwt.verify(token, OLD, OPTS)).toThrow();
+  });
+
+  it('rejects tokens signed with an unknown secret', async () => {
+    const rogue = signWith('totally-unknown-secret-at-least-32-characters!!');
+    const { verifyAccessToken } = await loadJwt({ primary: NEW, previous: OLD });
+    expect(() => verifyAccessToken(rogue)).toThrow('Invalid access token');
+  });
+
+  it('reports expiry (not invalid) for an expired token signed with a previous key', async () => {
+    const expired = signWith(OLD, { expiresIn: -10 });
+    const { verifyAccessToken } = await loadJwt({ primary: NEW, previous: OLD });
+    expect(() => verifyAccessToken(expired)).toThrow('Access token expired');
+  });
+
+  it('supports a comma-separated list of previous secrets', async () => {
+    const tokenFromOldKey = signWith(OLD);
+    const { verifyAccessToken } = await loadJwt({
+      primary: NEW,
+      previous: `another-old-secret-at-least-32-characters!!, ${OLD}`,
+    });
+    expect(verifyAccessToken(tokenFromOldKey).userId).toBe('u1');
+  });
+});

--- a/backend/utils/security/jwt.js
+++ b/backend/utils/security/jwt.js
@@ -3,7 +3,17 @@ import { randomUUID } from 'crypto';
 import logger from '../../config/logger.js';
 import { sha256, timingSafeEqual } from './crypto.js';
 
-// Validate required JWT secrets at startup
+// ---------------------------------------------------------------------------
+// JWT secret rotation (audit gap A4)
+//
+// Tokens are always SIGNED with the current/primary secret. Verification tries
+// the primary first, then any PREVIOUS secrets, so a key can be rotated with
+// zero downtime:
+//   1. Deploy: JWT_ACCESS_SECRET=<new>, JWT_ACCESS_SECRET_PREVIOUS=<old>
+//      → new tokens use <new>; in-flight tokens still verify against <old>.
+//   2. After the max token TTL (refresh = 7d) elapses, drop the PREVIOUS var.
+// JWT_*_SECRET_PREVIOUS accepts a comma-separated list to overlap several keys.
+// ---------------------------------------------------------------------------
 const ACCESS_TOKEN_SECRET = process.env.JWT_ACCESS_SECRET;
 const REFRESH_TOKEN_SECRET = process.env.JWT_REFRESH_SECRET;
 
@@ -15,14 +25,58 @@ if (!ACCESS_TOKEN_SECRET || !REFRESH_TOKEN_SECRET) {
   throw error;
 }
 
+// Parse a comma-separated list of previous secrets (for verification only).
+const parsePreviousSecrets = (raw) =>
+  (raw || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+// Verification key sets: primary first, then previous keys (newest-rotated first).
+const ACCESS_VERIFY_SECRETS = [
+  ACCESS_TOKEN_SECRET,
+  ...parsePreviousSecrets(process.env.JWT_ACCESS_SECRET_PREVIOUS),
+];
+const REFRESH_VERIFY_SECRETS = [
+  REFRESH_TOKEN_SECRET,
+  ...parsePreviousSecrets(process.env.JWT_REFRESH_SECRET_PREVIOUS),
+];
+
 // Validate minimum secret length (256 bits = 32 characters minimum recommended)
 const MIN_SECRET_LENGTH = 32;
 if (
-  ACCESS_TOKEN_SECRET.length < MIN_SECRET_LENGTH ||
-  REFRESH_TOKEN_SECRET.length < MIN_SECRET_LENGTH
+  [...ACCESS_VERIFY_SECRETS, ...REFRESH_VERIFY_SECRETS].some((s) => s.length < MIN_SECRET_LENGTH)
 ) {
   logger.warn(`JWT secrets should be at least ${MIN_SECRET_LENGTH} characters for security`);
 }
+
+/**
+ * Verify a token against an ordered list of secrets (rotation-aware).
+ * Retries the next secret only on a signature mismatch; expiry / malformed /
+ * audience / issuer errors are terminal and not key-related.
+ * @param {string} token
+ * @param {string[]} secrets - primary first, then previous
+ * @param {{ expired: string, invalid: string }} messages - error text to surface
+ * @returns {Object} decoded payload
+ */
+const verifyWithRotation = (token, secrets, messages) => {
+  let lastError;
+  for (const secret of secrets) {
+    try {
+      return jwt.verify(token, secret, { issuer: 'rag-backend', audience: 'rag-api' });
+    } catch (error) {
+      if (error.name === 'JsonWebTokenError' && error.message === 'invalid signature') {
+        lastError = error; // signed with a different key — try the next one
+        continue;
+      }
+      lastError = error;
+      break; // expired / malformed / wrong issuer|audience — no other key helps
+    }
+  }
+  if (lastError?.name === 'TokenExpiredError') throw new Error(messages.expired);
+  if (lastError?.name === 'JsonWebTokenError') throw new Error(messages.invalid);
+  throw lastError;
+};
 
 // Token expiration times
 const ACCESS_TOKEN_EXPIRY = process.env.JWT_ACCESS_EXPIRY || '15m'; // 15 minutes
@@ -106,19 +160,10 @@ export const generateRefreshToken = (payload) => {
  * @returns {Object} Decoded token payload
  */
 export const verifyAccessToken = (token) => {
-  try {
-    return jwt.verify(token, ACCESS_TOKEN_SECRET, {
-      issuer: 'rag-backend',
-      audience: 'rag-api',
-    });
-  } catch (error) {
-    if (error.name === 'TokenExpiredError') {
-      throw new Error('Access token expired');
-    } else if (error.name === 'JsonWebTokenError') {
-      throw new Error('Invalid access token');
-    }
-    throw error;
-  }
+  return verifyWithRotation(token, ACCESS_VERIFY_SECRETS, {
+    expired: 'Access token expired',
+    invalid: 'Invalid access token',
+  });
 };
 
 /**
@@ -127,19 +172,10 @@ export const verifyAccessToken = (token) => {
  * @returns {Object} Decoded token payload
  */
 export const verifyRefreshToken = (token) => {
-  try {
-    return jwt.verify(token, REFRESH_TOKEN_SECRET, {
-      issuer: 'rag-backend',
-      audience: 'rag-api',
-    });
-  } catch (error) {
-    if (error.name === 'TokenExpiredError') {
-      throw new Error('Refresh token expired');
-    } else if (error.name === 'JsonWebTokenError') {
-      throw new Error('Invalid refresh token');
-    }
-    throw error;
-  }
+  return verifyWithRotation(token, REFRESH_VERIFY_SECRETS, {
+    expired: 'Refresh token expired',
+    invalid: 'Invalid refresh token',
+  });
 };
 
 /**


### PR DESCRIPTION
## Summary

Closes audit gap A4 — there was no JWT secret rotation strategy (single static secret per token type).

## How it works
Tokens are still **signed** with the primary secret (`JWT_ACCESS_SECRET` / `JWT_REFRESH_SECRET`). **Verification** now tries the primary first, then any previous secrets from `JWT_ACCESS_SECRET_PREVIOUS` / `JWT_REFRESH_SECRET_PREVIOUS` (comma-separated).

Zero-downtime rotation:
1. Deploy `JWT_ACCESS_SECRET=<new>`, `JWT_ACCESS_SECRET_PREVIOUS=<old>` → new tokens use `<new>`; in-flight tokens still verify against `<old>`.
2. After the max TTL (refresh = 7d) elapses, drop the `_PREVIOUS` var.

Verification retries the next key **only** on a signature mismatch; expiry, malformed, and issuer/audience errors stay terminal and keep their existing messages (`Access token expired`, `Invalid access token`, …) so behavior is unchanged when no previous secret is configured.

## Verification
- New `jwtRotation.test.js`: primary verify, previous-key verify during rotation, signs-with-primary, unknown-key rejection, expiry-on-previous-key, comma-separated list
- Existing `jwt.test.js` unchanged and passing (34/34)
- Full backend unit suite: 58 files / 1254 passed; lint clean; pre-push hook passed
- Docs: new optional env vars added to `.env.example`