### PR TITLE
release: require workspace access on all conversation routes

### DIFF
--- a/backend/routes/conversationRoutes.js
+++ b/backend/routes/conversationRoutes.js
@@ -22,9 +22,10 @@ import {
 
 const router = express.Router();
 
-// Conversation management — all routes require authentication
-// Conversations are user-scoped (userId), not workspace-scoped
-// Users can only access their own conversations (BOLA protection in controllers)
+// Conversation management — every route requires authentication AND workspace
+// access. requireWorkspaceAccess rejects an X-Workspace-Id the caller is not a
+// member of; per-conversation access is further enforced by ownership (BOLA)
+// checks in the controllers/services.
 router.post(
   '/',
   authenticate,
@@ -32,22 +33,42 @@ router.post(
   validateBody(createConversationSchema),
   createConversation
 );
-router.get('/', authenticate, validateQuery(listConversationsQuerySchema), getConversations);
+router.get(
+  '/',
+  authenticate,
+  requireWorkspaceAccess,
+  validateQuery(listConversationsQuerySchema),
+  getConversations
+);
 router.post(
   '/bulk-delete',
   authenticate,
+  requireWorkspaceAccess,
   validateBody(bulkDeleteConversationsSchema),
   bulkDeleteConversations
 ); // Must be before /:id routes
-router.get('/:id', authenticate, validateParams(idParamsSchema), getConversation);
+router.get(
+  '/:id',
+  authenticate,
+  requireWorkspaceAccess,
+  validateParams(idParamsSchema),
+  getConversation
+);
 router.patch(
   '/:id',
   authenticate,
+  requireWorkspaceAccess,
   validateParams(idParamsSchema),
   validateBody(updateConversationSchema),
   updateConversation
 );
-router.delete('/:id', authenticate, validateParams(idParamsSchema), deleteConversation);
+router.delete(
+  '/:id',
+  authenticate,
+  requireWorkspaceAccess,
+  validateParams(idParamsSchema),
+  deleteConversation
+);
 
 // Ask question in conversation
 router.post(

--- a/backend/tests/integrationtest/conversation.integration.test.js
+++ b/backend/tests/integrationtest/conversation.integration.test.js
@@ -137,6 +137,7 @@ describe('Conversation API Integration Tests', () => {
   let user1Id;
   let user2Id;
   let workspaceId;
+  let foreignWorkspaceId; // a workspace user1 is NOT a member of
 
   beforeAll(async () => {
     mongoServer = await MongoMemoryServer.create({
@@ -222,6 +223,22 @@ describe('Conversation API Integration Tests', () => {
         canManageMembers: false,
         canManageSettings: false,
       },
+    });
+
+    // A second workspace that user1 is NOT a member of (owned by user2) — used
+    // to prove the active X-Workspace-Id is validated against membership.
+    const foreignWorkspace = await Workspace.create({
+      name: 'Foreign Workspace',
+      userId: user2Id,
+      syncStatus: 'synced',
+    });
+    foreignWorkspaceId = foreignWorkspace._id.toString();
+    await WorkspaceMember.create({
+      workspaceId: foreignWorkspace._id,
+      userId: user2Id,
+      role: 'owner',
+      status: 'active',
+      permissions: { canQuery: true, canManageMembers: true, canManageSettings: true },
     });
   }, 30000);
 
@@ -387,6 +404,36 @@ describe('Conversation API Integration Tests', () => {
         .set('X-Workspace-Id', workspaceId.toString());
 
       expect([400, 404, 500]).toContain(res.status);
+    });
+  });
+
+  // =============================================================================
+  // Tenant isolation — active workspace must be a membership
+  // =============================================================================
+  describe('tenant isolation (active workspace must be a membership)', () => {
+    it('rejects GET /conversations when X-Workspace-Id is a non-member workspace', async () => {
+      const res = await request
+        .get(`${API_BASE}/conversations`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .set('X-Workspace-Id', foreignWorkspaceId);
+      expect(res.status).toBe(403);
+    });
+
+    it('rejects GET /conversations/:id when X-Workspace-Id is a non-member workspace', async () => {
+      // Create a conversation in user1's real workspace...
+      const created = await request
+        .post(`${API_BASE}/conversations`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .set('X-Workspace-Id', workspaceId.toString())
+        .send({ title: 'isolation probe' });
+      const id = created.body.data?.conversation?.id || created.body.data?.conversation?._id;
+
+      // ...then try to read it while claiming a workspace user1 does not belong to.
+      const res = await request
+        .get(`${API_BASE}/conversations/${id}`)
+        .set('Authorization', `Bearer ${user1Token}`)
+        .set('X-Workspace-Id', foreignWorkspaceId);
+      expect(res.status).toBe(403);
     });
   });
 


### PR DESCRIPTION
Promote `dev` → `main` (production auto-deploy).

Ships #298 — applies `requireWorkspaceAccess` uniformly to the conversation list/get/update/delete/bulk-delete routes, so a spoofed `X-Workspace-Id` (a workspace the caller isn't a member of) is rejected with 403 everywhere. Consistency/defense-in-depth follow-up to the #294 cross-workspace isolation fix. Integration tests assert the 403 on GET /conversations and GET /conversations/:id. No data exposure was open (ownership already gated reads).