### PR TITLE
feat(web): translate navigation chrome — EN/FR (i18n batch 2)

### DIFF
--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname } from 'next/navigation';
 import { Menu } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
 import { ThemeToggle } from '@/components/theme/theme-toggle';
@@ -9,43 +10,45 @@ import { LanguageSwitcher } from '@/shared/ui/language-switcher';
 import { UserNav } from './user-nav';
 import { useUIStore } from '@/lib/stores/ui-store';
 
-// Maps route prefixes/exact paths to human-readable page titles
+// Maps route prefixes/exact paths to i18n title keys (resolved with t() below)
 const PAGE_TITLES: Record<string, string> = {
-  '/risk-register':       'Risk Register',
-  '/workspaces':          'Vendors',
-  '/assessments':         'Gap Analysis',
-  '/questionnaires':      'Questionnaires',
-  '/chat':                'Ask AI',
-  '/conversations':       'Conversation History',
-  '/settings':            'Settings',
-  '/settings/security':   'Security',
-  '/settings/team':       'Team',
-  '/settings/billing':    'Billing',
+  '/risk-register': 'nav.titles.riskRegister',
+  '/workspaces': 'nav.titles.vendors',
+  '/assessments': 'nav.titles.gapAnalysis',
+  '/questionnaires': 'nav.titles.questionnaires',
+  '/chat': 'nav.titles.askAi',
+  '/conversations': 'nav.titles.conversationHistory',
+  '/settings': 'nav.titles.settings',
+  '/settings/security': 'nav.titles.security',
+  '/settings/team': 'nav.titles.team',
+  '/settings/billing': 'nav.titles.billing',
 };
 
-// Dynamic route titles for path prefixes
+// Dynamic route titles for path prefixes (also i18n keys)
 const DYNAMIC_TITLES: Array<[string, string]> = [
-  ['/assessments/', 'Assessment Detail'],
-  ['/workspaces/',  'Vendor Detail'],
-  ['/conversations/', 'Conversation'],
-  ['/questionnaires/', 'Questionnaire'],
+  ['/assessments/', 'nav.titles.assessmentDetail'],
+  ['/workspaces/', 'nav.titles.vendorDetail'],
+  ['/conversations/', 'nav.titles.conversation'],
+  ['/questionnaires/', 'nav.titles.questionnaire'],
 ];
 
