### PR TITLE
ci(actions): bump remaining node 20 actions to node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
           NEXT_PUBLIC_APP_NAME: Retrieva
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./docs/build
 
@@ -64,4 +64,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Final cleanup of the Node-24 actions migration — clears the last three Node-20 pins so **every** workflow is Node-24 clean before the June 2 2026 force-migration.

These didn't run on the app deploy (the `upload-artifact` one lives in the e2e job, skipped on push), but they fire on PRs and on docs deploys:

| Action | File | Before | After | Node |
|--------|------|--------|-------|------|
| `actions/upload-artifact` | `ci.yml` (playwright report) | v4 | **v7** | 24 |
| `actions/upload-pages-artifact` | `docs.yml` | v3 | **v5** | 24 (bundles `upload-artifact@v7`) |
| `actions/deploy-pages` | `docs.yml` | v4 | **v5** | 24 |

Verified each latest major runs on `node24`. Inputs are unchanged (`name`/`path`/`retention-days` for upload-artifact; `path` for upload-pages-artifact; deploy-pages takes none). The docs `setup-node` `node-version: '20'` is the *build* runtime, not an action runtime, so it's intentionally untouched.

After this: zero Node-20 actions anywhere in `ci.yml`, `cd.yml`, `docs.yml`, `release.yml`.