### PR TITLE
release: bump remaining node 20 actions to node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
           NEXT_PUBLIC_APP_NAME: Retrieva
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./docs/build
 
@@ -64,4 +64,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Promote `dev` → `main` (production auto-deploy).

Ships #290 — the last three Node-20 action pins:

- `actions/upload-artifact` v4 → v7 (ci.yml)
- `actions/upload-pages-artifact` v3 → v5 (docs.yml)
- `actions/deploy-pages` v4 → v5 (docs.yml)

Validated on #290's CI — Frontend E2E ran (exercising `upload-artifact@v7`) with 0 Node-20 annotations. After this, zero Node-20 actions remain in any workflow.