### PR TITLE
feat(auth): MFA frontend — login challenge + enrollment (A1)

### DIFF
--- a/backend/services/AuthService.js
+++ b/backend/services/AuthService.js
@@ -27,6 +27,7 @@ function toUserPayload(user, overrides = {}) {
     name: safeDecrypt(user.name),
     role: user.role,
     isEmailVerified: user.isEmailVerified,
+    mfaEnabled: !!user.mfaEnabled,
     organizationId: user.organizationId ? user.organizationId.toString() : null,
     onboardingCompleted: user.onboardingCompleted,
     onboardingChecklist: user.onboardingChecklist,

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useForm } from 'react-hook-form';
@@ -27,6 +27,11 @@ export default function LoginPage() {
   const setUser = useAuthStore((state) => state.setUser);
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // MFA challenge state: when set, the user passed password auth but must enter
+  // a TOTP/recovery code to finish (step 2).
+  const [mfaToken, setMfaToken] = useState<string | null>(null);
+  const [mfaCode, setMfaCode] = useState('');
+  const [verifyingMfa, setVerifyingMfa] = useState(false);
 
   const form = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
@@ -38,25 +43,62 @@ export default function LoginPage() {
 
   const { isSubmitting } = form.formState;
 
+  const completeLogin = (user: Parameters<typeof setUser>[0]) => {
+    setUser(user);
+    router.push('/chat');
+  };
+
   const onSubmit = async (data: LoginFormData) => {
     setError(null);
     try {
       const response = await authApi.login({ email: data.email, password: data.password });
-      if (response.status === 'success' && response.data) {
-        setUser(response.data.user);
+      const result = response.data;
+      if (response.status === 'success' && result) {
+        // MFA-enabled accounts get a challenge instead of a session.
+        if (result.mfaRequired && result.mfaToken) {
+          setMfaToken(result.mfaToken);
+          return;
+        }
+        completeLogin(result.user);
       }
-      router.push('/chat');
     } catch (err) {
       setError(getErrorMessage(err));
     }
   };
 
+  const onVerifyMfa = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!mfaToken) return;
+    setError(null);
+    setVerifyingMfa(true);
+    try {
+      const response = await authApi.verifyMfa(mfaToken, mfaCode.trim());
+      if (response.status === 'success' && response.data) {
+        completeLogin(response.data.user);
+      }
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setVerifyingMfa(false);
+    }
+  };
+
+  const cancelMfa = () => {
+    setMfaToken(null);
+    setMfaCode('');
+    setError(null);
+  };
+
   return (
     <div className="space-y-6">
       <div className="space-y-2 text-center">
-        <h2 className="text-2xl font-semibold tracking-tight">Welcome back</h2>
+        <h2 className="text-2xl font-semibold tracking-tight">
+          {mfaToken ? 'Two-factor authentication' : 'Welcome back'}
+        </h2>
         <p className="text-sm text-muted-foreground">
-          Enter your credentials to access your account
+          {mfaToken
+            ? 'Enter the 6-digit code from your authenticator app, or a recovery code'
+            : 'Enter your credentials to access your account'}
         </p>
       </div>
 
@@ -66,7 +108,43 @@ export default function LoginPage() {
         </div>
       )}
 
-      <Form {...form}>
+      {mfaToken ? (
+        <form onSubmit={onVerifyMfa} className="space-y-4">
+          <Input
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            autoFocus
+            placeholder="6-digit code or recovery code"
+            value={mfaCode}
+            onChange={(e) => setMfaCode(e.target.value)}
+            disabled={verifyingMfa}
+          />
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={verifyingMfa || mfaCode.trim().length < 6}
+          >
+            {verifyingMfa ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Verifying...
+              </>
+            ) : (
+              'Verify'
+            )}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            className="w-full"
+            onClick={cancelMfa}
+            disabled={verifyingMfa}
+          >
+            Use a different account
+          </Button>
+        </form>
+      ) : (
+        <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
           <FormField
             control={form.control}
@@ -147,14 +225,17 @@ export default function LoginPage() {
             )}
           </Button>
         </form>
-      </Form>
+        </Form>
+      )}
 
