### PR TITLE
feat(security): activate database-level tenant isolation (B2)

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -21,6 +21,7 @@ import billingRoutes from './routes/billingRoutes.js';
 import { handleStripeWebhook } from './controllers/billingController.js';
 import { requireActivePlan } from './middleware/requireActivePlan.js';
 import { optionalAuth } from './middleware/auth.js';
+import { setTenantContext } from './services/tenantIsolation.js';
 import logger from './config/logger.js';
 import { globalErrorHandler } from './utils/index.js';
 
@@ -243,12 +244,28 @@ app.use('/api/v1/billing', billingRoutes);
 // have no token and pass through to the router's own authenticate.
 // authenticate is idempotent so the router's router.use(authenticate) is a
 // no-op when req.user is already set by optionalAuth.
-app.use('/api/v1', optionalAuth, requireActivePlan, ragRoutes);
-app.use('/api/v1/conversations', optionalAuth, requireActivePlan, conversationRoutes);
+// B2: setTenantContext (after auth) makes the active workspace available to the
+// tenantIsolationPlugin, which then filters workspace-scoped models by it. Only
+// applied to the workspace-scoped routers — NOT /workspaces (which legitimately
+// queries across all of a user's workspaces, e.g. my-workspaces).
+app.use('/api/v1', optionalAuth, requireActivePlan, setTenantContext, ragRoutes);
+app.use(
+  '/api/v1/conversations',
+  optionalAuth,
+  requireActivePlan,
+  setTenantContext,
+  conversationRoutes
+);
 app.use('/api/v1/workspaces', optionalAuth, requireActivePlan, workspaceRoutes);
-app.use('/api/v1/assessments', optionalAuth, requireActivePlan, assessmentRoutes);
+app.use('/api/v1/assessments', optionalAuth, requireActivePlan, setTenantContext, assessmentRoutes);
 app.use('/api/v1/compliance', optionalAuth, requireActivePlan, complianceRoutes);
