### PR TITLE
fix(embeddings): self-host ollama for embeddings

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -71,6 +71,13 @@ GROQ_API_KEY=
 # =============================================================================
 EMBEDDING_PROVIDER=ollama
 OLLAMA_BASE_URL=https://ollama.com
+# Embeddings use a SEPARATE, self-hosted Ollama: Ollama Cloud (ollama.com)
+# serves chat/generate but NOT the embeddings API (it returns "unauthorized").
+# Point this at a local/self-hosted Ollama with bge-m3 pulled; chat keeps using
+# OLLAMA_BASE_URL above. Host dev: http://localhost:11434. Under docker compose
+# the backend service overrides this to http://ollama:11434 (the sidecar).
+# Prod: run Ollama beside the API (sidecar/host) and set this accordingly.
+EMBEDDING_OLLAMA_BASE_URL=http://localhost:11434
 EMBEDDING_MODEL=bge-m3:latest
 
 # bge-m3 context window in tokens (used to compute max chunk size)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,6 @@
 #   docker compose down -v            # Stop and remove volumes
 # =============================================================================
 
-version: '3.8'
-
 services:
   # ===========================================================================
   # Frontend (Next.js)
@@ -81,6 +79,10 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - QDRANT_URL=http://qdrant:6333
+      # Embeddings hit the self-hosted Ollama sidecar — Ollama Cloud does not
+      # authorize the embeddings API. Overrides OLLAMA_BASE_URL from .env so the
+      # chat LLM can stay on Ollama Cloud while embeddings run locally (bge-m3).
+      - EMBEDDING_OLLAMA_BASE_URL=http://ollama:11434
     depends_on:
       mongodb:
         condition: service_healthy
@@ -88,6 +90,10 @@ services:
         condition: service_healthy
       qdrant:
         condition: service_healthy
+      ollama:
+        condition: service_healthy
+      ollama-pull:
+        condition: service_completed_successfully
     volumes:
       - ./backend:/app
       - /app/node_modules
@@ -184,6 +190,49 @@ services:
       - rag-network
     restart: unless-stopped
 
+  # ===========================================================================
+  # Ollama (self-hosted embeddings — bge-m3, 1024-dim)
+  # ===========================================================================
+  # Ollama Cloud serves chat/generate but NOT the embeddings API (it returns
+  # "unauthorized"). RAG embeddings therefore run against this local sidecar,
+  # which keeps the existing 1024-dim Qdrant vectors valid (no re-indexing).
+  ollama:
+    image: ollama/ollama:latest
+    container_name: rag-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - rag-network
+    restart: unless-stopped
+
+  # One-shot: pull the embedding model into the ollama volume, then exit.
+  # Runs on every `up` but is a fast no-op once bge-m3 is cached.
+  ollama-pull:
+    image: ollama/ollama:latest
+    container_name: rag-ollama-pull
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      - OLLAMA_HOST=http://ollama:11434
+    entrypoint: ["/bin/sh", "-c", "ollama pull bge-m3:latest"]
+    networks:
+      - rag-network
+    restart: "no"
+
 # =============================================================================
 # Networks
 # =============================================================================
@@ -198,3 +247,4 @@ volumes:
   mongodb_data:
   redis_data:
   qdrant_data:
+  ollama_data:

