### PR TITLE
ci(actions): bump codecov-action to v6 (node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           ENCRYPTION_KEY: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -122,7 +122,7 @@ jobs:
         working-directory: ./frontend
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Final piece of the Node-24 actions migration.

After the `docker/*` bump (#286) shipped, the prod CD run still showed **one** Node-20 deprecation annotation — for `actions/github-script@v7.0.1`. That isn't one of our own pins: it's bundled **inside `codecov/codecov-action@v5`** (used by the `Backend Tests` / `Frontend Tests` jobs).

`codecov/codecov-action@v6` bundles `actions/github-script@v8.0.0`, which I verified runs on `node24` — so this clears the last warning.

- `codecov/codecov-action` v5 → **v6** (both occurrences in `ci.yml`)
- Inputs we pass (`token`, `directory`, `flags`, `fail_ci_if_error`) are all still supported in v6 — no config change.

After this, no Node-20 actions remain anywhere in CI/CD.