-app.use('/api/v1/questionnaires', optionalAuth, requireActivePlan, questionnaireRoutes);
+app.use(
+  '/api/v1/questionnaires',
+  optionalAuth,
+  requireActivePlan,
+  setTenantContext,
+  questionnaireRoutes
+);
 
 app.get('/', (req, res) => {
   res.send('Hello from a secure app.js!');

--- a/backend/models/Assessment.js
+++ b/backend/models/Assessment.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import { tenantIsolationPlugin } from '../services/tenantIsolation.js';
 
 // ── Formal risk decision recorded by a compliance officer ──────────────────────
 const riskDecisionSchema = new mongoose.Schema(
@@ -121,5 +122,16 @@ const assessmentSchema = new mongoose.Schema(
 // Compound index for listing assessments per workspace
 assessmentSchema.index({ workspaceId: 1, createdAt: -1 });
 assessmentSchema.index({ createdBy: 1, status: 1 });
+
+// B2: database-level tenant isolation. Auto-filters queries by the active
+// workspace when a tenant context is set (see setTenantContext). Disabled in
+// tests to keep fixtures simple, matching the Conversation model.
+if (process.env.NODE_ENV !== 'test') {
+  assessmentSchema.plugin(tenantIsolationPlugin, {
+    tenantField: 'workspaceId',
+    enforceOnSave: true,
+    auditLog: process.env.NODE_ENV !== 'production',
+  });
+}
 
 export const Assessment = mongoose.model('Assessment', assessmentSchema);

--- a/backend/models/VendorQuestionnaire.js
+++ b/backend/models/VendorQuestionnaire.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import { tenantIsolationPlugin } from '../services/tenantIsolation.js';
 
 const questionResponseSchema = new mongoose.Schema(
   {
@@ -57,6 +58,16 @@ const vendorQuestionnaireSchema = new mongoose.Schema(
 
 vendorQuestionnaireSchema.index({ workspaceId: 1, createdAt: -1 });
 vendorQuestionnaireSchema.index({ createdBy: 1, status: 1 });
+
+// B2: database-level tenant isolation (see Assessment / Conversation). Auto-filters
+// by the active workspace when a tenant context is set. Disabled in tests.
+if (process.env.NODE_ENV !== 'test') {
+  vendorQuestionnaireSchema.plugin(tenantIsolationPlugin, {
+    tenantField: 'workspaceId',
+    enforceOnSave: true,
+    auditLog: process.env.NODE_ENV !== 'production',
+  });
+}
 
 export const VendorQuestionnaire = mongoose.model('VendorQuestionnaire', vendorQuestionnaireSchema);
 

--- a/backend/services/tenantIsolation.js
+++ b/backend/services/tenantIsolation.js
@@ -64,8 +64,13 @@ export function withTenantContext(context, fn) {
  * app.use(setTenantContext);
  */
 export function setTenantContext(req, res, next) {
+  // X-Workspace-Id is how the frontend signals the active workspace; fall back
+  // to a loaded workspace doc or an explicit body/query workspaceId.
   const workspaceId =
-    req.workspace?._id?.toString() || req.body?.workspaceId || req.query?.workspaceId;
+    req.workspace?._id?.toString() ||
+    req.headers?.['x-workspace-id'] ||
+    req.body?.workspaceId ||
+    req.query?.workspaceId;
   const userId = req.user?.userId || req.user?.id;
 
   if (workspaceId || userId) {
@@ -126,11 +131,11 @@ export function tenantIsolationPlugin(schema, options = {}) {
           });
         }
       } else if (this.getOptions()?.requireTenant !== false) {
-        // Log warning for queries without tenant context (unless explicitly allowed)
-        logger.warn('Query executed without tenant context', {
+        // Queries outside a request (workers, startup, scripts) legitimately run
+        // without tenant context — log at debug to avoid flooding worker logs.
+        logger.debug('Query executed without tenant context', {
           operation: hook,
           collection: this.model?.collection?.name,
-          query: JSON.stringify(this.getQuery()),
         });
       }
     });

--- a/backend/tests/unittest/tenantContext.test.js
+++ b/backend/tests/unittest/tenantContext.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../config/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+  setTenantContext,
+  getCurrentTenantId,
+  getCurrentUserId,
+} from '../../services/tenantIsolation.js';
+
+describe('setTenantContext (B2)', () => {
+  it('reads the active workspace from the X-Workspace-Id header', () => {
+    const req = { headers: { 'x-workspace-id': 'ws-1' }, user: { userId: 'u1' } };
+    let captured;
+    setTenantContext(req, {}, () => {
+      captured = { ws: getCurrentTenantId(), user: getCurrentUserId() };
+    });
+    expect(captured).toEqual({ ws: 'ws-1', user: 'u1' });
+  });
+
+  it('falls back to body, then query workspaceId', () => {
+    let fromBody;
+    setTenantContext({ headers: {}, body: { workspaceId: 'ws-b' } }, {}, () => {
+      fromBody = getCurrentTenantId();
+    });
+    expect(fromBody).toBe('ws-b');
+
+    let fromQuery;
+    setTenantContext({ headers: {}, query: { workspaceId: 'ws-q' } }, {}, () => {
+      fromQuery = getCurrentTenantId();
+    });
+    expect(fromQuery).toBe('ws-q');
+  });
+
+  it('prefers a loaded req.workspace over the header', () => {
+    const req = {
+      workspace: { _id: { toString: () => 'ws-loaded' } },
+      headers: { 'x-workspace-id': 'ws-h' },
+    };
+    let ws;
+    setTenantContext(req, {}, () => {
+      ws = getCurrentTenantId();
+    });
+    expect(ws).toBe('ws-loaded');
+  });
+
+  it('still calls next() when there is no workspace or user', () => {
+    const next = vi.fn();
+    setTenantContext({ headers: {} }, {}, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes no tenant id outside of a request context', () => {
+    expect(getCurrentTenantId()).toBeNull();
+  });
+});


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until a docker-compose end-to-end smoke test passes

Per `CLAUDE.md`, tenant-isolation changes must be validated against local infra (`docker compose up`), not unit tests alone. This PR is unit/integration-green but **has not been validated against a real DB**, and it changes single-resource read behavior. Hold until the smoke test below passes.

## Summary

Closes audit gap **B2**. The `tenantIsolationPlugin` existed but was **dormant** — `setTenantContext` was wired nowhere, so `getCurrentTenantId()` was always `null` and only `Conversation` imported the plugin (CLAUDE.md's claim that this layer was active was doc drift).

This activates **request-path** isolation:
- `setTenantContext` now also reads the **`X-Workspace-Id`** header (the frontend's active workspace) and is wired after auth on the workspace-scoped routers: **rag, conversations, assessments, questionnaires** — **not** `/workspaces` (which legitimately queries across all of a user's workspaces).
- Plugin attached to **`Assessment`** and **`VendorQuestionnaire`** (matching `Conversation`); disabled in tests.
- The plugin's "no tenant context" log dropped to **debug** so background workers (no request context) don't flood logs.

## ⚠️ Behavior change to validate
Single-resource reads (`findById`) now get the active workspace injected. A user opening a resource in a **different** authorized workspace than their active `X-Workspace-Id` will get a **404** (must switch workspace). This matches a standard "active workspace" model but is a behavior change — **the smoke test must confirm normal in-workspace flows still work**.

## Smoke test before merge (`docker compose up -d`)
1. Log in, set `X-Workspace-Id` to workspace A; create/list/read assessments, questionnaires, conversations, and run a RAG query → all succeed.
2. Watch `docker logs -f rag-backend` for "Tenant isolation applied to query" on those reads.
3. Confirm cross-workspace access behaves as intended (resource in B with header A → 404).
4. Confirm the assessment/questionnaire **workers** still process jobs (they run without context; plugin no-ops + debug log).

## Follow-ups
- Wrap worker job processing in `withTenantContext({ workspaceId })` for worker-side isolation (currently request-path only).
- Update `CLAUDE.md` to reflect that the layer is now active.

## Test status
- Unit: 1253 passed · Full `vitest run` (unit+integration combined, as pre-push runs): **64 files / 1385 passed**.
- ⚠️ Observed **one transient failure** of `rag.integration.test.js > POST /rag > should reject without workspace access` during a pre-push run; it passes deterministically in isolation, full-file, and on full-suite re-run (MongoMemoryServer timing flake under combined load). Please confirm during validation.