-      <div className="text-center text-sm">
-        <span className="text-muted-foreground">Don&apos;t have an account? </span>
-        <Link href="/register" className="text-primary hover:underline font-medium">
-          Sign up
-        </Link>
-      </div>
+      {!mfaToken && (
+        <div className="text-center text-sm">
+          <span className="text-muted-foreground">Don&apos;t have an account? </span>
+          <Link href="/register" className="text-primary hover:underline font-medium">
+            Sign up
+          </Link>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/(dashboard)/settings/security/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/security/page.tsx
@@ -29,6 +29,7 @@ import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { authApi } from '@/lib/api';
 import { useAuthStore } from '@/lib/stores/auth-store';
+import { MfaSection } from '@/features/settings/components/mfa-section';
 
 const changePasswordSchema = z
   .object({
@@ -211,6 +212,11 @@ export default function SecuritySettingsPage() {
           </Form>
         </CardContent>
       </Card>
+
+      {/* Two-Factor Authentication */}
+      <div className="mt-6">
+        <MfaSection />
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/settings/components/mfa-section.tsx
+++ b/frontend/src/features/settings/components/mfa-section.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { Loader2, ShieldCheck, ShieldOff, Copy } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
+import { authApi, getErrorMessage } from '@/lib/api';
+import { useAuthStore } from '@/lib/stores/auth-store';
+import type { MfaSetupResponse } from '@/types';
+
+/**
+ * Two-factor authentication (TOTP) enrollment + teardown.
+ *
+ * Flow: Set up → scan/enter the secret in an authenticator app → confirm a code
+ * → MFA enabled, recovery codes shown once. Disable requires password + a code.
+ */
+export function MfaSection() {
+  const user = useAuthStore((state) => state.user);
+  const setUser = useAuthStore((state) => state.setUser);
+  const enabled = !!user?.mfaEnabled;
+
+  const [setup, setSetup] = useState<MfaSetupResponse | null>(null);
+  const [code, setCode] = useState('');
+  const [recoveryCodes, setRecoveryCodes] = useState<string[] | null>(null);
+  const [disablePassword, setDisablePassword] = useState('');
+  const [disableCode, setDisableCode] = useState('');
+
+  const setupMutation = useMutation({
+    mutationFn: () => authApi.setupMfa(),
+    onSuccess: (res) => {
+      if (res.data) setSetup(res.data);
+      setRecoveryCodes(null);
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const enableMutation = useMutation({
+    mutationFn: () => authApi.enableMfa(code.trim()),
+    onSuccess: (res) => {
+      setRecoveryCodes(res.data?.recoveryCodes ?? []);
+      setSetup(null);
+      setCode('');
+      if (user) setUser({ ...user, mfaEnabled: true });
+      toast.success('Two-factor authentication enabled');
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const disableMutation = useMutation({
+    mutationFn: () => authApi.disableMfa(disablePassword, disableCode.trim()),
+    onSuccess: () => {
+      if (user) setUser({ ...user, mfaEnabled: false });
+      setDisablePassword('');
+      setDisableCode('');
+      toast.success('Two-factor authentication disabled');
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const copyRecoveryCodes = () => {
+    if (recoveryCodes) {
+      navigator.clipboard?.writeText(recoveryCodes.join('\n'));
+      toast.success('Recovery codes copied');
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          {enabled ? (
+            <ShieldCheck className="h-5 w-5 text-green-600" />
+          ) : (
+            <ShieldOff className="h-5 w-5 text-muted-foreground" />
+          )}
+          Two-Factor Authentication
+        </CardTitle>
+        <CardDescription>
+          {enabled
+            ? 'Your account is protected with an authenticator app.'
+            : 'Add a second step at sign-in using an authenticator app (TOTP).'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* One-time recovery codes shown right after enabling */}
+        {recoveryCodes && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 p-4 space-y-3 dark:bg-amber-950/30">
+            <p className="text-sm font-medium">
+              Save these recovery codes now — they are shown only once. Each can be used once
+              if you lose your device.
+            </p>
+            <div className="grid grid-cols-2 gap-2 font-mono text-sm">
+              {recoveryCodes.map((rc) => (
+                <span key={rc}>{rc}</span>
+              ))}
+            </div>
+            <Button type="button" variant="outline" size="sm" onClick={copyRecoveryCodes}>
+              <Copy className="mr-2 h-4 w-4" />
+              Copy codes
+            </Button>
+          </div>
+        )}
+
+        {/* Disabled → enrollment */}
+        {!enabled && !setup && (
+          <Button onClick={() => setupMutation.mutate()} disabled={setupMutation.isPending}>
+            {setupMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Set up two-factor authentication
+          </Button>
+        )}
+
+        {!enabled && setup && (
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <p className="text-sm font-medium">1. Add this account to your authenticator app</p>
+              <p className="text-xs text-muted-foreground">
+                Scan the otpauth URL as a QR code, or enter the secret manually:
+              </p>
+              <code className="block break-all rounded bg-muted px-2 py-1 text-xs">
+                {setup.secret}
+              </code>
+              <code className="block break-all rounded bg-muted px-2 py-1 text-xs">
+                {setup.otpauthUrl}
+              </code>
+            </div>
+            <Separator />
+            <div className="space-y-2">
+              <p className="text-sm font-medium">2. Enter the 6-digit code to confirm</p>
+              <Input
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                placeholder="123456"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                disabled={enableMutation.isPending}
+              />
+              <div className="flex gap-2">
+                <Button
+                  onClick={() => enableMutation.mutate()}
+                  disabled={enableMutation.isPending || code.trim().length < 6}
+                >
+                  {enableMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  Enable
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => {
+                    setSetup(null);
+                    setCode('');
+                  }}
+                  disabled={enableMutation.isPending}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Enabled → disable form */}
+        {enabled && (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              To disable, confirm your password and a current code.
+            </p>
+            <Input
+              type="password"
+              autoComplete="current-password"
+              placeholder="Current password"
+              value={disablePassword}
+              onChange={(e) => setDisablePassword(e.target.value)}
+              disabled={disableMutation.isPending}
+            />
+            <Input
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              placeholder="6-digit code or recovery code"
+              value={disableCode}
+              onChange={(e) => setDisableCode(e.target.value)}
+              disabled={disableMutation.isPending}
+            />
+            <Button
+              variant="destructive"
+              onClick={() => disableMutation.mutate()}
+              disabled={
+                disableMutation.isPending ||
+                disablePassword.length < 1 ||
+                disableCode.trim().length < 6
+              }
+            >
+              {disableMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Disable two-factor authentication
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/shared/api/auth.ts
+++ b/frontend/src/shared/api/auth.ts
@@ -8,17 +8,62 @@ import type {
   ForgotPasswordData,
   ResetPasswordData,
   ChangePasswordData,
+  MfaSetupResponse,
+  MfaEnableResponse,
 } from '@/types';
 
 export const authApi = {
   /**
-   * Login with email and password
+   * Login with email and password.
+   * When the account has MFA enabled, the response carries
+   * `{ mfaRequired: true, mfaToken }` instead of a session — call `verifyMfa`.
    */
   login: async (credentials: LoginCredentials) => {
     const response = await apiClient.post<ApiResponse<AuthResponse>>(
       '/auth/login',
       credentials
     );
+    return response.data;
+  },
+
+  /**
+   * Step 2 of MFA login: exchange the challenge token + a TOTP or recovery code
+   * for a session.
+   */
+  verifyMfa: async (mfaToken: string, code: string) => {
+    const response = await apiClient.post<ApiResponse<AuthResponse>>('/auth/mfa/verify', {
+      mfaToken,
+      code,
+    });
+    return response.data;
+  },
+
+  /**
+   * Start MFA enrollment — returns the TOTP secret + otpauth URI (not yet enabled).
+   */
+  setupMfa: async () => {
+    const response = await apiClient.post<ApiResponse<MfaSetupResponse>>('/auth/mfa/setup');
+    return response.data;
+  },
+
+  /**
+   * Finish MFA enrollment — verify the first code, enable MFA, return recovery codes.
+   */
+  enableMfa: async (token: string) => {
+    const response = await apiClient.post<ApiResponse<MfaEnableResponse>>('/auth/mfa/enable', {
+      token,
+    });
+    return response.data;
+  },
+
+  /**
+   * Disable MFA — requires the current password and a valid TOTP/recovery code.
+   */
+  disableMfa: async (password: string, code: string) => {
+    const response = await apiClient.post<ApiResponse>('/auth/mfa/disable', {
+      password,
+      code,
+    });
     return response.data;
   },
 

--- a/frontend/src/tests/auth-api.test.ts
+++ b/frontend/src/tests/auth-api.test.ts
@@ -260,4 +260,55 @@ describe('authApi', () => {
       expect(result.status).toBe('success');
     });
   });
+
+  // -------------------------------------------------------------------------
+  // MFA (TOTP)
+  // -------------------------------------------------------------------------
+  describe('MFA', () => {
+    it('login() passes through an MFA challenge response', async () => {
+      mockPost.mockResolvedValue({
+        data: { status: 'success', data: { mfaRequired: true, mfaToken: 'mfa-tok' } },
+      });
+      const result = await authApi.login({ email: 'a@b.io', password: 'x' });
+      expect(result.data.mfaRequired).toBe(true);
+      expect(result.data.mfaToken).toBe('mfa-tok');
+    });
+
+    it('verifyMfa() posts the challenge token + code', async () => {
+      mockPost.mockResolvedValue({ data: { status: 'success', data: mockAuthResponse } });
+      const result = await authApi.verifyMfa('mfa-tok', '123456');
+      expect(mockPost).toHaveBeenCalledWith('/auth/mfa/verify', {
+        mfaToken: 'mfa-tok',
+        code: '123456',
+      });
+      expect(result.data.user.email).toBe('alice@example.com');
+    });
+
+    it('setupMfa() posts to /auth/mfa/setup', async () => {
+      mockPost.mockResolvedValue({
+        data: { status: 'success', data: { secret: 'S', otpauthUrl: 'otpauth://x' } },
+      });
+      const result = await authApi.setupMfa();
+      expect(mockPost).toHaveBeenCalledWith('/auth/mfa/setup');
+      expect(result.data.otpauthUrl).toBe('otpauth://x');
+    });
+
+    it('enableMfa() posts the token and returns recovery codes', async () => {
+      mockPost.mockResolvedValue({
+        data: { status: 'success', data: { recoveryCodes: ['a-b', 'c-d'] } },
+      });
+      const result = await authApi.enableMfa('123456');
+      expect(mockPost).toHaveBeenCalledWith('/auth/mfa/enable', { token: '123456' });
+      expect(result.data.recoveryCodes).toHaveLength(2);
+    });
+
+    it('disableMfa() posts password + code', async () => {
+      mockPost.mockResolvedValue({ data: { status: 'success' } });
+      await authApi.disableMfa('pw', '123456');
+      expect(mockPost).toHaveBeenCalledWith('/auth/mfa/disable', {
+        password: 'pw',
+        code: '123456',
+      });
+    });
+  });
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -47,6 +47,7 @@ export interface User {
   name: string;
   role: GlobalRole;
   isEmailVerified?: boolean;
+  mfaEnabled?: boolean;
   createdAt?: string;
   lastLogin?: string;
   organizationId?: string | null;
@@ -65,6 +66,20 @@ export interface AuthResponse {
   accessToken: string;
   refreshToken: string;
   needsOrganization?: boolean;
+  // Present instead of user/tokens when the account has MFA enabled: the client
+  // must call verifyMfa with this short-lived token + a code to finish login.
+  mfaRequired?: boolean;
+  mfaToken?: string;
+}
+
+// MFA (TOTP) enrollment + verification
+export interface MfaSetupResponse {
+  secret: string;
+  otpauthUrl: string;
+}
+
+export interface MfaEnableResponse {
+  recoveryCodes: string[];
 }
 
 // Workspace Types


### PR DESCRIPTION
## Summary

Completes A1 by making the TOTP MFA backend usable end-to-end from the UI (closes the "frontend not done" gap on #273).

### Login challenge (the critical fix)
`login` now returns `{ mfaRequired, mfaToken }` for MFA-enabled accounts. The login page handles this with a **second step**: enter a 6-digit TOTP **or** a recovery code → `verifyMfa` → session. Without this, an MFA-enabled user could not log in.

### Enrollment (settings → security)
New `MfaSection` (`features/settings/components/`):
- **Set up** → `setupMfa` shows the secret + `otpauth://` URI (scan as QR or enter manually)
- **Confirm** a code → `enableMfa` → **recovery codes shown once** (with copy)
- **Disable** → password + code → `disableMfa`

### Plumbing
- `authApi`: `verifyMfa`, `setupMfa`, `enableMfa`, `disableMfa`.
- Types: `AuthResponse.mfaRequired/mfaToken`, `User.mfaEnabled`, `MfaSetupResponse`, `MfaEnableResponse`.
- Backend (1 line): expose `mfaEnabled` in the user payload so the UI reflects current state.

## Verification
- `next build` (typecheck) ✓ compiled successfully; ESLint clean (frontend + backend).
- Frontend tests: 21 files / 511 passed (incl. 5 new MFA `authApi` tests).
- Backend auth integration: 35 passed; full backend `vitest run`: 67 files / 1407 passed.

> Note: the pre-push hook intermittently trips the known flaky `rag.integration POST /rag reject-without-workspace` test (surfaced by B2's `setTenantContext` under combined load); it passes deterministically on re-run. Worth stabilizing separately.