--- a/docs/docs/deployment/embeddings.md
+++ b/docs/docs/deployment/embeddings.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 8
+---
+
+# Embeddings (self-hosted Ollama)
+
+RAG embeddings run on a **self-hosted Ollama** with the `bge-m3` model
+(1024-dim). The chat LLM and embeddings use **different** Ollama endpoints.
+
+## Why embeddings can't use Ollama Cloud ⚠️
+
+Ollama Cloud (`https://ollama.com`) serves **chat/generate** but **not** the
+embeddings API — `POST /api/embed` returns `{"error":"unauthorized"}` for every
+model, even with valid keys (verified for both dev and prod keys). So
+`OLLAMA_BASE_URL=https://ollama.com` works for the LLM but **not** for embeddings.
+
+## Configuration
+
+Two independent endpoints:
+
+| Var | Used for | Value |
+| --- | --- | --- |
+| `OLLAMA_BASE_URL` | chat LLM | `https://ollama.com` (Ollama Cloud) |
+| `EMBEDDING_OLLAMA_BASE_URL` | embeddings | a self-hosted Ollama with `bge-m3` |
+
+The code prefers `EMBEDDING_OLLAMA_BASE_URL` over `OLLAMA_BASE_URL`
+(`config/embeddings.js`), so the LLM stays on the cloud while embeddings stay
+local. Keep `EMBEDDING_MODEL=bge-m3:latest` — switching models/providers changes
+the vector dimension and forces a full Qdrant re-index.
+
+## Local dev (docker compose)
+
+`docker compose` runs an `ollama` sidecar plus a one-shot `ollama-pull` that
+fetches `bge-m3` into a named volume. The backend service overrides
+`EMBEDDING_OLLAMA_BASE_URL=http://ollama:11434` (the sidecar's service name).
+
+```bash
+docker compose up -d            # ollama starts, bge-m3 is pulled, backend waits for it
+```
+
+For the backend run **on the host** (`npm run dev:backend`), `.env` uses
+`EMBEDDING_OLLAMA_BASE_URL=http://localhost:11434`.
+
+Verify:
+
+```bash
+curl -s http://localhost:11434/api/embed \
+  -d '{"model":"bge-m3:latest","input":"test"}' | head -c 80
+# -> {"model":"bge-m3:latest","embeddings":[[...]]}   (1024 numbers)
+```
+
+## Production
+
+Run Ollama next to the API (sidecar container or a host process), pull `bge-m3`,
+and set `EMBEDDING_OLLAMA_BASE_URL` in the prod env to point at it
+(e.g. `http://ollama:11434` on the same network, or an internal host:port).
+`OLLAMA_BASE_URL` stays on Ollama Cloud for the chat LLM.
+
+> bge-m3 emits **1024-dim** vectors. The Qdrant collections are built at this
+> dimension — do not change the embedding model without recreating/re-indexing
+> them.


### PR DESCRIPTION
## Problem
RAG embeddings were configured to use **Ollama Cloud** (`OLLAMA_BASE_URL=https://ollama.com`) with `bge-m3`. But Ollama Cloud serves **chat/generate only** — `POST /api/embed` returns `{"error":"unauthorized"}` for every model, on both dev and prod keys (chat works fine). So embeddings (document indexing **and** query embedding) were non-functional in every environment.

## Fix (option 1 — no re-index)
Run embeddings against a **self-hosted Ollama** while the chat LLM stays on Ollama Cloud. The code already prefers `EMBEDDING_OLLAMA_BASE_URL` over `OLLAMA_BASE_URL` (`config/embeddings.js`).

- `docker-compose.yml`: add an `ollama` sidecar + one-shot `ollama-pull` (bge-m3) + `ollama_data` volume; backend overrides `EMBEDDING_OLLAMA_BASE_URL=http://ollama:11434` and waits for the model pull. Also dropped the obsolete `version` key.
- `.env.example`: document `EMBEDDING_OLLAMA_BASE_URL` (host vs docker vs prod).
- `docs/deployment/embeddings.md`: why cloud fails, config, local + prod setup.

bge-m3 stays **1024-dim**, so existing Qdrant collections need no re-index.

## Validation (end-to-end)
Brought up the sidecar, pulled bge-m3, and ran the app's real path:
`embeddings.embedQuery()` → **OK dim=1024** (previously `unauthorized`).

## Prod follow-up
Run Ollama beside the API and set `EMBEDDING_OLLAMA_BASE_URL` in the prod env (see the new doc). `OLLAMA_BASE_URL` stays on Ollama Cloud for chat.