### PR TITLE
release: cross-workspace isolation fix, embeddings, lint

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -71,6 +71,13 @@ GROQ_API_KEY=
 # =============================================================================
 EMBEDDING_PROVIDER=ollama
 OLLAMA_BASE_URL=https://ollama.com
+# Embeddings use a SEPARATE, self-hosted Ollama: Ollama Cloud (ollama.com)
+# serves chat/generate but NOT the embeddings API (it returns "unauthorized").
+# Point this at a local/self-hosted Ollama with bge-m3 pulled; chat keeps using
+# OLLAMA_BASE_URL above. Host dev: http://localhost:11434. Under docker compose
+# the backend service overrides this to http://ollama:11434 (the sidecar).
+# Prod: run Ollama beside the API (sidecar/host) and set this accordingly.
+EMBEDDING_OLLAMA_BASE_URL=http://localhost:11434
 EMBEDDING_MODEL=bge-m3:latest
 
 # bge-m3 context window in tokens (used to compute max chunk size)

--- a/backend/config/embeddingProvider.js
+++ b/backend/config/embeddingProvider.js
@@ -11,9 +11,7 @@ import logger from './logger.js';
 // Embeddings use a dedicated env var so they can run against a separate (typically
 // self-hosted) Ollama instance even when the chat LLM points at Ollama Cloud.
 const OLLAMA_BASE_URL =
-  process.env.EMBEDDING_OLLAMA_BASE_URL ||
-  process.env.OLLAMA_BASE_URL ||
-  'http://localhost:11434';
+  process.env.EMBEDDING_OLLAMA_BASE_URL || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
 const OLLAMA_MODEL = process.env.EMBEDDING_MODEL || 'bge-m3:latest';
 const OPENAI_MODEL = process.env.OPENAI_EMBEDDING_MODEL || 'text-embedding-3-small';
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
@@ -22,9 +20,6 @@ const OLLAMA_API_KEY =
 const OLLAMA_AUTH_HEADERS = OLLAMA_API_KEY
   ? { Authorization: `Bearer ${OLLAMA_API_KEY}` }
   : undefined;
-
-// Embedding provider type (openai, ollama)
-const EMBEDDING_PROVIDER = process.env.EMBEDDING_PROVIDER || 'ollama';
 
 // =============================================================================
 // EMBEDDING PREFIX REGISTRY

