### PR TITLE
release: bump codecov-action to node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           ENCRYPTION_KEY: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -122,7 +122,7 @@ jobs:
         working-directory: ./frontend
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Promote `dev` → `main` (production auto-deploy).

Ships #288 — `codecov/codecov-action@v5 → v6`. This clears the last Node-20 deprecation warning (`actions/github-script@v7.0.1`, bundled inside codecov-action@v5); v6 bundles `github-script@v8.0.0` (node24). Inputs unchanged.

After this deploy, no Node-20 actions remain anywhere in CI/CD — the June 2 2026 deadline is fully cleared.