### PR TITLE
fix(security): authorize active workspace to stop cross-workspace RAG exposure

### DIFF
--- a/backend/controllers/conversationController.js
+++ b/backend/controllers/conversationController.js
@@ -133,7 +133,11 @@ export const askQuestion = catchAsync(async (req, res) => {
   const { question, filters } = req.body;
   const userId = getUserId(req);
 
-  const answer = await conversationService.askQuestion(id, userId, { question, filters });
+  const answer = await conversationService.askQuestion(id, userId, {
+    question,
+    filters,
+    authorizedWorkspaceIds: req.authorizedWorkspaces?.map((w) => w.workspaceId) || [],
+  });
 
   // B1: honor the workspace canViewSources permission before returning sources.
   const workspaceId = req.headers?.['x-workspace-id'] || req.body?.workspaceId;

--- a/backend/controllers/ragController.js
+++ b/backend/controllers/ragController.js
@@ -26,6 +26,7 @@ export const askQuestion = catchAsync(async (req, res) => {
       conversationId,
       filters: filters || null,
       userId: req.user?.userId?.toString(),
+      authorizedWorkspaceIds: req.authorizedWorkspaces?.map((w) => w.workspaceId) || [],
       forceIntent: forceIntent || null,
       useIntentAware,
     });
@@ -88,6 +89,7 @@ export const askQuestionStream = catchAsync(async (req, res) => {
       conversationId,
       filters: filters || null,
       userId: req.user?.userId?.toString(),
+      authorizedWorkspaceIds: req.authorizedWorkspaces?.map((w) => w.workspaceId) || [],
       forceIntent: forceIntent || null,
       useIntentAware,
       onEvent: send,

--- a/backend/middleware/workspaceAuth.js
+++ b/backend/middleware/workspaceAuth.js
@@ -70,6 +70,24 @@ export const requireWorkspaceAccess = async (req, res, next) => {
     // Attach authorized workspaces to request
     req.authorizedWorkspaces = activeWorkspaces;
 
+    // SECURITY (tenant isolation): if the client names an active workspace
+    // (X-Workspace-Id / body / query), it MUST be one this user belongs to.
+    // Otherwise a member of workspace A could set X-Workspace-Id: B and have
+    // downstream code (setTenantContext, retrieval) operate on workspace B.
+    const requestedWorkspaceId =
+      req.headers?.['x-workspace-id'] || req.body?.workspaceId || req.query?.workspaceId;
+    if (requestedWorkspaceId) {
+      const isMember = activeWorkspaces.some((w) => w.workspaceId === String(requestedWorkspaceId));
+      if (!isMember) {
+        logger.warn('Active workspace not authorized for user', {
+          service: 'workspace-auth',
+          userId,
+          requestedWorkspaceId: String(requestedWorkspaceId),
+        });
+        return sendError(res, 403, 'You do not have access to this workspace');
+      }
+    }
+
     logger.debug('Workspace access granted', {
       service: 'workspace-auth',
       userId,

--- a/backend/routes/conversationRoutes.js
+++ b/backend/routes/conversationRoutes.js
@@ -9,6 +9,7 @@ import {
   bulkDeleteConversations,
 } from '../controllers/conversationController.js';
 import { authenticate } from '../middleware/auth.js';
+import { requireWorkspaceAccess } from '../middleware/workspaceAuth.js';
 import { validateBody, validateParams, validateQuery } from '../middleware/validate.js';
 import {
   createConversationSchema,
@@ -24,7 +25,13 @@ const router = express.Router();
 // Conversation management — all routes require authentication
 // Conversations are user-scoped (userId), not workspace-scoped
 // Users can only access their own conversations (BOLA protection in controllers)
-router.post('/', authenticate, validateBody(createConversationSchema), createConversation);
+router.post(
+  '/',
+  authenticate,
+  requireWorkspaceAccess,
+  validateBody(createConversationSchema),
+  createConversation
+);
 router.get('/', authenticate, validateQuery(listConversationsQuerySchema), getConversations);
 router.post(
   '/bulk-delete',
@@ -46,6 +53,7 @@ router.delete('/:id', authenticate, validateParams(idParamsSchema), deleteConver
 router.post(
   '/:id/ask',
   authenticate,
+  requireWorkspaceAccess,
   validateParams(idParamsSchema),
   validateBody(askInConversationSchema),
   askQuestion

--- a/backend/services/ConversationService.js
+++ b/backend/services/ConversationService.js
@@ -120,7 +120,7 @@ class ConversationService {
     return { conversation, messages, totalMessages };
   }
 
-  async askQuestion(id, userId, { question, filters }) {
+  async askQuestion(id, userId, { question, filters, authorizedWorkspaceIds = null }) {
     if (!question || question.trim().length === 0) {
       throw new AppError('Question is required', 400);
     }
@@ -144,6 +144,8 @@ class ConversationService {
     return this.ragService.askWithConversation(question, {
       conversationId: id,
       filters: filters || null,
+      userId,
+      authorizedWorkspaceIds,
     });
   }
 

--- a/backend/services/rag.js
+++ b/backend/services/rag.js
@@ -3,6 +3,7 @@ import { ChatPromptTemplate, MessagesPlaceholder } from '@langchain/core/prompts
 import { HumanMessage, AIMessage } from '@langchain/core/messages';
 import { randomUUID } from 'crypto';
 import mongoose from 'mongoose';
+import { AppError } from '../utils/index.js';
 
 // Prompts
 import { ragPrompt } from '../prompts/ragPrompt.js';
@@ -227,6 +228,33 @@ class RAGService {
     const sources = formatSources(sanitizedDocs);
 
     return { context, sources, sanitizedDocs };
+  }
+
+  /**
+   * SECURITY (tenant isolation): authorize the workspace used for retrieval
+   * against the caller's real memberships. Throws 403 if the caller is not a
+   * member of the conversation's workspace (or, for personal/legacy
+   * null/'default' conversations, is not the owner). Called without HTTP
+   * context (workers/internal), it is a no-op — those callers are trusted.
+   */
+  _assertWorkspaceAuthorized(
+    workspaceId,
+    conversationOwnerId,
+    { userId, authorizedWorkspaceIds } = {}
+  ) {
+    if (!userId && !authorizedWorkspaceIds) return;
+    const ws = workspaceId && workspaceId !== 'default' ? String(workspaceId) : null;
+    if (ws) {
+      const allowed = (authorizedWorkspaceIds || []).map(String);
+      if (!allowed.includes(ws)) {
+        throw new AppError('You do not have access to this workspace', 403);
+      }
+      return;
+    }
+    // Personal / legacy conversation (no workspace): must be the owner.
+    if (userId && conversationOwnerId && String(conversationOwnerId) !== String(userId)) {
+      throw new AppError('You do not have access to this conversation', 403);
+    }
   }
 
   async _resolveQdrantWorkspaceId(workspaceId) {
@@ -462,6 +490,10 @@ class RAGService {
       filters = null,
       onEvent = null,
       responseInstruction: callerInstruction = '',
+      // SECURITY (tenant isolation): supplied by the HTTP layer so retrieval can
+      // be authorized against the caller's real workspace memberships.
+      userId = null,
+      authorizedWorkspaceIds = null,
     } = options;
 
     if (!conversationId) {
@@ -481,6 +513,15 @@ class RAGService {
     if (!conversation) throw new Error(`Conversation ${conversationId} not found`);
 
     const workspaceId = conversation.workspaceId || null;
+
+    // SECURITY (tenant isolation): the retrieval workspace IS the conversation's
+    // workspace. Authorize it against the caller's real memberships so a user
+    // cannot read another workspace's documents via a spoofed X-Workspace-Id or
+    // a conversation id they do not own.
+    this._assertWorkspaceAuthorized(workspaceId, conversation.userId, {
+      userId,
+      authorizedWorkspaceIds,
+    });
 
     this.logger.info('Processing RAG question', {
       service: 'rag',

--- a/backend/services/ragExecutor.js
+++ b/backend/services/ragExecutor.js
@@ -26,7 +26,14 @@ export class InputGuardrailError extends AppError {
  * @param {Function} [params.onEvent]      SSE callback: (type, data) => void
  * @returns {Object} RAG result
  */
-export async function executeRAG({ question, conversationId, filters = null, onEvent = null }) {
+export async function executeRAG({
+  question,
+  conversationId,
+  filters = null,
+  onEvent = null,
+  userId = null,
+  authorizedWorkspaceIds = null,
+}) {
   logger.info('Executing RAG query', {
     service: 'rag-executor',
     questionLength: question.length,
@@ -38,6 +45,8 @@ export async function executeRAG({ question, conversationId, filters = null, onE
     conversationId,
     filters,
     onEvent,
+    userId,
+    authorizedWorkspaceIds,
   });
 
   logger.info('RAG query completed', {

--- a/backend/tests/unittest/ragController.test.js
+++ b/backend/tests/unittest/ragController.test.js
@@ -100,6 +100,7 @@ describe('ragController — askQuestion', () => {
       conversationId: 'conv-abc',
       filters: { domain: 'ICT' },
       userId: 'user-123',
+      authorizedWorkspaceIds: [],
       forceIntent: 'compliance',
       useIntentAware: false,
     });

--- a/backend/tests/unittest/ragService.test.js
+++ b/backend/tests/unittest/ragService.test.js
@@ -635,3 +635,80 @@ describe('init()', () => {
     expect(svc._initialized).toBe(true);
   });
 });
+
+// ─── Tenant isolation (cross-workspace document exposure) ──────────────────────
+
+describe('tenant isolation: _assertWorkspaceAuthorized', () => {
+  it('allows when the conversation workspace is in the caller authorized set', () => {
+    const { svc } = makeService();
+    expect(() =>
+      svc._assertWorkspaceAuthorized('ws-A', 'owner', {
+        userId: 'u1',
+        authorizedWorkspaceIds: ['ws-A', 'ws-C'],
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects (403) when the conversation workspace is NOT in the caller set', () => {
+    const { svc } = makeService();
+    let thrown;
+    try {
+      svc._assertWorkspaceAuthorized('ws-B', 'owner', {
+        userId: 'attacker',
+        authorizedWorkspaceIds: ['ws-A'],
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown.statusCode).toBe(403);
+  });
+
+  it('allows a personal (null/default) conversation for its owner', () => {
+    const { svc } = makeService();
+    expect(() =>
+      svc._assertWorkspaceAuthorized(null, 'u1', { userId: 'u1', authorizedWorkspaceIds: [] })
+    ).not.toThrow();
+    expect(() =>
+      svc._assertWorkspaceAuthorized('default', 'u1', { userId: 'u1', authorizedWorkspaceIds: [] })
+    ).not.toThrow();
+  });
+
+  it('rejects a personal conversation for a non-owner', () => {
+    const { svc } = makeService();
+    expect(() =>
+      svc._assertWorkspaceAuthorized(null, 'owner', {
+        userId: 'attacker',
+        authorizedWorkspaceIds: [],
+      })
+    ).toThrow();
+  });
+
+  it('is a no-op for internal/worker callers (no userId or authorizedWorkspaceIds)', () => {
+    const { svc } = makeService();
+    expect(() => svc._assertWorkspaceAuthorized('ws-B', 'owner', {})).not.toThrow();
+  });
+});
+
+describe('tenant isolation: askWithConversation blocks cross-workspace retrieval', () => {
+  it('throws 403 before retrieval when the conversation is in a workspace the caller is not in', async () => {
+    const { svc, mockConversation, mockVectorStore } = makeService();
+    svc._initialized = true; // skip init
+    mockConversation.findById.mockResolvedValue({
+      _id: 'conv-x',
+      workspaceId: 'ws-B',
+      userId: 'victim',
+    });
+
+    await expect(
+      svc.askWithConversation('what are the secret findings?', {
+        conversationId: 'conv-x',
+        userId: 'attacker',
+        authorizedWorkspaceIds: ['ws-A'],
+      })
+    ).rejects.toMatchObject({ statusCode: 403 });
+
+    // No vector search should have happened — isolation rejects before retrieval.
+    expect(mockVectorStore.similaritySearch).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/unittest/workspaceAuth.test.js
+++ b/backend/tests/unittest/workspaceAuth.test.js
@@ -152,6 +152,49 @@ describe('Workspace Auth Middleware', () => {
       expect(mockNext).toHaveBeenCalled();
     });
 
+    it('rejects 403 when X-Workspace-Id is not a workspace the user belongs to', async () => {
+      mockReq.user = { userId: 'user-123' };
+      mockReq.headers = { 'x-workspace-id': 'ws-B' }; // attacker requests another workspace
+
+      WorkspaceMember.find.mockReturnValue({
+        populate: vi.fn().mockResolvedValue([
+          {
+            workspaceId: { _id: { toString: () => 'ws-A' }, name: 'My WS', syncStatus: 'synced' },
+            role: 'member',
+            permissions: { canQuery: true },
+          },
+        ]),
+      });
+
+      await requireWorkspaceAccess(mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(403);
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('access to this workspace') })
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('allows when X-Workspace-Id matches one of the user memberships', async () => {
+      mockReq.user = { userId: 'user-123' };
+      mockReq.headers = { 'x-workspace-id': 'ws-A' };
+
+      WorkspaceMember.find.mockReturnValue({
+        populate: vi.fn().mockResolvedValue([
+          {
+            workspaceId: { _id: { toString: () => 'ws-A' }, name: 'My WS', syncStatus: 'synced' },
+            role: 'member',
+            permissions: { canQuery: true },
+          },
+        ]),
+      });
+
+      await requireWorkspaceAccess(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockRes.status).not.toHaveBeenCalledWith(403);
+    });
+
     it('should filter out null workspace references', async () => {
       mockReq.user = { userId: 'user-123' };
 


### PR DESCRIPTION
## Vulnerability (pre-existing; not from the embeddings change)
RAG retrieval is correctly filtered by `metadata.workspaceId`, and the workspace used is the **conversation's** `workspaceId`. But the **active workspace was attacker-controlled and never validated against membership**:
- `setTenantContext` trusts `X-Workspace-Id` as-is.
- `requireWorkspaceAccess` only checked the user belongs to **≥1** workspace, not that the active one is theirs.
- `createConversation` had **no** `requireWorkspaceAccess` and stored the header `workspaceId` unvalidated.

**Exploit:** a member of workspace **A** sets `X-Workspace-Id: B` (or creates/uses a conversation in B) → `executeRAG` loads the conversation, reads `workspaceId=B`, and returns an answer synthesized from **workspace B's documents**. (B1 strips raw `sources`, but the generated answer still leaks B's content.)

## Fix (defense-in-depth)
1. **`rag.js` `askWithConversation`** — new `_assertWorkspaceAuthorized`: the conversation's `workspaceId` must be in the caller's `authorizedWorkspaceIds` (or, for personal/`null`/`default` convs, the caller must own it). Throws **403 before any vector search**. No-op for internal/worker callers.
2. **`ragExecutor` / `ragController` / `conversationController`** — thread `userId` + `authorizedWorkspaceIds` into **both** RAG entry points (`POST /rag`, `POST /rag/stream`, `POST /conversations/:id/ask`).
3. **`requireWorkspaceAccess`** — rejects (403) an `X-Workspace-Id` the user is not a member of (hardens every route using it).
4. **`conversationRoutes`** — require workspace access on **create** + **ask**.

## Tests
- `_assertWorkspaceAuthorized`: allow same-workspace, **403** cross-workspace, owner-only personal convs, internal no-op.
- `askWithConversation`: **403 before retrieval** for a conversation in a non-member workspace (asserts `similaritySearch` never called).
- `requireWorkspaceAccess`: **403** when `X-Workspace-Id` ∉ memberships; allow when it matches.

Full unit suite green (1285+); `eslint .` 0 errors. The embedding backend is untouched — isolation is enforced at the retrieval/auth layers.

## Follow-up (not in this PR)
Conversation **list/get** still rely on ownership checks; assessment/questionnaire paths already scope to `authorizedWorkspaces`. Worth a later pass to apply `requireWorkspaceAccess` uniformly.