--- a/backend/controllers/conversationController.js
+++ b/backend/controllers/conversationController.js
@@ -133,7 +133,11 @@ export const askQuestion = catchAsync(async (req, res) => {
   const { question, filters } = req.body;
   const userId = getUserId(req);
 
-  const answer = await conversationService.askQuestion(id, userId, { question, filters });
+  const answer = await conversationService.askQuestion(id, userId, {
+    question,
+    filters,
+    authorizedWorkspaceIds: req.authorizedWorkspaces?.map((w) => w.workspaceId) || [],
+  });
 
   // B1: honor the workspace canViewSources permission before returning sources.
   const workspaceId = req.headers?.['x-workspace-id'] || req.body?.workspaceId;

--- a/backend/controllers/ragController.js
+++ b/backend/controllers/ragController.js
@@ -26,6 +26,7 @@ export const askQuestion = catchAsync(async (req, res) => {
       conversationId,
       filters: filters || null,
       userId: req.user?.userId?.toString(),
+      authorizedWorkspaceIds: req.authorizedWorkspaces?.map((w) => w.workspaceId) || [],
       forceIntent: forceIntent || null,
       useIntentAware,
     });
@@ -88,6 +89,7 @@ export const askQuestionStream = catchAsync(async (req, res) => {
       conversationId,
       filters: filters || null,
       userId: req.user?.userId?.toString(),
+      authorizedWorkspaceIds: req.authorizedWorkspaces?.map((w) => w.workspaceId) || [],
       forceIntent: forceIntent || null,
       useIntentAware,
       onEvent: send,

--- a/backend/middleware/workspaceAuth.js
+++ b/backend/middleware/workspaceAuth.js
@@ -70,6 +70,24 @@ export const requireWorkspaceAccess = async (req, res, next) => {
     // Attach authorized workspaces to request
     req.authorizedWorkspaces = activeWorkspaces;
 
+    // SECURITY (tenant isolation): if the client names an active workspace
+    // (X-Workspace-Id / body / query), it MUST be one this user belongs to.
+    // Otherwise a member of workspace A could set X-Workspace-Id: B and have
+    // downstream code (setTenantContext, retrieval) operate on workspace B.
+    const requestedWorkspaceId =
+      req.headers?.['x-workspace-id'] || req.body?.workspaceId || req.query?.workspaceId;
+    if (requestedWorkspaceId) {
+      const isMember = activeWorkspaces.some((w) => w.workspaceId === String(requestedWorkspaceId));
+      if (!isMember) {
+        logger.warn('Active workspace not authorized for user', {
+          service: 'workspace-auth',
+          userId,
+          requestedWorkspaceId: String(requestedWorkspaceId),
+        });
+        return sendError(res, 403, 'You do not have access to this workspace');
+      }
+    }
+
     logger.debug('Workspace access granted', {
       service: 'workspace-auth',
       userId,

--- a/backend/routes/conversationRoutes.js
+++ b/backend/routes/conversationRoutes.js
@@ -9,6 +9,7 @@ import {
   bulkDeleteConversations,
 } from '../controllers/conversationController.js';
 import { authenticate } from '../middleware/auth.js';
+import { requireWorkspaceAccess } from '../middleware/workspaceAuth.js';
 import { validateBody, validateParams, validateQuery } from '../middleware/validate.js';
 import {
   createConversationSchema,
@@ -24,7 +25,13 @@ const router = express.Router();
 // Conversation management — all routes require authentication
 // Conversations are user-scoped (userId), not workspace-scoped
 // Users can only access their own conversations (BOLA protection in controllers)
-router.post('/', authenticate, validateBody(createConversationSchema), createConversation);
+router.post(
+  '/',
+  authenticate,
+  requireWorkspaceAccess,
+  validateBody(createConversationSchema),
+  createConversation
+);
 router.get('/', authenticate, validateQuery(listConversationsQuerySchema), getConversations);
 router.post(
   '/bulk-delete',
@@ -46,6 +53,7 @@ router.delete('/:id', authenticate, validateParams(idParamsSchema), deleteConver
 router.post(
   '/:id/ask',
   authenticate,
+  requireWorkspaceAccess,
   validateParams(idParamsSchema),
   validateBody(askInConversationSchema),
   askQuestion

--- a/backend/services/ConversationService.js
+++ b/backend/services/ConversationService.js
@@ -120,7 +120,7 @@ class ConversationService {
     return { conversation, messages, totalMessages };
   }
 
-  async askQuestion(id, userId, { question, filters }) {
+  async askQuestion(id, userId, { question, filters, authorizedWorkspaceIds = null }) {
     if (!question || question.trim().length === 0) {
       throw new AppError('Question is required', 400);
     }
@@ -144,6 +144,8 @@ class ConversationService {
     return this.ragService.askWithConversation(question, {
       conversationId: id,
       filters: filters || null,
+      userId,
+      authorizedWorkspaceIds,
     });
   }
 

--- a/backend/services/QuestionnaireService.js
+++ b/backend/services/QuestionnaireService.js
@@ -27,10 +27,7 @@ class QuestionnaireService {
 
     const template = await this.templateRepo.findDefault();
     if (!template) {
-      throw new AppError(
-        'No default questionnaire template found. Please contact support.',
-        500
-      );
+      throw new AppError('No default questionnaire template found. Please contact support.', 500);
     }
 
     const questions = template.questions.map((q) => ({
@@ -119,7 +116,7 @@ class QuestionnaireService {
     });
   }
 
-  async sendQuestionnaire(id, { userId, userName, userEmail }, authorizedWorkspaces) {
+  async sendQuestionnaire(id, { userName, userEmail }, authorizedWorkspaces) {
     const authorizedWorkspaceIds = authorizedWorkspaces.map((w) => w._id.toString());
     const questionnaire = await this.questionnaireRepo.findById(id);
     if (!questionnaire) throw new AppError('Questionnaire not found', 404);
@@ -141,9 +138,8 @@ class QuestionnaireService {
     await questionnaire.save();
 
     const workspaceName =
-      authorizedWorkspaces.find(
-        (w) => w._id.toString() === questionnaire.workspaceId.toString()
-      )?.name || 'Your Assessment Team';
+      authorizedWorkspaces.find((w) => w._id.toString() === questionnaire.workspaceId.toString())
+        ?.name || 'Your Assessment Team';
 
     await this.emailService.sendQuestionnaireInvitation({
       toEmail: questionnaire.vendorEmail,
@@ -173,10 +169,7 @@ class QuestionnaireService {
       return { state: 'complete' };
     }
 
-    if (
-      questionnaire.tokenExpiresAt &&
-      new Date() > new Date(questionnaire.tokenExpiresAt)
-    ) {
+    if (questionnaire.tokenExpiresAt && new Date() > new Date(questionnaire.tokenExpiresAt)) {
       await this.questionnaireRepo.updateById(questionnaire._id, { status: 'expired' });
       return { state: 'expired' };
     }
@@ -201,10 +194,7 @@ class QuestionnaireService {
     }
 
     // Token expired during THIS request — flip status and signal a 410.
-    if (
-      questionnaire.tokenExpiresAt &&
-      new Date() > new Date(questionnaire.tokenExpiresAt)
-    ) {
+    if (questionnaire.tokenExpiresAt && new Date() > new Date(questionnaire.tokenExpiresAt)) {
       questionnaire.status = 'expired';
       await questionnaire.save();
       return { state: 'justExpired' };

--- a/backend/services/rag.js
+++ b/backend/services/rag.js
@@ -3,6 +3,7 @@ import { ChatPromptTemplate, MessagesPlaceholder } from '@langchain/core/prompts
 import { HumanMessage, AIMessage } from '@langchain/core/messages';
 import { randomUUID } from 'crypto';
 import mongoose from 'mongoose';
+import { AppError } from '../utils/index.js';
 
 // Prompts
 import { ragPrompt } from '../prompts/ragPrompt.js';
@@ -227,6 +228,33 @@ class RAGService {
     const sources = formatSources(sanitizedDocs);
 
     return { context, sources, sanitizedDocs };
+  }
+
+  /**
+   * SECURITY (tenant isolation): authorize the workspace used for retrieval
+   * against the caller's real memberships. Throws 403 if the caller is not a
+   * member of the conversation's workspace (or, for personal/legacy
+   * null/'default' conversations, is not the owner). Called without HTTP
+   * context (workers/internal), it is a no-op — those callers are trusted.
+   */
+  _assertWorkspaceAuthorized(
+    workspaceId,
+    conversationOwnerId,
+    { userId, authorizedWorkspaceIds } = {}
+  ) {
+    if (!userId && !authorizedWorkspaceIds) return;
+    const ws = workspaceId && workspaceId !== 'default' ? String(workspaceId) : null;
+    if (ws) {
+      const allowed = (authorizedWorkspaceIds || []).map(String);
+      if (!allowed.includes(ws)) {
+        throw new AppError('You do not have access to this workspace', 403);
+      }
+      return;
+    }
+    // Personal / legacy conversation (no workspace): must be the owner.
+    if (userId && conversationOwnerId && String(conversationOwnerId) !== String(userId)) {
+      throw new AppError('You do not have access to this conversation', 403);
+    }
   }
 
   async _resolveQdrantWorkspaceId(workspaceId) {
@@ -462,6 +490,10 @@ class RAGService {
       filters = null,
       onEvent = null,
       responseInstruction: callerInstruction = '',
+      // SECURITY (tenant isolation): supplied by the HTTP layer so retrieval can
+      // be authorized against the caller's real workspace memberships.
+      userId = null,
+      authorizedWorkspaceIds = null,
     } = options;
 
     if (!conversationId) {
@@ -481,6 +513,15 @@ class RAGService {
     if (!conversation) throw new Error(`Conversation ${conversationId} not found`);
 
     const workspaceId = conversation.workspaceId || null;
+
+    // SECURITY (tenant isolation): the retrieval workspace IS the conversation's
+    // workspace. Authorize it against the caller's real memberships so a user
+    // cannot read another workspace's documents via a spoofed X-Workspace-Id or
+    // a conversation id they do not own.
+    this._assertWorkspaceAuthorized(workspaceId, conversation.userId, {
+      userId,
+      authorizedWorkspaceIds,
+    });
 
     this.logger.info('Processing RAG question', {
       service: 'rag',

--- a/backend/services/ragExecutor.js
+++ b/backend/services/ragExecutor.js
@@ -26,7 +26,14 @@ export class InputGuardrailError extends AppError {
  * @param {Function} [params.onEvent]      SSE callback: (type, data) => void
  * @returns {Object} RAG result
  */
-export async function executeRAG({ question, conversationId, filters = null, onEvent = null }) {
+export async function executeRAG({
+  question,
+  conversationId,
+  filters = null,
+  onEvent = null,
+  userId = null,
+  authorizedWorkspaceIds = null,
+}) {
   logger.info('Executing RAG query', {
     service: 'rag-executor',
     questionLength: question.length,
@@ -38,6 +45,8 @@ export async function executeRAG({ question, conversationId, filters = null, onE
     conversationId,
     filters,
     onEvent,
+    userId,
+    authorizedWorkspaceIds,
   });
 
   logger.info('RAG query completed', {

--- a/backend/tests/unittest/gapAnalysisAgent.test.js
+++ b/backend/tests/unittest/gapAnalysisAgent.test.js
@@ -120,8 +120,6 @@ describe('runGapAnalysis', () => {
   it('succeeds with ReAct agent for DORA framework', async () => {
     assessmentRepository.findById.mockResolvedValue(makeAssessment());
 
-    // Simulate agent capturing result via tool call
-    let capturedTool;
     createReactAgent.mockReturnValue({
       invoke: vi.fn().mockImplementation(async () => {
         // The tool's fn is captured when buildTools is called.
@@ -133,9 +131,6 @@ describe('runGapAnalysis', () => {
     // We need to intercept the tool() call to simulate gap capture
     const { tool } = await import('@langchain/core/tools');
     tool.mockImplementation((fn, config) => {
-      if (config?.name === 'record_gap_analysis') {
-        capturedTool = { fn, config };
-      }
       return { fn, config };
     });
 

--- a/backend/tests/unittest/questionnaireController.test.js
+++ b/backend/tests/unittest/questionnaireController.test.js
@@ -103,17 +103,6 @@ function makeReq(overrides = {}) {
   };
 }
 
-/**
- * Returns an object that works for BOTH usage patterns found in the controller:
- *   await VendorQuestionnaire.findById(id)          → resolves to doc
- *   await VendorQuestionnaire.findById(id).lean()   → resolves to doc
- */
-function makeQueryResult(doc) {
-  return Object.assign(Promise.resolve(doc), {
-    lean: () => Promise.resolve(doc),
-  });
-}
-
 const MOCK_TEMPLATE = {
   _id: 'tpl-001',
   isDefault: true,

--- a/backend/tests/unittest/ragController.test.js
+++ b/backend/tests/unittest/ragController.test.js
@@ -100,6 +100,7 @@ describe('ragController — askQuestion', () => {
       conversationId: 'conv-abc',
       filters: { domain: 'ICT' },
       userId: 'user-123',
+      authorizedWorkspaceIds: [],
       forceIntent: 'compliance',
       useIntentAware: false,
     });

--- a/backend/tests/unittest/ragService.test.js
+++ b/backend/tests/unittest/ragService.test.js
@@ -635,3 +635,80 @@ describe('init()', () => {
     expect(svc._initialized).toBe(true);
   });
 });
+
+// ─── Tenant isolation (cross-workspace document exposure) ──────────────────────
+
+describe('tenant isolation: _assertWorkspaceAuthorized', () => {
+  it('allows when the conversation workspace is in the caller authorized set', () => {
+    const { svc } = makeService();
+    expect(() =>
+      svc._assertWorkspaceAuthorized('ws-A', 'owner', {
+        userId: 'u1',
+        authorizedWorkspaceIds: ['ws-A', 'ws-C'],
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects (403) when the conversation workspace is NOT in the caller set', () => {
+    const { svc } = makeService();
+    let thrown;
+    try {
+      svc._assertWorkspaceAuthorized('ws-B', 'owner', {
+        userId: 'attacker',
+        authorizedWorkspaceIds: ['ws-A'],
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown.statusCode).toBe(403);
+  });
+
+  it('allows a personal (null/default) conversation for its owner', () => {
+    const { svc } = makeService();
+    expect(() =>
+      svc._assertWorkspaceAuthorized(null, 'u1', { userId: 'u1', authorizedWorkspaceIds: [] })
+    ).not.toThrow();
+    expect(() =>
+      svc._assertWorkspaceAuthorized('default', 'u1', { userId: 'u1', authorizedWorkspaceIds: [] })
+    ).not.toThrow();
+  });
+
+  it('rejects a personal conversation for a non-owner', () => {
+    const { svc } = makeService();
+    expect(() =>
+      svc._assertWorkspaceAuthorized(null, 'owner', {
+        userId: 'attacker',
+        authorizedWorkspaceIds: [],
+      })
+    ).toThrow();
+  });
+
+  it('is a no-op for internal/worker callers (no userId or authorizedWorkspaceIds)', () => {
+    const { svc } = makeService();
+    expect(() => svc._assertWorkspaceAuthorized('ws-B', 'owner', {})).not.toThrow();
+  });
+});
+
+describe('tenant isolation: askWithConversation blocks cross-workspace retrieval', () => {
+  it('throws 403 before retrieval when the conversation is in a workspace the caller is not in', async () => {
+    const { svc, mockConversation, mockVectorStore } = makeService();
+    svc._initialized = true; // skip init
+    mockConversation.findById.mockResolvedValue({
+      _id: 'conv-x',
+      workspaceId: 'ws-B',
+      userId: 'victim',
+    });
+
+    await expect(
+      svc.askWithConversation('what are the secret findings?', {
+        conversationId: 'conv-x',
+        userId: 'attacker',
+        authorizedWorkspaceIds: ['ws-A'],
+      })
+    ).rejects.toMatchObject({ statusCode: 403 });
+
+    // No vector search should have happened — isolation rejects before retrieval.
+    expect(mockVectorStore.similaritySearch).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/unittest/ragService.test.js
+++ b/backend/tests/unittest/ragService.test.js
@@ -598,7 +598,7 @@ describe('askWithConversation', () => {
 
 describe('init()', () => {
   it('sets _initialized to true after successful init', async () => {
-    const { svc, mockLLM, mockVectorStore } = makeService();
+    const { svc, mockLLM } = makeService();
     const mockChain = { pipe: vi.fn().mockReturnThis() };
     mockLLM.pipe.mockReturnValue(mockChain);
 
@@ -613,7 +613,7 @@ describe('init()', () => {
   });
 
   it('does not re-initialize if already initialized', async () => {
-    const { svc, mockVectorStore } = makeService();
+    const { svc } = makeService();
     svc._initialized = true;
 
     await svc.init();
@@ -622,7 +622,7 @@ describe('init()', () => {
   });
 
   it('reuses existing _initPromise for concurrent calls', async () => {
-    const { svc, mockLLM, mockVectorStore } = makeService();
+    const { svc, mockLLM } = makeService();
     const mockChain = { pipe: vi.fn().mockReturnThis() };
     mockLLM.pipe.mockReturnValue(mockChain);
 

--- a/backend/tests/unittest/workspaceAuth.test.js
+++ b/backend/tests/unittest/workspaceAuth.test.js
@@ -152,6 +152,49 @@ describe('Workspace Auth Middleware', () => {
       expect(mockNext).toHaveBeenCalled();
     });
 
+    it('rejects 403 when X-Workspace-Id is not a workspace the user belongs to', async () => {
+      mockReq.user = { userId: 'user-123' };
+      mockReq.headers = { 'x-workspace-id': 'ws-B' }; // attacker requests another workspace
+
+      WorkspaceMember.find.mockReturnValue({
+        populate: vi.fn().mockResolvedValue([
+          {
+            workspaceId: { _id: { toString: () => 'ws-A' }, name: 'My WS', syncStatus: 'synced' },
+            role: 'member',
+            permissions: { canQuery: true },
+          },
+        ]),
+      });
+
+      await requireWorkspaceAccess(mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(403);
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('access to this workspace') })
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('allows when X-Workspace-Id matches one of the user memberships', async () => {
+      mockReq.user = { userId: 'user-123' };
+      mockReq.headers = { 'x-workspace-id': 'ws-A' };
+
+      WorkspaceMember.find.mockReturnValue({
+        populate: vi.fn().mockResolvedValue([
+          {
+            workspaceId: { _id: { toString: () => 'ws-A' }, name: 'My WS', syncStatus: 'synced' },
+            role: 'member',
+            permissions: { canQuery: true },
+          },
+        ]),
+      });
+
+      await requireWorkspaceAccess(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockRes.status).not.toHaveBeenCalledWith(403);
+    });
+
     it('should filter out null workspace references', async () => {
       mockReq.user = { userId: 'user-123' };
 

--- a/backend/tests/unittest/workspaceService.unit.test.js
+++ b/backend/tests/unittest/workspaceService.unit.test.js
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { WorkspaceService, serializeWorkspace } from '../../services/WorkspaceService.js';
-import { AppError } from '../../utils/index.js';
 
 // ---------------------------------------------------------------------------
 // Mock module-level imports so the singleton doesn't crash on load

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,6 @@
 #   docker compose down -v            # Stop and remove volumes
 # =============================================================================
 
-version: '3.8'
-
 services:
   # ===========================================================================
   # Frontend (Next.js)
@@ -81,6 +79,10 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - QDRANT_URL=http://qdrant:6333
+      # Embeddings hit the self-hosted Ollama sidecar — Ollama Cloud does not
+      # authorize the embeddings API. Overrides OLLAMA_BASE_URL from .env so the
+      # chat LLM can stay on Ollama Cloud while embeddings run locally (bge-m3).
+      - EMBEDDING_OLLAMA_BASE_URL=http://ollama:11434
     depends_on:
       mongodb:
         condition: service_healthy
@@ -88,6 +90,10 @@ services:
         condition: service_healthy
       qdrant:
         condition: service_healthy
+      ollama:
+        condition: service_healthy
+      ollama-pull:
+        condition: service_completed_successfully
     volumes:
       - ./backend:/app
       - /app/node_modules
@@ -184,6 +190,49 @@ services:
       - rag-network
     restart: unless-stopped
 
+  # ===========================================================================
+  # Ollama (self-hosted embeddings — bge-m3, 1024-dim)
+  # ===========================================================================
+  # Ollama Cloud serves chat/generate but NOT the embeddings API (it returns
+  # "unauthorized"). RAG embeddings therefore run against this local sidecar,
+  # which keeps the existing 1024-dim Qdrant vectors valid (no re-indexing).
+  ollama:
+    image: ollama/ollama:latest
+    container_name: rag-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - rag-network
+    restart: unless-stopped
+
+  # One-shot: pull the embedding model into the ollama volume, then exit.
+  # Runs on every `up` but is a fast no-op once bge-m3 is cached.
+  ollama-pull:
+    image: ollama/ollama:latest
+    container_name: rag-ollama-pull
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      - OLLAMA_HOST=http://ollama:11434
+    entrypoint: ["/bin/sh", "-c", "ollama pull bge-m3:latest"]
+    networks:
+      - rag-network
+    restart: "no"
+
 # =============================================================================
 # Networks
 # =============================================================================
@@ -198,3 +247,4 @@ volumes:
   mongodb_data:
   redis_data:
   qdrant_data:
+  ollama_data:

--- a/docs/docs/deployment/embeddings.md
+++ b/docs/docs/deployment/embeddings.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 8
+---
+
+# Embeddings (self-hosted Ollama)
+
+RAG embeddings run on a **self-hosted Ollama** with the `bge-m3` model
+(1024-dim). The chat LLM and embeddings use **different** Ollama endpoints.
+
+## Why embeddings can't use Ollama Cloud ⚠️
+
+Ollama Cloud (`https://ollama.com`) serves **chat/generate** but **not** the
+embeddings API — `POST /api/embed` returns `{"error":"unauthorized"}` for every
+model, even with valid keys (verified for both dev and prod keys). So
+`OLLAMA_BASE_URL=https://ollama.com` works for the LLM but **not** for embeddings.
+
+## Configuration
+
+Two independent endpoints:
+
+| Var | Used for | Value |
+| --- | --- | --- |
+| `OLLAMA_BASE_URL` | chat LLM | `https://ollama.com` (Ollama Cloud) |
+| `EMBEDDING_OLLAMA_BASE_URL` | embeddings | a self-hosted Ollama with `bge-m3` |
+
+The code prefers `EMBEDDING_OLLAMA_BASE_URL` over `OLLAMA_BASE_URL`
+(`config/embeddings.js`), so the LLM stays on the cloud while embeddings stay
+local. Keep `EMBEDDING_MODEL=bge-m3:latest` — switching models/providers changes
+the vector dimension and forces a full Qdrant re-index.
+
+## Local dev (docker compose)
+
+`docker compose` runs an `ollama` sidecar plus a one-shot `ollama-pull` that
+fetches `bge-m3` into a named volume. The backend service overrides
+`EMBEDDING_OLLAMA_BASE_URL=http://ollama:11434` (the sidecar's service name).
+
+```bash
+docker compose up -d            # ollama starts, bge-m3 is pulled, backend waits for it
+```
+
+For the backend run **on the host** (`npm run dev:backend`), `.env` uses
+`EMBEDDING_OLLAMA_BASE_URL=http://localhost:11434`.
+
+Verify:
+
+```bash
+curl -s http://localhost:11434/api/embed \
+  -d '{"model":"bge-m3:latest","input":"test"}' | head -c 80
+# -> {"model":"bge-m3:latest","embeddings":[[...]]}   (1024 numbers)
+```
+
+## Production
+
+Run Ollama next to the API (sidecar container or a host process), pull `bge-m3`,
+and set `EMBEDDING_OLLAMA_BASE_URL` in the prod env to point at it
+(e.g. `http://ollama:11434` on the same network, or an internal host:port).
+`OLLAMA_BASE_URL` stays on Ollama Cloud for the chat LLM.
+
+> bge-m3 emits **1024-dim** vectors. The Qdrant collections are built at this
+> dimension — do not change the embedding model without recreating/re-indexing
+> them.


### PR DESCRIPTION
Promote `dev` → `main` (production auto-deploy).

- **#294 fix(security)** — authorize the active workspace against the caller's memberships so a user cannot read another workspace's documents via RAG (spoofed `X-Workspace-Id` or a conversation in another workspace). **Effective immediately on deploy.**
- **#293 fix(embeddings)** — code prefers a self-hosted `EMBEDDING_OLLAMA_BASE_URL` for embeddings. Safe to deploy (no regression). NOTE: does **not** fix prod embeddings until an Ollama instance is run beside the prod API and `EMBEDDING_OLLAMA_BASE_URL` is set there (see `docs/deployment/embeddings.md`). The docker-compose sidecar is local-only.
- **#292 chore(lint)** — clear no-unused-vars warnings.