### PR TITLE
fix(prod): pull bge-m3 into the ollama sidecar for embeddings

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -146,6 +146,31 @@ services:
       - rag-network
 
   # ---------------------------------------------------------------------------
+  # Ollama model pull (one-shot)
+  # ---------------------------------------------------------------------------
+  # Ensures the embedding model (bge-m3, 1024-dim) is present in the ollama
+  # volume so embeddings work. Runs on every deploy but is a fast no-op once the
+  # model is cached. Backend depends on `ollama` (started), NOT on this one-shot,
+  # so a transient pull failure can never block an API deploy or trigger rollback.
+  ollama-pull:
+    image: ollama/ollama:latest
+    container_name: retrieva-ollama-pull
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      - OLLAMA_HOST=http://ollama:11434
+    entrypoint: ["/bin/sh", "-c", "ollama pull bge-m3:latest"]
+    restart: "no"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - rag-network
+
+  # ---------------------------------------------------------------------------
   # Backend (Node.js/Express)
   # ---------------------------------------------------------------------------
   # MongoDB connection string comes from backend/.env


### PR DESCRIPTION
## Context
The prod compose already wires embeddings to the local Ollama sidecar — the `ollama` service plus `EMBEDDING_OLLAMA_BASE_URL=http://ollama:11434` + `EMBEDDING_MODEL=bge-m3:latest` on the backend (overriding the `.env`'s `ollama.com`) have been deployed since #198. So the endpoint is wired; what was missing is the **model**.

## Problem
There was no step to pull `bge-m3` into the `ollama_data` volume, so embeddings could fail with *model-not-found* on a host where it was never pulled manually.

## Fix
Add a one-shot `ollama-pull` service that runs `ollama pull bge-m3:latest` against the sidecar on every deploy — idempotent, fast no-op once cached.

- Decoupled from the backend: `backend` still `depends_on: ollama (service_started)`, **not** on this one-shot, so a transient pull failure can never block the API deploy or trigger the CD rollback.
- `bge-m3` is 1024-dim — matches existing Qdrant collections (no re-index).

## Effect / rollout
Takes effect on the next prod deploy (CD's `docker compose -f docker-compose.production.yml up -d` runs the one-shot). For immediate effect without waiting, the model can be pulled on the host: `docker exec retrieva-ollama ollama pull bge-m3:latest`.