### PR TITLE
chore(lint): clear no-unused-vars warnings

### DIFF
--- a/backend/config/embeddingProvider.js
+++ b/backend/config/embeddingProvider.js
@@ -11,9 +11,7 @@ import logger from './logger.js';
 // Embeddings use a dedicated env var so they can run against a separate (typically
 // self-hosted) Ollama instance even when the chat LLM points at Ollama Cloud.
 const OLLAMA_BASE_URL =
-  process.env.EMBEDDING_OLLAMA_BASE_URL ||
-  process.env.OLLAMA_BASE_URL ||
-  'http://localhost:11434';
+  process.env.EMBEDDING_OLLAMA_BASE_URL || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
 const OLLAMA_MODEL = process.env.EMBEDDING_MODEL || 'bge-m3:latest';
 const OPENAI_MODEL = process.env.OPENAI_EMBEDDING_MODEL || 'text-embedding-3-small';
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
@@ -22,9 +20,6 @@ const OLLAMA_API_KEY =
 const OLLAMA_AUTH_HEADERS = OLLAMA_API_KEY
   ? { Authorization: `Bearer ${OLLAMA_API_KEY}` }
   : undefined;
-
-// Embedding provider type (openai, ollama)
-const EMBEDDING_PROVIDER = process.env.EMBEDDING_PROVIDER || 'ollama';
 
 // =============================================================================
 // EMBEDDING PREFIX REGISTRY

