### PR TITLE
release: bump docker actions to node 24

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,10 +59,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}
           tags: |
@@ -78,7 +78,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,10 +228,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build ${{ matrix.service }} Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           push: false


### PR DESCRIPTION
Promote `dev` → `main` (production auto-deploy).

Ships the Node-24 GitHub Actions migration for the `docker/*` actions (#286):

- `docker/setup-buildx-action` v3 → v4
- `docker/build-push-action` v5 → v7
- `docker/login-action` v3 → v4
- `docker/metadata-action` v5 → v6

All run on `node24`, completing the migration started in #280. Validated on #286's CI — both `docker-build` jobs (which build with `build-push-action@v7`) passed green. No input/config changes. After this merge, prod CD itself runs on the bumped actions, clearing the June 2 2026 Node-20 deprecation deadline.