### PR TITLE
ci(actions): bump docker actions to node 24

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,10 +59,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}
           tags: |
@@ -78,7 +78,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,10 +228,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build ${{ matrix.service }} Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           push: false


### PR DESCRIPTION
Completes the Node-24 migration started in #280 (which bumped `checkout`/`setup-node`).

The `docker/*` actions still ran on **Node 20** and were flagged in the latest CD run annotations. GitHub forces Node 24 on **June 2, 2026** and removes Node 20 from runners on **Sept 16, 2026**.

Bumped to the latest majors — all verified to run on `node24` (`runs.using: node24`):

| Action | Before | After |
|--------|--------|-------|
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/build-push-action` | v5 | **v7** |
| `docker/login-action` | v3 | **v4** |
| `docker/metadata-action` | v5 | **v6** |

Applied to both `ci.yml` and `cd.yml`. The inputs we pass (`context`, `push`, `tags`, `labels`, `build-args`, `cache-from/to`, `images`) are unchanged across these majors, so no config migration is needed. CI's `docker-build` job exercises `build-push-action@v7` on this PR.