### PR TITLE
feat(web): translate login page — EN/FR (i18n batch 3)

### DIFF
--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
 import { Loader2, Eye, EyeOff } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -23,6 +24,7 @@ import { loginSchema, type LoginFormData } from '@/lib/utils/validation';
 import { getErrorMessage } from '@/lib/api';
 
 export default function LoginPage() {
+  const { t } = useTranslation();
   const router = useRouter();
   const setUser = useAuthStore((state) => state.setUser);
   const [showPassword, setShowPassword] = useState(false);
@@ -93,12 +95,10 @@ export default function LoginPage() {
     <div className="space-y-6">
       <div className="space-y-2 text-center">
         <h2 className="text-2xl font-semibold tracking-tight">
-          {mfaToken ? 'Two-factor authentication' : 'Welcome back'}
+          {mfaToken ? t('auth.login.mfaTitle') : t('auth.login.title')}
         </h2>
         <p className="text-sm text-muted-foreground">
-          {mfaToken
-            ? 'Enter the 6-digit code from your authenticator app, or a recovery code'
-            : 'Enter your credentials to access your account'}
+          {mfaToken ? t('auth.login.mfaSubtitle') : t('auth.login.subtitle')}
         </p>
       </div>
 
@@ -114,7 +114,7 @@ export default function LoginPage() {
             inputMode="numeric"
             autoComplete="one-time-code"
             autoFocus
-            placeholder="6-digit code or recovery code"
+            placeholder={t('auth.login.mfaCodePlaceholder')}
             value={mfaCode}
             onChange={(e) => setMfaCode(e.target.value)}
             disabled={verifyingMfa}
@@ -127,10 +127,10 @@ export default function LoginPage() {
             {verifyingMfa ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Verifying...
+                {t('auth.login.verifying')}
               </>
             ) : (
-              'Verify'
+              t('auth.login.verify')
             )}
           </Button>
           <Button
@@ -140,7 +140,7 @@ export default function LoginPage() {
             onClick={cancelMfa}
             disabled={verifyingMfa}
           >
-            Use a different account
+            {t('auth.login.useDifferentAccount')}
           </Button>
         </form>
       ) : (
@@ -151,11 +151,11 @@ export default function LoginPage() {
             name="email"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Email</FormLabel>
+                <FormLabel>{t('auth.common.email')}</FormLabel>
                 <FormControl>
                   <Input
                     type="email"
-                    placeholder="you@example.com"
+                    placeholder={t('auth.common.emailPlaceholder')}
                     autoComplete="email"
                     disabled={isSubmitting}
                     {...field}
@@ -172,19 +172,19 @@ export default function LoginPage() {
             render={({ field }) => (
               <FormItem>
                 <div className="flex items-center justify-between">
-                  <FormLabel>Password</FormLabel>
+                  <FormLabel>{t('auth.common.password')}</FormLabel>
                   <Link
                     href="/forgot-password"
                     className="text-sm text-primary hover:underline"
                   >
-                    Forgot password?
+                    {t('auth.login.forgotPassword')}
                   </Link>
                 </div>
                 <div className="relative">
                   <FormControl>
                     <Input
                       type={showPassword ? 'text' : 'password'}
-                      placeholder="Enter your password"
+                      placeholder={t('auth.login.passwordPlaceholder')}
                       autoComplete="current-password"
                       disabled={isSubmitting}
                       className="pr-10"
@@ -205,7 +205,7 @@ export default function LoginPage() {
                       <Eye className="h-4 w-4 text-muted-foreground" />
                     )}
                     <span className="sr-only">
-                      {showPassword ? 'Hide password' : 'Show password'}
+                      {showPassword ? t('auth.common.hidePassword') : t('auth.common.showPassword')}
                     </span>
                   </Button>
                 </div>
@@ -218,10 +218,10 @@ export default function LoginPage() {
             {isSubmitting ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Signing in...
+                {t('auth.login.signingIn')}
               </>
             ) : (
-              'Sign in'
+              t('auth.login.signIn')
             )}
           </Button>
         </form>
@@ -230,9 +230,9 @@ export default function LoginPage() {
 
       {!mfaToken && (
         <div className="text-center text-sm">
-          <span className="text-muted-foreground">Don&apos;t have an account? </span>
+          <span className="text-muted-foreground">{t('auth.login.noAccount')}</span>
           <Link href="/register" className="text-primary hover:underline font-medium">
-            Sign up
+            {t('auth.login.signUp')}
           </Link>
         </div>
       )}

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -12,6 +12,31 @@
     "en": "English",
     "fr": "Français"
   },
+  "auth": {
+    "common": {
+      "email": "Email",
+      "emailPlaceholder": "you@example.com",
+      "password": "Password",
+      "showPassword": "Show password",
+      "hidePassword": "Hide password"
+    },
+    "login": {
+      "title": "Welcome back",
+      "subtitle": "Enter your credentials to access your account",
+      "mfaTitle": "Two-factor authentication",
+      "mfaSubtitle": "Enter the 6-digit code from your authenticator app, or a recovery code",
+      "mfaCodePlaceholder": "6-digit code or recovery code",
+      "verify": "Verify",
+      "verifying": "Verifying...",
+      "useDifferentAccount": "Use a different account",
+      "forgotPassword": "Forgot password?",
+      "passwordPlaceholder": "Enter your password",
+      "signIn": "Sign in",
+      "signingIn": "Signing in...",
+      "noAccount": "Don't have an account? ",
+      "signUp": "Sign up"
+    }
+  },
   "nav": {
     "sections": {
       "compliance": "Compliance",

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -12,6 +12,31 @@
     "en": "English",
     "fr": "Français"
   },
+  "auth": {
+    "common": {
+      "email": "E-mail",
+      "emailPlaceholder": "vous@exemple.com",
+      "password": "Mot de passe",
+      "showPassword": "Afficher le mot de passe",
+      "hidePassword": "Masquer le mot de passe"
+    },
+    "login": {
+      "title": "Bon retour",
+      "subtitle": "Saisissez vos identifiants pour accéder à votre compte",
+      "mfaTitle": "Authentification à deux facteurs",
+      "mfaSubtitle": "Saisissez le code à 6 chiffres de votre application d'authentification, ou un code de récupération",
+      "mfaCodePlaceholder": "Code à 6 chiffres ou code de récupération",
+      "verify": "Vérifier",
+      "verifying": "Vérification…",
+      "useDifferentAccount": "Utiliser un autre compte",
+      "forgotPassword": "Mot de passe oublié ?",
+      "passwordPlaceholder": "Saisissez votre mot de passe",
+      "signIn": "Se connecter",
+      "signingIn": "Connexion…",
+      "noAccount": "Vous n'avez pas de compte ? ",
+      "signUp": "S'inscrire"
+    }
+  },
   "nav": {
     "sections": {
       "compliance": "Conformité",


### PR DESCRIPTION
i18n **batch 3** — translates the **login** form (including the MFA challenge step) to `t()`.

- `(auth)/login/page.tsx` — all visible strings via `t()` (title/subtitle, MFA copy, field labels, placeholders, show/hide, buttons, sign-up link)
- `en.json` / `fr.json` — new `auth` namespace (`auth.common` for shared email/password labels, `auth.login` for the page)

Scoped to login (highest-traffic auth page) for a focused, low-risk PR. **Next:** register, then onboarding / forgot-password / reset-password / verify-email.

Validation: `npm run build` green · `eslint` clean · EN/FR key-parity test passing.