--- a/backend/services/QuestionnaireService.js
+++ b/backend/services/QuestionnaireService.js
@@ -27,10 +27,7 @@ class QuestionnaireService {
 
     const template = await this.templateRepo.findDefault();
     if (!template) {
-      throw new AppError(
-        'No default questionnaire template found. Please contact support.',
-        500
-      );
+      throw new AppError('No default questionnaire template found. Please contact support.', 500);
     }
 
     const questions = template.questions.map((q) => ({
@@ -119,7 +116,7 @@ class QuestionnaireService {
     });
   }
 
-  async sendQuestionnaire(id, { userId, userName, userEmail }, authorizedWorkspaces) {
+  async sendQuestionnaire(id, { userName, userEmail }, authorizedWorkspaces) {
     const authorizedWorkspaceIds = authorizedWorkspaces.map((w) => w._id.toString());
     const questionnaire = await this.questionnaireRepo.findById(id);
     if (!questionnaire) throw new AppError('Questionnaire not found', 404);
@@ -141,9 +138,8 @@ class QuestionnaireService {
     await questionnaire.save();
 
     const workspaceName =
-      authorizedWorkspaces.find(
-        (w) => w._id.toString() === questionnaire.workspaceId.toString()
-      )?.name || 'Your Assessment Team';
+      authorizedWorkspaces.find((w) => w._id.toString() === questionnaire.workspaceId.toString())
+        ?.name || 'Your Assessment Team';
 
     await this.emailService.sendQuestionnaireInvitation({
       toEmail: questionnaire.vendorEmail,
@@ -173,10 +169,7 @@ class QuestionnaireService {
       return { state: 'complete' };
     }
 
-    if (
-      questionnaire.tokenExpiresAt &&
-      new Date() > new Date(questionnaire.tokenExpiresAt)
-    ) {
+    if (questionnaire.tokenExpiresAt && new Date() > new Date(questionnaire.tokenExpiresAt)) {
       await this.questionnaireRepo.updateById(questionnaire._id, { status: 'expired' });
       return { state: 'expired' };
     }
@@ -201,10 +194,7 @@ class QuestionnaireService {
     }
 
     // Token expired during THIS request — flip status and signal a 410.
-    if (
-      questionnaire.tokenExpiresAt &&
-      new Date() > new Date(questionnaire.tokenExpiresAt)
-    ) {
+    if (questionnaire.tokenExpiresAt && new Date() > new Date(questionnaire.tokenExpiresAt)) {
       questionnaire.status = 'expired';
       await questionnaire.save();
       return { state: 'justExpired' };

--- a/backend/tests/unittest/gapAnalysisAgent.test.js
+++ b/backend/tests/unittest/gapAnalysisAgent.test.js
@@ -120,8 +120,6 @@ describe('runGapAnalysis', () => {
   it('succeeds with ReAct agent for DORA framework', async () => {
     assessmentRepository.findById.mockResolvedValue(makeAssessment());
 
-    // Simulate agent capturing result via tool call
-    let capturedTool;
     createReactAgent.mockReturnValue({
       invoke: vi.fn().mockImplementation(async () => {
         // The tool's fn is captured when buildTools is called.
@@ -133,9 +131,6 @@ describe('runGapAnalysis', () => {
     // We need to intercept the tool() call to simulate gap capture
     const { tool } = await import('@langchain/core/tools');
     tool.mockImplementation((fn, config) => {
-      if (config?.name === 'record_gap_analysis') {
-        capturedTool = { fn, config };
-      }
       return { fn, config };
     });
 

--- a/backend/tests/unittest/questionnaireController.test.js
+++ b/backend/tests/unittest/questionnaireController.test.js
@@ -103,17 +103,6 @@ function makeReq(overrides = {}) {
   };
 }
 
-/**
- * Returns an object that works for BOTH usage patterns found in the controller:
- *   await VendorQuestionnaire.findById(id)          → resolves to doc
- *   await VendorQuestionnaire.findById(id).lean()   → resolves to doc
- */
-function makeQueryResult(doc) {
-  return Object.assign(Promise.resolve(doc), {
-    lean: () => Promise.resolve(doc),
-  });
-}
-
 const MOCK_TEMPLATE = {
   _id: 'tpl-001',
   isDefault: true,

--- a/backend/tests/unittest/ragService.test.js
+++ b/backend/tests/unittest/ragService.test.js
@@ -598,7 +598,7 @@ describe('askWithConversation', () => {
 
 describe('init()', () => {
   it('sets _initialized to true after successful init', async () => {
-    const { svc, mockLLM, mockVectorStore } = makeService();
+    const { svc, mockLLM } = makeService();
     const mockChain = { pipe: vi.fn().mockReturnThis() };
     mockLLM.pipe.mockReturnValue(mockChain);
 
@@ -613,7 +613,7 @@ describe('init()', () => {
   });
 
   it('does not re-initialize if already initialized', async () => {
-    const { svc, mockVectorStore } = makeService();
+    const { svc } = makeService();
     svc._initialized = true;
 
     await svc.init();
@@ -622,7 +622,7 @@ describe('init()', () => {
   });
 
   it('reuses existing _initPromise for concurrent calls', async () => {
-    const { svc, mockLLM, mockVectorStore } = makeService();
+    const { svc, mockLLM } = makeService();
     const mockChain = { pipe: vi.fn().mockReturnThis() };
     mockLLM.pipe.mockReturnValue(mockChain);
 

--- a/backend/tests/unittest/workspaceService.unit.test.js
+++ b/backend/tests/unittest/workspaceService.unit.test.js
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { WorkspaceService, serializeWorkspace } from '../../services/WorkspaceService.js';
-import { AppError } from '../../utils/index.js';
 
 // ---------------------------------------------------------------------------
 // Mock module-level imports so the singleton doesn't crash on load


### PR DESCRIPTION
Clears the 8 `no-unused-vars` ESLint warnings that show up as CI annotations on the Backend Tests job. All are dead/unused bindings — removed rather than `_`-prefixed:

| File | Removed |
|------|---------|
| `config/embeddingProvider.js` | unused `EMBEDDING_PROVIDER` const |
| `services/QuestionnaireService.js` | unused `userId` from `sendQuestionnaire` destructure |
| `tests/unittest/workspaceService.unit.test.js` | unused `AppError` import |
| `tests/unittest/questionnaireController.test.js` | unused `makeQueryResult` helper |
| `tests/unittest/gapAnalysisAgent.test.js` | dead `capturedTool` capture (never read) |
| `tests/unittest/ragService.test.js` | unused `mockVectorStore` in 3 destructures |

No behavior change. `eslint .` clean (0 warnings), full unit suite (1279 tests) green, and the pre-push full suite passed.