-function usePageTitle(pathname: string): string {
+/** Returns the i18n title key for the current path, or '' when none matches. */
+function usePageTitleKey(pathname: string): string {
   // Exact match first
   if (PAGE_TITLES[pathname]) return PAGE_TITLES[pathname];
   // Dynamic prefix match
-  for (const [prefix, title] of DYNAMIC_TITLES) {
-    if (pathname.startsWith(prefix)) return title;
+  for (const [prefix, key] of DYNAMIC_TITLES) {
+    if (pathname.startsWith(prefix)) return key;
   }
   return '';
 }
 
 export function Header() {
+  const { t } = useTranslation();
   const pathname = usePathname();
   const toggleSidebar = useUIStore((state) => state.toggleSidebar);
   const isMobile = useUIStore((state) => state.isMobile);
-  const pageTitle = usePageTitle(pathname);
+  const pageTitleKey = usePageTitleKey(pathname);
 
   return (
     <header className="sticky top-0 z-40 flex h-13 items-center gap-3 border-b border-border bg-background/95 backdrop-blur-sm px-5 sm:px-6">
@@ -56,9 +59,9 @@ export function Header() {
         </Button>
       )}
 
-      {pageTitle && (
+      {pageTitleKey && (
         <span className="text-sm font-medium text-foreground/60 tracking-tight">
-          {pageTitle}
+          {t(pageTitleKey)}
         </span>
       )}
 

--- a/frontend/src/components/layout/mobile-sidebar.tsx
+++ b/frontend/src/components/layout/mobile-sidebar.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { MessageSquare } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
@@ -13,6 +14,7 @@ import { usePermissions } from '@/lib/hooks/use-permissions';
 import { mobileMainNavItems, bottomNavItems, type NavItem } from '@/lib/constants/nav-items';
 
 export function MobileSidebar() {
+  const { t } = useTranslation();
   const pathname = usePathname();
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
   const setSidebarOpen = useUIStore((state) => state.setSidebarOpen);
@@ -74,7 +76,7 @@ export function MobileSidebar() {
                 >
                   <Link href={item.href}>
                     <item.icon className="mr-2 h-4 w-4" />
-                    <span>{item.title}</span>
+                    <span>{t(item.title)}</span>
                   </Link>
                 </Button>
               );
@@ -95,7 +97,7 @@ export function MobileSidebar() {
                 >
                   <Link href={item.href}>
                     <item.icon className="mr-2 h-4 w-4" />
-                    <span>{item.title}</span>
+                    <span>{t(item.title)}</span>
                   </Link>
                 </Button>
               );

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { ShieldCheck, PanelLeftClose, PanelLeft } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -14,6 +15,7 @@ import { usePermissions } from '@/lib/hooks/use-permissions';
 import { desktopNavSections, bottomNavItems, type NavItem } from '@/lib/constants/nav-items';
 
 export function Sidebar() {
+  const { t } = useTranslation();
   const pathname = usePathname();
   const sidebarCollapsed = useUIStore((state) => state.sidebarCollapsed);
   const setSidebarCollapsed = useUIStore((state) => state.setSidebarCollapsed);
@@ -100,7 +102,7 @@ export function Sidebar() {
                 {/* Section label — hidden when collapsed */}
                 {!sidebarCollapsed && (
                   <p className="mb-1 px-3 text-[10px] font-semibold uppercase tracking-[0.14em] text-sidebar-foreground/25 select-none">
-                    {section.label}
+                    {t(section.label)}
                   </p>
                 )}
 
@@ -163,10 +165,11 @@ function NavLink({
   isActive: boolean;
   collapsed: boolean;
 }) {
+  const { t } = useTranslation();
   return (
     <Link
       href={item.href}
-      title={collapsed ? item.title : undefined}
+      title={collapsed ? t(item.title) : undefined}
       className={cn(
         'relative flex items-center rounded-sm text-sm transition-colors duration-150',
         collapsed ? 'justify-center p-2.5' : 'gap-3 px-3 py-2',
@@ -176,7 +179,7 @@ function NavLink({
       )}
     >
       <item.icon className="h-4 w-4 shrink-0" aria-hidden />
-      {!collapsed && <span className="truncate">{item.title}</span>}
+      {!collapsed && <span className="truncate">{t(item.title)}</span>}
     </Link>
   );
 }

--- a/frontend/src/shared/constants/nav-items.ts
+++ b/frontend/src/shared/constants/nav-items.ts
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 
 export interface NavItem {
+  /** i18n key (e.g. 'nav.items.riskRegister') — resolved with t() at render. */
   title: string;
   href: string;
   icon: React.ComponentType<{ className?: string }>;
@@ -16,6 +17,7 @@ export interface NavItem {
 }
 
 export interface NavSection {
+  /** i18n key (e.g. 'nav.sections.compliance') — resolved with t() at render. */
   label: string;
   items: NavItem[];
 }
@@ -23,19 +25,24 @@ export interface NavSection {
 // Grouped navigation for the desktop sidebar
 export const desktopNavSections: NavSection[] = [
   {
-    label: 'Compliance',
+    label: 'nav.sections.compliance',
     items: [
-      { title: 'Risk Register', href: '/risk-register', icon: BarChart3 },
-      { title: 'Vendors', href: '/workspaces', icon: Building2 },
-      { title: 'Gap Analysis', href: '/assessments', icon: ShieldCheck },
-      { title: 'Questionnaires', href: '/questionnaires', icon: ClipboardList, workspaceRoles: ['owner', 'member'] },
+      { title: 'nav.items.riskRegister', href: '/risk-register', icon: BarChart3 },
+      { title: 'nav.items.vendors', href: '/workspaces', icon: Building2 },
+      { title: 'nav.items.gapAnalysis', href: '/assessments', icon: ShieldCheck },
+      {
+        title: 'nav.items.questionnaires',
+        href: '/questionnaires',
+        icon: ClipboardList,
+        workspaceRoles: ['owner', 'member'],
+      },
     ],
   },
   {
-    label: 'Intelligence',
+    label: 'nav.sections.intelligence',
     items: [
-      { title: 'Ask AI', href: '/chat', icon: MessageSquare },
-      { title: 'History', href: '/conversations', icon: FolderOpen },
+      { title: 'nav.items.askAi', href: '/chat', icon: MessageSquare },
+      { title: 'nav.items.history', href: '/conversations', icon: FolderOpen },
     ],
   },
 ];
@@ -44,12 +51,17 @@ export const desktopNavSections: NavSection[] = [
 export const desktopMainNavItems: NavItem[] = desktopNavSections.flatMap((s) => s.items);
 
 export const mobileMainNavItems: NavItem[] = [
-  { title: 'Gap Analysis', href: '/assessments', icon: ShieldCheck },
-  { title: 'Questionnaires', href: '/questionnaires', icon: ClipboardList, workspaceRoles: ['owner', 'member'] },
-  { title: 'Ask AI', href: '/chat', icon: MessageSquare },
-  { title: 'History', href: '/conversations', icon: FolderOpen },
+  { title: 'nav.items.gapAnalysis', href: '/assessments', icon: ShieldCheck },
+  {
+    title: 'nav.items.questionnaires',
+    href: '/questionnaires',
+    icon: ClipboardList,
+    workspaceRoles: ['owner', 'member'],
+  },
+  { title: 'nav.items.askAi', href: '/chat', icon: MessageSquare },
+  { title: 'nav.items.history', href: '/conversations', icon: FolderOpen },
 ];
 
 export const bottomNavItems: NavItem[] = [
-  { title: 'Settings', href: '/settings', icon: Settings },
+  { title: 'nav.items.settings', href: '/settings', icon: Settings },
 ];

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -12,6 +12,37 @@
     "en": "English",
     "fr": "Français"
   },
+  "nav": {
+    "sections": {
+      "compliance": "Compliance",
+      "intelligence": "Intelligence"
+    },
+    "items": {
+      "riskRegister": "Risk Register",
+      "vendors": "Vendors",
+      "gapAnalysis": "Gap Analysis",
+      "questionnaires": "Questionnaires",
+      "askAi": "Ask AI",
+      "history": "History",
+      "settings": "Settings"
+    },
+    "titles": {
+      "riskRegister": "Risk Register",
+      "vendors": "Vendors",
+      "gapAnalysis": "Gap Analysis",
+      "questionnaires": "Questionnaires",
+      "askAi": "Ask AI",
+      "conversationHistory": "Conversation History",
+      "settings": "Settings",
+      "security": "Security",
+      "team": "Team",
+      "billing": "Billing",
+      "assessmentDetail": "Assessment Detail",
+      "vendorDetail": "Vendor Detail",
+      "conversation": "Conversation",
+      "questionnaire": "Questionnaire"
+    }
+  },
   "landing": {
     "badge": "DORA Regulation (EU) 2022/2554",
     "heroTitle": "DORA Compliance Intelligence",

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -12,6 +12,37 @@
     "en": "English",
     "fr": "Français"
   },
+  "nav": {
+    "sections": {
+      "compliance": "Conformité",
+      "intelligence": "Intelligence"
+    },
+    "items": {
+      "riskRegister": "Registre des risques",
+      "vendors": "Fournisseurs",
+      "gapAnalysis": "Analyse d'écarts",
+      "questionnaires": "Questionnaires",
+      "askAi": "Demander à l'IA",
+      "history": "Historique",
+      "settings": "Paramètres"
+    },
+    "titles": {
+      "riskRegister": "Registre des risques",
+      "vendors": "Fournisseurs",
+      "gapAnalysis": "Analyse d'écarts",
+      "questionnaires": "Questionnaires",
+      "askAi": "Demander à l'IA",
+      "conversationHistory": "Historique des conversations",
+      "settings": "Paramètres",
+      "security": "Sécurité",
+      "team": "Équipe",
+      "billing": "Facturation",
+      "assessmentDetail": "Détail de l'évaluation",
+      "vendorDetail": "Détail du fournisseur",
+      "conversation": "Conversation",
+      "questionnaire": "Questionnaire"
+    }
+  },
   "landing": {
     "badge": "Règlement DORA (UE) 2022/2554",
     "heroTitle": "Intelligence de conformité DORA",


### PR DESCRIPTION
i18n **batch 2** — translates the app-wide navigation, so the sidebar, mobile sidebar and header page titles now render in EN/FR on **every** dashboard page (builds on the #307 foundation).

- `shared/constants/nav-items.ts` — section labels + item titles are now i18n **keys** (`nav.sections.*`, `nav.items.*`)
- `sidebar.tsx` / `mobile-sidebar.tsx` — resolve nav keys with `t()`
- `header.tsx` — page-title map uses `nav.titles.*` keys resolved with `t()`
- `en.json` / `fr.json` — new `nav` namespace (sections, items, titles)

## Validation
`npm run build` green · `eslint` clean · EN/FR **key-parity test** passing.

## Remaining batches
auth pages → chat / assessments / questionnaires → settings / workspaces / risk-register. Parity test keeps EN/FR in lockstep as each lands.