### PR TITLE
feat(security): run worker jobs inside the tenant context (B2 follow-up)

### DIFF
--- a/backend/workers/assessmentWorker.js
+++ b/backend/workers/assessmentWorker.js
@@ -10,6 +10,7 @@ import { Worker } from 'bullmq';
 import { redisConnection } from '../config/redis.js';
 import { assessmentRepository } from '../repositories/AssessmentRepository.js';
 import { ingestFile, assessmentCollectionName } from '../services/fileIngestionService.js';
+import { withTenantContext } from '../services/tenantIsolation.js';
 import logger from '../config/logger.js';
 import { connectDB } from '../config/database.js';
 
@@ -140,18 +141,33 @@ async function processGapAnalysis(job) {
 // Worker
 // ---------------------------------------------------------------------------
 
+// B2 follow-up: run each job inside its assessment's tenant context so all
+// DB work is workspace-scoped (matching request-path isolation). The bootstrap
+// lookup runs outside any context (unfiltered) purely to resolve the workspace.
+async function runInAssessmentTenantContext(job, fn) {
+  const { assessmentId, userId } = job.data;
+  const doc = assessmentId
+    ? await assessmentRepository.findById(assessmentId, { select: 'workspaceId', lean: true })
+    : null;
+  const workspaceId = doc?.workspaceId?.toString();
+  if (!workspaceId) return fn();
+  return withTenantContext({ workspaceId, userId }, fn);
+}
+
 const worker = new Worker(
   'assessmentJobs',
-  async (job) => {
-    switch (job.name) {
-      case 'fileIndex':
-        return processFileIndex(job);
-      case 'gapAnalysis':
-        return processGapAnalysis(job);
-      default:
-        logger.warn('Unknown assessment job type', { jobName: job.name, jobId: job.id });
-    }
-  },
+  async (job) =>
+    runInAssessmentTenantContext(job, () => {
+      switch (job.name) {
+        case 'fileIndex':
+          return processFileIndex(job);
+        case 'gapAnalysis':
+          return processGapAnalysis(job);
+        default:
+          logger.warn('Unknown assessment job type', { jobName: job.name, jobId: job.id });
+          return undefined;
+      }
+    }),
   {
     connection: redisConnection,
     concurrency: CONCURRENCY,

--- a/backend/workers/questionnaireWorker.js
+++ b/backend/workers/questionnaireWorker.js
@@ -9,6 +9,7 @@ import { Worker } from 'bullmq';
 import { redisConnection } from '../config/redis.js';
 import { vendorQuestionnaireRepository } from '../repositories/VendorQuestionnaireRepository.js';
 import { runScoring } from '../services/questionnaireScorer.js';
+import { withTenantContext } from '../services/tenantIsolation.js';
 import logger from '../config/logger.js';
 import { connectDB } from '../config/database.js';
 
@@ -40,16 +41,34 @@ async function processScoreQuestionnaire(job) {
   return { questionnaireId, scored: true };
 }
 
+// B2 follow-up: run each job inside its questionnaire's tenant context so all
+// DB work is workspace-scoped. The bootstrap lookup runs outside any context
+// (unfiltered) purely to resolve the workspace.
+async function runInQuestionnaireTenantContext(job, fn) {
+  const { questionnaireId } = job.data;
+  const doc = questionnaireId
+    ? await vendorQuestionnaireRepository.findById(questionnaireId, {
+        select: 'workspaceId',
+        lean: true,
+      })
+    : null;
+  const workspaceId = doc?.workspaceId?.toString();
+  if (!workspaceId) return fn();
+  return withTenantContext({ workspaceId }, fn);
+}
+
 const worker = new Worker(
   'questionnaireJobs',
-  async (job) => {
-    switch (job.name) {
-      case 'scoreQuestionnaire':
-        return processScoreQuestionnaire(job);
-      default:
-        logger.warn('Unknown questionnaire job type', { jobName: job.name, jobId: job.id });
-    }
-  },
+  async (job) =>
+    runInQuestionnaireTenantContext(job, () => {
+      switch (job.name) {
+        case 'scoreQuestionnaire':
+          return processScoreQuestionnaire(job);
+        default:
+          logger.warn('Unknown questionnaire job type', { jobName: job.name, jobId: job.id });
+          return undefined;
+      }
+    }),
   {
     connection: redisConnection,
     concurrency: CONCURRENCY,


### PR DESCRIPTION
## Summary

Follow-up to #274 (tenant isolation activation). #274 activated **request-path** isolation; this extends it to the **workers**.

Wraps assessment + questionnaire BullMQ job processing in `withTenantContext` so worker-side DB queries are workspace-scoped (just like requests). Each job resolves its workspace from the assessment/questionnaire via a **bootstrap lookup that runs outside any context** (so it's unfiltered and can always find the record), then executes the handler inside that tenant context.

- `assessmentWorker`: `runInAssessmentTenantContext` wraps `fileIndex` + `gapAnalysis`.
- `questionnaireWorker`: `runInQuestionnaireTenantContext` wraps `scoreQuestionnaire`.

Safe by construction: a job only ever touches its own workspace's records, so scoping queries to that workspace can't hide anything the job legitimately needs.

## Companion doc change (local only)
`CLAUDE.md` was updated to state the tenant-isolation DB layer is now active (it was documented as active while dormant) and describe what `setTenantContext` scopes. **Not in this PR** — `CLAUDE.md` is gitignored in this repo, so that edit is local/per-developer only.

## Verification
- Lint clean; full backend unit suite: 61 files / 1275 tests passed.
- No dedicated worker tests exist; the change is isolated (workers aren't imported by the API) and the wrap is conservative (job → its own workspace).