### PR TITLE
feat(auth): TOTP MFA — enrollment, login challenge, recovery codes (A1)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -1,6 +1,10 @@
 import { authService } from '../services/AuthService.js';
 import { catchAsync, sendSuccess } from '../utils/index.js';
-import { setAuthCookies, clearAuthCookies, getRefreshToken } from '../utils/security/cookieConfig.js';
+import {
+  setAuthCookies,
+  clearAuthCookies,
+  getRefreshToken,
+} from '../utils/security/cookieConfig.js';
 import logger from '../config/logger.js';
 
 const getDeviceInfo = (req) => {
@@ -44,9 +48,39 @@ export const register = catchAsync(async (req, res) => {
 export const login = catchAsync(async (req, res) => {
   const { email, password } = req.body;
 
-  const { user, tokens } = await authService.login({
+  const result = await authService.login({
     email,
     password,
+    deviceInfo: getDeviceInfo(req),
+  });
+
+  // A1: MFA-enabled accounts get a challenge instead of a session.
+  if (result.mfaRequired) {
+    sendSuccess(res, 200, 'MFA verification required', {
+      mfaRequired: true,
+      mfaToken: result.mfaToken,
+    });
+    return;
+  }
+
+  setAuthCookies(res, result.tokens);
+
+  sendSuccess(res, 200, 'Login successful', {
+    user: result.user,
+    ...result.tokens,
+  });
+});
+
+/**
+ * POST /api/v1/auth/mfa/verify
+ * Step 2 of MFA login: exchange the challenge token + code for a session.
+ */
+export const verifyMfa = catchAsync(async (req, res) => {
+  const { mfaToken, code } = req.body;
+
+  const { user, tokens } = await authService.verifyMfa({
+    mfaToken,
+    code,
     deviceInfo: getDeviceInfo(req),
   });
 
@@ -56,6 +90,38 @@ export const login = catchAsync(async (req, res) => {
     user,
     ...tokens,
   });
+});
+
+/**
+ * POST /api/v1/auth/mfa/setup
+ * Step 1 of enrollment: returns the TOTP secret + otpauth URI (not yet enabled).
+ */
+export const setupMfa = catchAsync(async (req, res) => {
+  const result = await authService.setupMfa(req.user.userId);
+  sendSuccess(res, 200, 'Scan the QR code in your authenticator app, then confirm', result);
+});
+
+/**
+ * POST /api/v1/auth/mfa/enable
+ * Step 2 of enrollment: verify the first code, enable MFA, return recovery codes.
+ */
+export const enableMfa = catchAsync(async (req, res) => {
+  const { recoveryCodes } = await authService.enableMfa(req.user.userId, req.body.token);
+  sendSuccess(res, 200, 'MFA enabled. Save your recovery codes now — they are shown once.', {
+    recoveryCodes,
+  });
+});
+
+/**
+ * POST /api/v1/auth/mfa/disable
+ * Disable MFA (requires current password + a valid code).
+ */
+export const disableMfa = catchAsync(async (req, res) => {
+  await authService.disableMfa(req.user.userId, {
+    password: req.body.password,
+    code: req.body.code,
+  });
+  sendSuccess(res, 200, 'MFA disabled');
 });
 
 /**
@@ -105,7 +171,11 @@ export const logout = async (req, res, next) => {
   }
 
   clearAuthCookies(res);
-  sendSuccess(res, 200, req.query.all === 'true' ? 'Logged out from all devices' : 'Logout successful');
+  sendSuccess(
+    res,
+    200,
+    req.query.all === 'true' ? 'Logged out from all devices' : 'Logout successful'
+  );
   if (typeof next === 'function') return;
 };
 

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -172,6 +172,23 @@ const userSchema = new mongoose.Schema(
       monitoringSetup: { type: Boolean, default: false },
       dismissed: { type: Boolean, default: false },
     },
+    // MFA (TOTP) — audit gap A1. The secret is encrypted at rest (see the
+    // encryption plugin below) and never returned by default (select: false).
+    // Recovery codes are stored as one-way hashes and consumed on use.
+    mfaEnabled: {
+      type: Boolean,
+      default: false,
+    },
+    mfaSecret: {
+      type: String,
+      select: false,
+      default: null,
+    },
+    mfaRecoveryCodes: {
+      type: [String],
+      select: false,
+      default: undefined,
+    },
   },
   {
     timestamps: true,
@@ -422,6 +439,6 @@ userSchema.methods.verifyEmail = async function (rawToken) {
 // Apply field-level encryption to PII
 // Note: email is NOT encrypted because it's used for authentication lookups and unique index
 // Password is already hashed with bcrypt, so no additional encryption needed
-userSchema.plugin(createEncryptionPlugin(['name']));
+userSchema.plugin(createEncryptionPlugin(['name', 'mfaSecret']));
 
 export const User = mongoose.model('User', userSchema);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -39,6 +39,7 @@
         "mongoose": "^9.1.2",
         "multer": "^2.0.2",
         "natural": "^8.1.0",
+        "otplib": "^12.0.1",
         "pdf-parse": "^1.1.1",
         "pino": "^10.3.0",
         "pino-http": "^11.0.0",
@@ -3617,6 +3618,56 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/plugin-crypto": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
+      "integrity": "sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/plugin-thirty-two": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz",
+      "integrity": "sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "thirty-two": "^1.0.2"
+      }
+    },
+    "node_modules/@otplib/preset-default": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
+      "integrity": "sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/preset-v11": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-v11/-/preset-v11-12.0.1.tgz",
+      "integrity": "sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -10103,6 +10154,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/otplib": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
+      "integrity": "sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/preset-default": "^12.0.1",
+        "@otplib/preset-v11": "^12.0.1"
+      }
+    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -12000,6 +12062,14 @@
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
+      "engines": {
+        "node": ">=0.2.6"
       }
     },
     "node_modules/thread-stream": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -64,6 +64,7 @@
     "mongoose": "^9.1.2",
     "multer": "^2.0.2",
     "natural": "^8.1.0",
+    "otplib": "^12.0.1",
     "pdf-parse": "^1.1.1",
     "pino": "^10.3.0",
     "pino-http": "^11.0.0",

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -12,6 +12,10 @@ import {
   resendVerification,
   changePassword,
   updateOnboarding,
+  verifyMfa,
+  setupMfa,
+  enableMfa,
+  disableMfa,
 } from '../controllers/authController.js';
 import { validateBody } from '../middleware/validate.js';
 import { authenticate } from '../middleware/auth.js';
@@ -33,6 +37,9 @@ import {
   updateProfileSchema,
   changePasswordSchema,
   updateOnboardingSchema,
+  mfaVerifySchema,
+  mfaEnableSchema,
+  mfaDisableSchema,
 } from '../validators/schemas.js';
 
 const router = express.Router();
@@ -50,6 +57,13 @@ router.post('/register', registerLimiter, validateBody(registerSchema), register
  * @access  Public
  */
 router.post('/login', loginLimiter, validateBody(loginSchema), login);
+
+/**
+ * @route   POST /api/v1/auth/mfa/verify
+ * @desc    Step 2 of MFA login — exchange the challenge token + code for a session
+ * @access  Public (requires a valid short-lived MFA challenge token)
+ */
+router.post('/mfa/verify', loginLimiter, validateBody(mfaVerifySchema), verifyMfa);
 
 /**
  * @route   POST /api/v1/auth/refresh
@@ -124,6 +138,15 @@ router.post('/resend-verification', resendVerifyLimiter, authenticate, resendVer
  * @access  Private
  */
 router.post('/change-password', authenticate, validateBody(changePasswordSchema), changePassword);
+
+/**
+ * @route   POST /api/v1/auth/mfa/setup | /mfa/enable | /mfa/disable
+ * @desc    TOTP enrollment (setup → enable) and teardown (disable)
+ * @access  Private
+ */
+router.post('/mfa/setup', authenticate, setupMfa);
+router.post('/mfa/enable', authenticate, validateBody(mfaEnableSchema), enableMfa);
+router.post('/mfa/disable', authenticate, validateBody(mfaDisableSchema), disableMfa);
 
 /**
  * @route   PATCH /api/v1/auth/onboarding

--- a/backend/services/AuthService.js
+++ b/backend/services/AuthService.js
@@ -8,11 +8,14 @@ import {
   generateAccessToken,
   generateRefreshToken,
   hashRefreshToken,
+  generateMfaToken,
+  verifyMfaToken,
 } from '../utils/security/jwt.js';
 import { sha256 } from '../utils/security/crypto.js';
 import { safeDecrypt } from '../utils/security/fieldEncryption.js';
 import { emailService } from './emailService.js';
 import { authAuditService } from './authAuditService.js';
+import { mfaService } from './mfaService.js';
 import logger from '../config/logger.js';
 
 const RESEND_VERIFICATION_COOLDOWN_MS = 60 * 1000;
@@ -38,6 +41,7 @@ class AuthService {
     this.memberRepo = deps.memberRepo || organizationMemberRepository;
     this.emailService = deps.emailService || emailService;
     this.authAudit = deps.authAudit || authAuditService;
+    this.mfa = deps.mfa || mfaService;
     this.logger = deps.logger || logger;
   }
 
@@ -205,6 +209,22 @@ class AuthService {
 
     await user.resetLoginAttempts();
 
+    // A1: if MFA is enabled, password is only step 1. Return a short-lived
+    // challenge instead of tokens; step 2 is POST /auth/mfa/verify.
+    if (user.mfaEnabled) {
+      this.logger.info('Login passed password, MFA required', { userId: user._id });
+      this.authAudit.logLoginSuccess?.({ userId: user._id, email: user.email, mfa: 'pending' });
+      return { mfaRequired: true, mfaToken: generateMfaToken({ userId: user._id }) };
+    }
+
+    return this._issueSession(user, deviceInfo);
+  }
+
+  /**
+   * Issue tokens + a refresh session for an already-authenticated user, and
+   * return the standard login payload. Shared by password login and MFA verify.
+   */
+  async _issueSession(user, deviceInfo) {
     const tokens = generateTokenPair({
       userId: user._id,
       email: user.email,
@@ -226,6 +246,127 @@ class AuthService {
       user: toUserPayload(user, { organization }),
       tokens,
     };
+  }
+
+  // ---------------------------------------------------------------------------
+  // MFA (TOTP) — audit gap A1
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Step 1 of enrollment: generate (but do not yet enable) a TOTP secret.
+   * Returns the secret + otpauth URI for the authenticator app / QR.
+   */
+  async setupMfa(userId) {
+    const user = await this.userRepo.findById(userId);
+    if (!user) throw new AppError('User not found', 404);
+    if (user.mfaEnabled) throw new AppError('MFA is already enabled', 409);
+
+    const secret = this.mfa.generateSecret();
+    user.mfaSecret = secret;
+    await user.save();
+
+    return {
+      secret,
+      otpauthUrl: this.mfa.keyUri(user.email, secret),
+    };
+  }
+
+  /**
+   * Step 2 of enrollment: verify the first code, enable MFA, and return the
+   * one-time recovery codes (shown to the user exactly once).
+   */
+  async enableMfa(userId, token) {
+    const user = await this.userRepo.findById(userId, { select: '+mfaSecret' });
+    if (!user) throw new AppError('User not found', 404);
+    if (user.mfaEnabled) throw new AppError('MFA is already enabled', 409);
+    if (!user.mfaSecret) throw new AppError('Start MFA setup first', 400);
+
+    if (!this.mfa.verifyTotp(user.mfaSecret, token)) {
+      throw new AppError('Invalid verification code', 400);
+    }
+
+    const { plain, hashed } = this.mfa.generateRecoveryCodes();
+    user.mfaEnabled = true;
+    user.mfaRecoveryCodes = hashed;
+    await user.save();
+
+    this.logger.info('MFA enabled', { userId: user._id });
+    return { recoveryCodes: plain };
+  }
+
+  /**
+   * Step 2 of login: exchange a valid MFA challenge token + TOTP (or recovery)
+   * code for a real session.
+   */
+  async verifyMfa({ mfaToken, code, deviceInfo }) {
+    let decoded;
+    try {
+      decoded = verifyMfaToken(mfaToken);
+    } catch (error) {
+      throw new AppError(error.message || 'Invalid MFA token', 401);
+    }
+
+    const user = await this.userRepo.findById(decoded.userId, {
+      select: '+mfaSecret +mfaRecoveryCodes',
+    });
+    if (!user || !user.mfaEnabled) {
+      throw new AppError('MFA is not enabled for this account', 400);
+    }
+    if (!user.isActive) throw new AppError('Account is inactive', 401);
+
+    if (!this._consumeMfaCode(user, code)) {
+      this.authAudit.logLoginFailed?.({ userId: user._id, reason: 'mfa' });
+      throw new AppError('Invalid verification code', 401);
+    }
+
+    // _consumeMfaCode may have spent a recovery code → persist before issuing.
+    if (user.isModified?.('mfaRecoveryCodes')) await user.save();
+
+    return this._issueSession(user, deviceInfo);
+  }
+
+  /**
+   * Disable MFA. Requires the current password AND a valid TOTP/recovery code
+   * so a hijacked session alone can't turn it off.
+   */
+  async disableMfa(userId, { password, code }) {
+    const user = await this.userRepo.findById(userId, {
+      select: '+password +mfaSecret +mfaRecoveryCodes',
+    });
+    if (!user) throw new AppError('User not found', 404);
+    if (!user.mfaEnabled) throw new AppError('MFA is not enabled', 400);
+
+    if (!(await user.comparePassword(password))) {
+      throw new AppError('Invalid password', 401);
+    }
+    if (!this._consumeMfaCode(user, code)) {
+      throw new AppError('Invalid verification code', 401);
+    }
+
+    user.mfaEnabled = false;
+    user.mfaSecret = null;
+    user.mfaRecoveryCodes = undefined;
+    await user.save();
+
+    this.logger.info('MFA disabled', { userId: user._id });
+    return { disabled: true };
+  }
+
+  /**
+   * Verify a code against the user's TOTP secret, falling back to single-use
+   * recovery codes (which are consumed in place). Returns true on success.
+   */
+  _consumeMfaCode(user, code) {
+    if (this.mfa.verifyTotp(user.mfaSecret, code)) return true;
+
+    const hash = this.mfa.hashRecoveryCode(code || '');
+    const codes = user.mfaRecoveryCodes || [];
+    const idx = codes.indexOf(hash);
+    if (idx === -1) return false;
+
+    codes.splice(idx, 1); // consume
+    user.mfaRecoveryCodes = codes;
+    return true;
   }
 
   /**

--- a/backend/services/mfaService.js
+++ b/backend/services/mfaService.js
@@ -1,0 +1,68 @@
+/**
+ * MFA (TOTP) service — audit gap A1.
+ *
+ * Thin wrapper around otplib's authenticator (RFC 6238 TOTP) plus recovery-code
+ * generation. Keeps all crypto/format choices in one place so AuthService and
+ * tests depend on a small, stable surface.
+ */
+
+import crypto from 'crypto';
+import pkg from 'otplib';
+import { sha256 } from '../utils/security/crypto.js';
+
+const { authenticator } = pkg;
+
+// Allow ±1 step (±30s) of clock drift between server and authenticator app.
+authenticator.options = { window: 1 };
+
+const ISSUER = process.env.MFA_ISSUER || 'Retrieva';
+const RECOVERY_CODE_COUNT = 10;
+
+export const mfaService = {
+  /** Generate a new base32 TOTP secret. */
+  generateSecret() {
+    return authenticator.generateSecret();
+  },
+
+  /**
+   * Build the otpauth:// URI an authenticator app scans (or that the frontend
+   * renders as a QR code).
+   */
+  keyUri(accountName, secret) {
+    return authenticator.keyuri(accountName, ISSUER, secret);
+  },
+
+  /** Verify a 6-digit TOTP code against a secret. */
+  verifyTotp(secret, token) {
+    if (!secret || !token) return false;
+    try {
+      return authenticator.verify({ token: String(token).trim(), secret });
+    } catch {
+      return false;
+    }
+  },
+
+  /**
+   * Generate one-time recovery codes. Returns the plaintext codes (shown to the
+   * user exactly once) and their hashes (persisted on the user).
+   */
+  generateRecoveryCodes(count = RECOVERY_CODE_COUNT) {
+    const plain = [];
+    const hashed = [];
+    for (let i = 0; i < count; i += 1) {
+      // 10 hex chars, grouped as xxxxx-xxxxx for readability.
+      const raw = crypto.randomBytes(5).toString('hex');
+      const code = `${raw.slice(0, 5)}-${raw.slice(5, 10)}`;
+      plain.push(code);
+      hashed.push(this.hashRecoveryCode(code));
+    }
+    return { plain, hashed };
+  },
+
+  /** Hash a recovery code for storage / comparison (normalized, case-insensitive). */
+  hashRecoveryCode(code) {
+    return sha256(String(code).trim().toLowerCase());
+  },
+};
+
+export default mfaService;

--- a/backend/tests/unittest/authServiceMfa.test.js
+++ b/backend/tests/unittest/authServiceMfa.test.js
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../config/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { AuthService } from '../../services/AuthService.js';
+import { generateMfaToken } from '../../utils/security/jwt.js';
+
+function makeUser(over = {}) {
+  return {
+    _id: 'u1',
+    email: 'u@x.io',
+    name: 'User',
+    role: 'user',
+    isActive: true,
+    mfaEnabled: false,
+    mfaSecret: null,
+    mfaRecoveryCodes: undefined,
+    organizationId: null,
+    comparePassword: vi.fn().mockResolvedValue(true),
+    addRefreshToken: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn().mockResolvedValue(undefined),
+    isModified: vi.fn().mockReturnValue(false),
+    ...over,
+  };
+}
+
+function makeSvc() {
+  const userRepo = { findById: vi.fn() };
+  const organizationRepo = { findById: vi.fn().mockResolvedValue(null) };
+  const mfa = {
+    generateSecret: vi.fn().mockReturnValue('SECRET'),
+    keyUri: vi.fn().mockReturnValue('otpauth://totp/Retrieva:u@x.io'),
+    verifyTotp: vi.fn().mockReturnValue(false),
+    generateRecoveryCodes: vi.fn().mockReturnValue({ plain: ['a1b2c-d3e4f'], hashed: ['H1'] }),
+    hashRecoveryCode: vi.fn((c) => `hash:${c}`),
+  };
+  const authAudit = { logLoginSuccess: vi.fn(), logLoginFailed: vi.fn() };
+  const svc = new AuthService({ userRepo, organizationRepo, mfa, authAudit });
+  return { svc, userRepo, organizationRepo, mfa };
+}
+
+describe('AuthService MFA (A1)', () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = makeSvc();
+  });
+
+  describe('setupMfa', () => {
+    it('generates a secret and returns the otpauth URI', async () => {
+      const user = makeUser();
+      ctx.userRepo.findById.mockResolvedValue(user);
+      const res = await ctx.svc.setupMfa('u1');
+      expect(res.secret).toBe('SECRET');
+      expect(res.otpauthUrl).toContain('otpauth://');
+      expect(user.mfaSecret).toBe('SECRET');
+      expect(user.save).toHaveBeenCalled();
+    });
+
+    it('refuses when MFA is already enabled', async () => {
+      ctx.userRepo.findById.mockResolvedValue(makeUser({ mfaEnabled: true }));
+      await expect(ctx.svc.setupMfa('u1')).rejects.toThrow('already enabled');
+    });
+  });
+
+  describe('enableMfa', () => {
+    it('rejects an invalid first code', async () => {
+      ctx.userRepo.findById.mockResolvedValue(makeUser({ mfaSecret: 'SECRET' }));
+      ctx.mfa.verifyTotp.mockReturnValue(false);
+      await expect(ctx.svc.enableMfa('u1', '000000')).rejects.toThrow('Invalid verification code');
+    });
+
+    it('enables MFA and returns recovery codes on a valid code', async () => {
+      const user = makeUser({ mfaSecret: 'SECRET' });
+      ctx.userRepo.findById.mockResolvedValue(user);
+      ctx.mfa.verifyTotp.mockReturnValue(true);
+      const res = await ctx.svc.enableMfa('u1', '123456');
+      expect(res.recoveryCodes).toEqual(['a1b2c-d3e4f']);
+      expect(user.mfaEnabled).toBe(true);
+      expect(user.mfaRecoveryCodes).toEqual(['H1']);
+      expect(user.save).toHaveBeenCalled();
+    });
+
+    it('requires setup before enable', async () => {
+      ctx.userRepo.findById.mockResolvedValue(makeUser({ mfaSecret: null }));
+      await expect(ctx.svc.enableMfa('u1', '123456')).rejects.toThrow('Start MFA setup first');
+    });
+  });
+
+  describe('verifyMfa', () => {
+    it('issues a session for a valid challenge token + TOTP code', async () => {
+      const user = makeUser({ mfaEnabled: true, mfaSecret: 'SECRET' });
+      ctx.userRepo.findById.mockResolvedValue(user);
+      ctx.mfa.verifyTotp.mockReturnValue(true);
+      const mfaToken = generateMfaToken({ userId: 'u1' });
+
+      const res = await ctx.svc.verifyMfa({ mfaToken, code: '123456', deviceInfo: {} });
+      expect(res.user.id).toBe('u1');
+      expect(res.tokens.accessToken).toBeTruthy();
+      expect(user.addRefreshToken).toHaveBeenCalled();
+    });
+
+    it('rejects an invalid code and audits the failure', async () => {
+      const user = makeUser({ mfaEnabled: true, mfaSecret: 'SECRET' });
+      ctx.userRepo.findById.mockResolvedValue(user);
+      ctx.mfa.verifyTotp.mockReturnValue(false);
+      const mfaToken = generateMfaToken({ userId: 'u1' });
+
+      await expect(ctx.svc.verifyMfa({ mfaToken, code: '000000', deviceInfo: {} })).rejects.toThrow(
+        'Invalid verification code'
+      );
+    });
+
+    it('accepts and consumes a recovery code when TOTP fails', async () => {
+      const user = makeUser({
+        mfaEnabled: true,
+        mfaSecret: 'SECRET',
+        mfaRecoveryCodes: ['hash:rec-ode', 'hash:other'],
+        isModified: vi.fn().mockReturnValue(true),
+      });
+      ctx.userRepo.findById.mockResolvedValue(user);
+      ctx.mfa.verifyTotp.mockReturnValue(false); // TOTP fails → recovery path
+      const mfaToken = generateMfaToken({ userId: 'u1' });
+
+      const res = await ctx.svc.verifyMfa({ mfaToken, code: 'rec-ode', deviceInfo: {} });
+      expect(res.tokens.accessToken).toBeTruthy();
+      expect(user.mfaRecoveryCodes).toEqual(['hash:other']); // consumed
+      expect(user.save).toHaveBeenCalled();
+    });
+
+    it('rejects a tampered/invalid MFA token', async () => {
+      await expect(
+        ctx.svc.verifyMfa({ mfaToken: 'not-a-token', code: '123456', deviceInfo: {} })
+      ).rejects.toThrow('Invalid MFA token');
+    });
+  });
+
+  describe('disableMfa', () => {
+    it('requires a correct password', async () => {
+      const user = makeUser({ mfaEnabled: true, mfaSecret: 'SECRET' });
+      user.comparePassword.mockResolvedValue(false);
+      ctx.userRepo.findById.mockResolvedValue(user);
+      await expect(ctx.svc.disableMfa('u1', { password: 'wrong', code: '123456' })).rejects.toThrow(
+        'Invalid password'
+      );
+    });
+
+    it('clears MFA state on valid password + code', async () => {
+      const user = makeUser({ mfaEnabled: true, mfaSecret: 'SECRET' });
+      ctx.userRepo.findById.mockResolvedValue(user);
+      ctx.mfa.verifyTotp.mockReturnValue(true);
+      await ctx.svc.disableMfa('u1', { password: 'right', code: '123456' });
+      expect(user.mfaEnabled).toBe(false);
+      expect(user.mfaSecret).toBeNull();
+      expect(user.save).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/tests/unittest/mfaService.test.js
+++ b/backend/tests/unittest/mfaService.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import pkg from 'otplib';
+import { mfaService } from '../../services/mfaService.js';
+
+const { authenticator } = pkg;
+
+describe('mfaService (A1)', () => {
+  it('generates a usable TOTP secret and verifies its current code', () => {
+    const secret = mfaService.generateSecret();
+    expect(typeof secret).toBe('string');
+    const code = authenticator.generate(secret);
+    expect(mfaService.verifyTotp(secret, code)).toBe(true);
+  });
+
+  it('rejects a wrong / empty code', () => {
+    const secret = mfaService.generateSecret();
+    expect(mfaService.verifyTotp(secret, '000000')).toBe(false);
+    expect(mfaService.verifyTotp(secret, '')).toBe(false);
+    expect(mfaService.verifyTotp(null, '123456')).toBe(false);
+  });
+
+  it('builds an otpauth URI with the issuer and account', () => {
+    const uri = mfaService.keyUri('user@example.com', mfaService.generateSecret());
+    expect(uri.startsWith('otpauth://totp/')).toBe(true);
+    expect(uri).toContain('Retrieva');
+    expect(uri).toContain('user%40example.com'); // url-encoded @
+  });
+
+  it('generates the requested number of recovery codes with matching hashes', () => {
+    const { plain, hashed } = mfaService.generateRecoveryCodes(8);
+    expect(plain).toHaveLength(8);
+    expect(hashed).toHaveLength(8);
+    expect(plain[0]).toMatch(/^[0-9a-f]{5}-[0-9a-f]{5}$/);
+    expect(mfaService.hashRecoveryCode(plain[0])).toBe(hashed[0]);
+  });
+
+  it('hashes recovery codes case-insensitively and trimmed', () => {
+    const h = mfaService.hashRecoveryCode('AB12C-DE34F');
+    expect(mfaService.hashRecoveryCode('  ab12c-de34f  ')).toBe(h);
+  });
+});

--- a/backend/utils/security/jwt.js
+++ b/backend/utils/security/jwt.js
@@ -154,6 +154,45 @@ export const generateTokenPair = (payload) => {
   };
 };
 
+// Short-lived token issued after password auth when MFA is required. It only
+// proves "this user passed step 1"; the distinct audience ('rag-mfa') means it
+// can never be accepted as an access token, and vice versa.
+const MFA_TOKEN_EXPIRY = process.env.JWT_MFA_EXPIRY || '5m';
+
+/**
+ * Generate an MFA challenge token (step-1 → step-2 handoff).
+ * @param {Object} payload - { userId }
+ * @returns {string} JWT
+ */
+export const generateMfaToken = (payload) => {
+  return jwt.sign({ userId: payload.userId, purpose: 'mfa' }, ACCESS_TOKEN_SECRET, {
+    expiresIn: MFA_TOKEN_EXPIRY,
+    issuer: 'rag-backend',
+    audience: 'rag-mfa',
+  });
+};
+
+/**
+ * Verify an MFA challenge token.
+ * @param {string} token
+ * @returns {Object} decoded payload ({ userId, purpose })
+ */
+export const verifyMfaToken = (token) => {
+  try {
+    const decoded = jwt.verify(token, ACCESS_TOKEN_SECRET, {
+      issuer: 'rag-backend',
+      audience: 'rag-mfa',
+    });
+    if (decoded.purpose !== 'mfa') throw new Error('Invalid MFA token');
+    return decoded;
+  } catch (error) {
+    if (error.name === 'TokenExpiredError') {
+      throw new Error('MFA session expired. Please log in again.');
+    }
+    throw new Error('Invalid MFA token');
+  }
+};
+
 /**
  * Decode token without verification (for debugging)
  * @param {string} token - JWT token

--- a/backend/validators/schemas.js
+++ b/backend/validators/schemas.js
@@ -323,6 +323,28 @@ export const changePasswordSchema = z
     path: ['newPassword'],
   });
 
+// MFA (TOTP) schemas — audit gap A1.
+// `code` accepts a 6-digit TOTP or an 11-char recovery code (xxxxx-xxxxx).
+export const mfaEnableSchema = z
+  .object({
+    token: z.string().min(6, 'Code must be 6 digits').max(10),
+  })
+  .strict();
+
+export const mfaVerifySchema = z
+  .object({
+    mfaToken: z.string().min(10, 'MFA token is required').max(1024),
+    code: z.string().min(6, 'Enter your 6-digit code or a recovery code').max(20),
+  })
+  .strict();
+
+export const mfaDisableSchema = z
+  .object({
+    password: z.string().min(1, 'Password is required').max(100),
+    code: z.string().min(6, 'Enter your 6-digit code or a recovery code').max(20),
+  })
+  .strict();
+
 // MongoDB ID validation
 export const mongoIdSchema = z.string().regex(/^[0-9a-fA-F]{24}$/, 'Invalid ID format');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "mongoose": "^9.1.2",
         "multer": "^2.0.2",
         "natural": "^8.1.0",
+        "otplib": "^12.0.1",
         "pdf-parse": "^1.1.1",
         "pino": "^10.3.0",
         "pino-http": "^11.0.0",
@@ -901,6 +902,12 @@
       "os": [
         "darwin"
       ]
+    },
+    "backend/node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
     },
     "backend/node_modules/@qdrant/js-client-rest": {
       "version": "1.16.2",
@@ -2036,6 +2043,17 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "backend/node_modules/otplib": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
+      "integrity": "sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/preset-default": "^12.0.1",
+        "@otplib/preset-v11": "^12.0.1"
       }
     },
     "backend/node_modules/p-finally": {
@@ -6485,6 +6503,74 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0"
       }
+    },
+    "node_modules/@otplib/plugin-crypto": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
+      "integrity": "sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/plugin-crypto/node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/plugin-thirty-two": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz",
+      "integrity": "sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "thirty-two": "^1.0.2"
+      }
+    },
+    "node_modules/@otplib/plugin-thirty-two/node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/preset-default": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
+      "integrity": "sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/preset-default/node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/preset-v11": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-v11/-/preset-v11-12.0.1.tgz",
+      "integrity": "sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/preset-v11/node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
@@ -20294,6 +20380,14 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
+      "engines": {
+        "node": ">=0.2.6"
       }
     },
     "node_modules/thread-stream": {


### PR DESCRIPTION
## Summary

Closes audit gap **A1** (HIGH) — adds TOTP-based multi-factor authentication. **Backend only** (no frontend); the API returns the `otpauth://` URI for the client/app to render as a QR code.

## What's added
- **User model**: `mfaEnabled`, `mfaSecret` (encrypted at rest via the field-encryption plugin, `select:false`), `mfaRecoveryCodes` (one-way hashed, `select:false`).
- **`mfaService`** (otplib v12): secret generation, otpauth URI, TOTP verification (±30s drift), one-time recovery-code generation/hashing.
- **`jwt`**: short-lived MFA challenge token with a **distinct audience (`rag-mfa`)** so it can never be accepted as an access token (or vice versa).
- **`AuthService`**: `login` returns an MFA challenge instead of a session when MFA is enabled; `setupMfa` → `enableMfa` (returns recovery codes once) → `verifyMfa` (TOTP **or** a single-use recovery code) → `disableMfa` (requires password **+** code).
- **Routes**: `POST /auth/mfa/verify` (public, rate-limited like login), `POST /auth/mfa/{setup,enable,disable}` (authenticated), all validated.

## Flow
1. `POST /auth/mfa/setup` → `{ secret, otpauthUrl }`
2. `POST /auth/mfa/enable { token }` → enables MFA, returns recovery codes (shown once)
3. Login with MFA on → `{ mfaRequired: true, mfaToken }` (no session)
4. `POST /auth/mfa/verify { mfaToken, code }` → sets auth cookies / returns tokens

**Non-MFA logins are unchanged.**

## Verification
- New unit tests: `mfaService.test.js` (5) + `authServiceMfa.test.js` (11 — every MFA path incl. recovery-code consumption, invalid token, password gate)
- Full backend unit: 59 files / 1264 passed · integration: 6 files / 132 passed
- Lint clean; pre-push hook (backend + frontend) passed
- New dependency: `otplib@^12` (added to `backend/package.json` + lockfile)

## Follow-ups (not in this PR)
- Frontend enrollment/verify UI
- Optional: HTTP-level integration tests for the `/auth/mfa/*` endpoints
- Optional: `MFA_ISSUER` env (defaults to `Retrieva`)