### PR TITLE
release: pull bge-m3 into prod ollama sidecar for embeddings

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -146,6 +146,31 @@ services:
       - rag-network
 
   # ---------------------------------------------------------------------------
+  # Ollama model pull (one-shot)
+  # ---------------------------------------------------------------------------
+  # Ensures the embedding model (bge-m3, 1024-dim) is present in the ollama
+  # volume so embeddings work. Runs on every deploy but is a fast no-op once the
+  # model is cached. Backend depends on `ollama` (started), NOT on this one-shot,
+  # so a transient pull failure can never block an API deploy or trigger rollback.
+  ollama-pull:
+    image: ollama/ollama:latest
+    container_name: retrieva-ollama-pull
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      - OLLAMA_HOST=http://ollama:11434
+    entrypoint: ["/bin/sh", "-c", "ollama pull bge-m3:latest"]
+    restart: "no"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - rag-network
+
+  # ---------------------------------------------------------------------------
   # Backend (Node.js/Express)
   # ---------------------------------------------------------------------------
   # MongoDB connection string comes from backend/.env


### PR DESCRIPTION
Promote `dev` → `main` (production auto-deploy).

Ships #296 — adds a one-shot `ollama-pull` to `docker-compose.production.yml` that pulls `bge-m3` into the prod Ollama sidecar on deploy (idempotent). The embedding endpoint was already wired (`EMBEDDING_OLLAMA_BASE_URL=http://ollama:11434`); this guarantees the model is present so prod embeddings work. Decoupled from the backend, so it cannot block the deploy/rollback. 1024-dim → no Qdrant re-index.

On this deploy, CD's `docker compose -f docker-compose.production.yml up -d` runs the pull.