### PR TITLE
feat(web): translate remaining auth pages — EN/FR (i18n batch 5)

### DIFF
--- a/frontend/src/app/(auth)/forgot-password/page.tsx
+++ b/frontend/src/app/(auth)/forgot-password/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
 import { Loader2, ArrowLeft, Mail } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -20,6 +21,7 @@ import { authApi, getErrorMessage } from '@/lib/api';
 import { forgotPasswordSchema, type ForgotPasswordFormData } from '@/lib/utils/validation';
 
 export default function ForgotPasswordPage() {
+  const { t } = useTranslation();
   const [error, setError] = useState<string | null>(null);
   const [isSuccess, setIsSuccess] = useState(false);
 
@@ -49,10 +51,8 @@ export default function ForgotPasswordPage() {
           <Mail className="h-6 w-6 text-primary" />
         </div>
         <div className="space-y-2">
-          <h2 className="text-2xl font-semibold tracking-tight">Check your email</h2>
-          <p className="text-sm text-muted-foreground">
-            If an account exists with that email, we&apos;ve sent password reset instructions.
-          </p>
+          <h2 className="text-2xl font-semibold tracking-tight">{t('auth.forgot.successTitle')}</h2>
+          <p className="text-sm text-muted-foreground">{t('auth.forgot.successSubtitle')}</p>
         </div>
         <div className="space-y-3">
           <Button
@@ -63,12 +63,12 @@ export default function ForgotPasswordPage() {
               form.reset();
             }}
           >
-            Try another email
+            {t('auth.forgot.tryAnother')}
           </Button>
           <Link href="/login">
             <Button variant="ghost" className="w-full">
               <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to login
+              {t('auth.forgot.backToLogin')}
             </Button>
           </Link>
         </div>
@@ -79,10 +79,8 @@ export default function ForgotPasswordPage() {
   return (
     <div className="space-y-6">
       <div className="space-y-2 text-center">
-        <h2 className="text-2xl font-semibold tracking-tight">Forgot password?</h2>
-        <p className="text-sm text-muted-foreground">
-          Enter your email and we&apos;ll send you a reset link
-        </p>
+        <h2 className="text-2xl font-semibold tracking-tight">{t('auth.forgot.title')}</h2>
+        <p className="text-sm text-muted-foreground">{t('auth.forgot.subtitle')}</p>
       </div>
 
       {error && (
@@ -98,11 +96,11 @@ export default function ForgotPasswordPage() {
             name="email"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Email</FormLabel>
+                <FormLabel>{t('auth.common.email')}</FormLabel>
                 <FormControl>
                   <Input
                     type="email"
-                    placeholder="you@example.com"
+                    placeholder={t('auth.common.emailPlaceholder')}
                     autoComplete="email"
                     disabled={isSubmitting}
                     {...field}
@@ -117,10 +115,10 @@ export default function ForgotPasswordPage() {
             {isSubmitting ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Sending...
+                {t('auth.forgot.sending')}
               </>
             ) : (
-              'Send reset link'
+              t('auth.forgot.sendLink')
             )}
           </Button>
         </form>
@@ -132,7 +130,7 @@ export default function ForgotPasswordPage() {
           className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center"
         >
           <ArrowLeft className="mr-1 h-3 w-3" />
-          Back to login
+          {t('auth.forgot.backToLogin')}
         </Link>
       </div>
     </div>

--- a/frontend/src/app/(auth)/onboarding/page.tsx
+++ b/frontend/src/app/(auth)/onboarding/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
 import { Loader2, Building2 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -39,6 +40,7 @@ const onboardingSchema = z.object({
 type OnboardingFormData = z.infer<typeof onboardingSchema>;
 
 export default function OnboardingPage() {
+  const { t } = useTranslation();
   const router = useRouter();
   const { user, isAuthenticated, isInitialized } = useAuthStore();
   const { syncCurrentUser } = useAuthSession();
@@ -75,7 +77,7 @@ export default function OnboardingPage() {
         country: data.country || '',
       });
       await syncCurrentUser();
-      toast.success(`${data.name} created! Welcome to Retrieva.`);
+      toast.success(t('auth.onboarding.toastSuccess', { name: data.name }));
       router.push('/assessments');
     } catch (err) {
       setError(getErrorMessage(err));
@@ -90,10 +92,8 @@ export default function OnboardingPage() {
     <div className="space-y-6">
       <div className="space-y-2 text-center">
         <Building2 className="h-10 w-10 mx-auto text-primary" />
-        <h2 className="text-2xl font-semibold tracking-tight">Create your organization</h2>
-        <p className="text-sm text-muted-foreground">
-          Set up your company account to manage DORA compliance for all vendors
-        </p>
+        <h2 className="text-2xl font-semibold tracking-tight">{t('auth.onboarding.title')}</h2>
+        <p className="text-sm text-muted-foreground">{t('auth.onboarding.subtitle')}</p>
       </div>
 
       {error && (
@@ -109,10 +109,10 @@ export default function OnboardingPage() {
             name="name"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Organization name</FormLabel>
+                <FormLabel>{t('auth.onboarding.orgName')}</FormLabel>
                 <FormControl>
                   <Input
-                    placeholder="HDI Global SE"
+                    placeholder={t('auth.onboarding.orgNamePlaceholder')}
                     disabled={isSubmitting}
                     {...field}
                   />
@@ -127,7 +127,7 @@ export default function OnboardingPage() {
             name="industry"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Industry</FormLabel>
+                <FormLabel>{t('auth.onboarding.industry')}</FormLabel>
                 <Select
                   onValueChange={field.onChange}
                   defaultValue={field.value}
@@ -135,15 +135,15 @@ export default function OnboardingPage() {
                 >
                   <FormControl>
                     <SelectTrigger>
-                      <SelectValue placeholder="Select industry" />
+                      <SelectValue placeholder={t('auth.onboarding.industryPlaceholder')} />
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    <SelectItem value="insurance">Insurance</SelectItem>
-                    <SelectItem value="banking">Banking</SelectItem>
-                    <SelectItem value="investment">Investment / Asset Management</SelectItem>
-                    <SelectItem value="payments">Payments</SelectItem>
-                    <SelectItem value="other">Other Financial Services</SelectItem>
+                    <SelectItem value="insurance">{t('auth.onboarding.industries.insurance')}</SelectItem>
+                    <SelectItem value="banking">{t('auth.onboarding.industries.banking')}</SelectItem>
+                    <SelectItem value="investment">{t('auth.onboarding.industries.investment')}</SelectItem>
+                    <SelectItem value="payments">{t('auth.onboarding.industries.payments')}</SelectItem>
+                    <SelectItem value="other">{t('auth.onboarding.industries.other')}</SelectItem>
                   </SelectContent>
                 </Select>
                 <FormMessage />
@@ -156,10 +156,13 @@ export default function OnboardingPage() {
             name="country"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Country <span className="text-muted-foreground">(optional)</span></FormLabel>
+                <FormLabel>
+                  {t('auth.onboarding.country')}{' '}
+                  <span className="text-muted-foreground">({t('auth.onboarding.optional')})</span>
+                </FormLabel>
                 <FormControl>
                   <Input
-                    placeholder="Germany"
+                    placeholder={t('auth.onboarding.countryPlaceholder')}
                     disabled={isSubmitting}
                     {...field}
                   />
@@ -173,10 +176,10 @@ export default function OnboardingPage() {
             {isSubmitting ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Creating organization...
+                {t('auth.onboarding.creating')}
               </>
             ) : (
-              'Create organization'
+              t('auth.onboarding.create')
             )}
           </Button>
         </form>

--- a/frontend/src/app/(auth)/reset-password/page.tsx
+++ b/frontend/src/app/(auth)/reset-password/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
 import { Loader2, Eye, EyeOff, Check, ArrowLeft } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -21,6 +22,7 @@ import { authApi, getErrorMessage } from '@/lib/api';
 import { resetPasswordSchema, type ResetPasswordFormData } from '@/lib/utils/validation';
 
 function ResetPasswordForm() {
+  const { t } = useTranslation();
   const searchParams = useSearchParams();
   const token = searchParams.get('token');
 
@@ -41,7 +43,7 @@ function ResetPasswordForm() {
 
   const onSubmit = async (data: ResetPasswordFormData) => {
     if (!token) {
-      setError('Invalid reset link. Please request a new password reset.');
+      setError(t('auth.reset.invalidLinkError'));
       return;
     }
 
@@ -58,13 +60,11 @@ function ResetPasswordForm() {
     return (
       <div className="space-y-6 text-center">
         <div className="space-y-2">
-          <h2 className="text-2xl font-semibold tracking-tight">Invalid Link</h2>
-          <p className="text-sm text-muted-foreground">
-            This password reset link is invalid or has expired.
-          </p>
+          <h2 className="text-2xl font-semibold tracking-tight">{t('auth.reset.invalidTitle')}</h2>
+          <p className="text-sm text-muted-foreground">{t('auth.reset.invalidSubtitle')}</p>
         </div>
         <Link href="/forgot-password">
-          <Button className="w-full">Request new reset link</Button>
+          <Button className="w-full">{t('auth.reset.requestNew')}</Button>
         </Link>
       </div>
     );
@@ -77,13 +77,11 @@ function ResetPasswordForm() {
           <Check className="h-6 w-6 text-success" />
         </div>
         <div className="space-y-2">
-          <h2 className="text-2xl font-semibold tracking-tight">Password reset!</h2>
-          <p className="text-sm text-muted-foreground">
-            Your password has been successfully reset. You can now log in with your new password.
-          </p>
+          <h2 className="text-2xl font-semibold tracking-tight">{t('auth.reset.successTitle')}</h2>
+          <p className="text-sm text-muted-foreground">{t('auth.reset.successSubtitle')}</p>
         </div>
         <Link href="/login">
-          <Button className="w-full">Go to login</Button>
+          <Button className="w-full">{t('auth.reset.goToLogin')}</Button>
         </Link>
       </div>
     );
@@ -92,8 +90,8 @@ function ResetPasswordForm() {
   return (
     <div className="space-y-6">
       <div className="space-y-2 text-center">
-        <h2 className="text-2xl font-semibold tracking-tight">Reset password</h2>
-        <p className="text-sm text-muted-foreground">Enter your new password below</p>
+        <h2 className="text-2xl font-semibold tracking-tight">{t('auth.reset.title')}</h2>
+        <p className="text-sm text-muted-foreground">{t('auth.reset.subtitle')}</p>
       </div>
 
       {error && (
@@ -109,12 +107,12 @@ function ResetPasswordForm() {
             name="password"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>New Password</FormLabel>
+                <FormLabel>{t('auth.reset.newPassword')}</FormLabel>
                 <FormControl>
                   <div className="relative">
                     <Input
                       type={showPassword ? 'text' : 'password'}
-                      placeholder="Enter new password"
+                      placeholder={t('auth.reset.newPasswordPlaceholder')}
                       autoComplete="new-password"
                       disabled={isSubmitting}
                       {...field}
@@ -145,12 +143,12 @@ function ResetPasswordForm() {
             name="confirmPassword"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Confirm New Password</FormLabel>
+                <FormLabel>{t('auth.reset.confirmNewPassword')}</FormLabel>
                 <FormControl>
                   <div className="relative">
                     <Input
                       type={showConfirmPassword ? 'text' : 'password'}
-                      placeholder="Confirm new password"
+                      placeholder={t('auth.reset.confirmNewPasswordPlaceholder')}
                       autoComplete="new-password"
                       disabled={isSubmitting}
                       {...field}
@@ -180,10 +178,10 @@ function ResetPasswordForm() {
             {isSubmitting ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Resetting password...
+                {t('auth.reset.resetting')}
               </>
             ) : (
-              'Reset password'
+              t('auth.reset.title')
             )}
           </Button>
         </form>
@@ -195,7 +193,7 @@ function ResetPasswordForm() {
           className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center"
         >
           <ArrowLeft className="mr-1 h-3 w-3" />
-          Back to login
+          {t('auth.reset.backToLogin')}
         </Link>
       </div>
     </div>

--- a/frontend/src/app/(auth)/verify-email/page.tsx
+++ b/frontend/src/app/(auth)/verify-email/page.tsx
@@ -3,12 +3,14 @@
 import { useState, useEffect, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
 import { Loader2, Check, X } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { authApi, getErrorMessage } from '@/lib/api';
 
 function VerifyEmailContent() {
+  const { t } = useTranslation();
   const searchParams = useSearchParams();
   const token = searchParams.get('token');
 
@@ -19,7 +21,7 @@ function VerifyEmailContent() {
     const verifyEmail = async () => {
       if (!token) {
         setStatus('error');
-        setError('Invalid verification link. Please request a new verification email.');
+        setError(t('auth.verifyEmail.invalidLink'));
         return;
       }
 
@@ -33,7 +35,7 @@ function VerifyEmailContent() {
     };
 
     verifyEmail();
-  }, [token]);
+  }, [token, t]);
 
   if (status === 'loading') {
     return (
@@ -42,8 +44,12 @@ function VerifyEmailContent() {
           <Loader2 className="h-6 w-6 text-primary animate-spin" />
         </div>
         <div className="space-y-2">
-          <h2 className="text-2xl font-semibold tracking-tight">Verifying your email...</h2>
-          <p className="text-sm text-muted-foreground">Please wait while we verify your email address.</p>
+          <h2 className="text-2xl font-semibold tracking-tight">
+            {t('auth.verifyEmail.verifyingTitle')}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {t('auth.verifyEmail.verifyingSubtitle')}
+          </p>
         </div>
       </div>
     );
@@ -56,13 +62,13 @@ function VerifyEmailContent() {
           <Check className="h-6 w-6 text-success" />
         </div>
         <div className="space-y-2">
-          <h2 className="text-2xl font-semibold tracking-tight">Email verified!</h2>
-          <p className="text-sm text-muted-foreground">
-            Your email has been successfully verified. You can now access all features.
-          </p>
+          <h2 className="text-2xl font-semibold tracking-tight">
+            {t('auth.verifyEmail.successTitle')}
+          </h2>
+          <p className="text-sm text-muted-foreground">{t('auth.verifyEmail.successSubtitle')}</p>
         </div>
         <Link href="/">
-          <Button className="w-full">Go to Dashboard</Button>
+          <Button className="w-full">{t('auth.verifyEmail.goToDashboard')}</Button>
         </Link>
       </div>
     );
@@ -74,16 +80,30 @@ function VerifyEmailContent() {
         <X className="h-6 w-6 text-destructive" />
       </div>
       <div className="space-y-2">
-        <h2 className="text-2xl font-semibold tracking-tight">Verification failed</h2>
+        <h2 className="text-2xl font-semibold tracking-tight">
+          {t('auth.verifyEmail.failedTitle')}
+        </h2>
         <p className="text-sm text-muted-foreground">{error}</p>
       </div>
       <div className="space-y-3">
         <Link href="/login">
-          <Button className="w-full">Go to Login</Button>
+          <Button className="w-full">{t('auth.verifyEmail.goToLogin')}</Button>
         </Link>
-        <p className="text-xs text-muted-foreground">
-          Need a new verification email? Log in and request one from your account settings.
-        </p>
+        <p className="text-xs text-muted-foreground">{t('auth.verifyEmail.needNew')}</p>
+      </div>
+    </div>
+  );
+}
+
+function VerifyEmailFallback() {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-6 text-center">
+      <div className="mx-auto w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center">
+        <Loader2 className="h-6 w-6 text-primary animate-spin" />
+      </div>
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold tracking-tight">{t('auth.verifyEmail.loading')}</h2>
       </div>
     </div>
   );
@@ -91,18 +111,7 @@ function VerifyEmailContent() {
 
 export default function VerifyEmailPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="space-y-6 text-center">
-          <div className="mx-auto w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center">
-            <Loader2 className="h-6 w-6 text-primary animate-spin" />
-          </div>
-          <div className="space-y-2">
-            <h2 className="text-2xl font-semibold tracking-tight">Loading...</h2>
-          </div>
-        </div>
-      }
-    >
+    <Suspense fallback={<VerifyEmailFallback />}>
       <VerifyEmailContent />
     </Suspense>
   );

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -62,6 +62,66 @@
         "number": "One number",
         "special": "One special character (!@#$...)"
       }
+    },
+    "verifyEmail": {
+      "verifyingTitle": "Verifying your email...",
+      "verifyingSubtitle": "Please wait while we verify your email address.",
+      "successTitle": "Email verified!",
+      "successSubtitle": "Your email has been successfully verified. You can now access all features.",
+      "goToDashboard": "Go to Dashboard",
+      "failedTitle": "Verification failed",
+      "goToLogin": "Go to Login",
+      "needNew": "Need a new verification email? Log in and request one from your account settings.",
+      "invalidLink": "Invalid verification link. Please request a new verification email.",
+      "loading": "Loading..."
+    },
+    "forgot": {
+      "title": "Forgot password?",
+      "subtitle": "Enter your email and we'll send you a reset link",
+      "successTitle": "Check your email",
+      "successSubtitle": "If an account exists with that email, we've sent password reset instructions.",
+      "tryAnother": "Try another email",
+      "backToLogin": "Back to login",
+      "sending": "Sending...",
+      "sendLink": "Send reset link"
+    },
+    "reset": {
+      "title": "Reset password",
+      "subtitle": "Enter your new password below",
+      "invalidTitle": "Invalid Link",
+      "invalidSubtitle": "This password reset link is invalid or has expired.",
+      "invalidLinkError": "Invalid reset link. Please request a new password reset.",
+      "requestNew": "Request new reset link",
+      "successTitle": "Password reset!",
+      "successSubtitle": "Your password has been successfully reset. You can now log in with your new password.",
+      "goToLogin": "Go to login",
+      "newPassword": "New Password",
+      "newPasswordPlaceholder": "Enter new password",
+      "confirmNewPassword": "Confirm New Password",
+      "confirmNewPasswordPlaceholder": "Confirm new password",
+      "resetting": "Resetting password...",
+      "backToLogin": "Back to login"
+    },
+    "onboarding": {
+      "title": "Create your organization",
+      "subtitle": "Set up your company account to manage DORA compliance for all vendors",
+      "orgName": "Organization name",
+      "orgNamePlaceholder": "HDI Global SE",
+      "industry": "Industry",
+      "industryPlaceholder": "Select industry",
+      "industries": {
+        "insurance": "Insurance",
+        "banking": "Banking",
+        "investment": "Investment / Asset Management",
+        "payments": "Payments",
+        "other": "Other Financial Services"
+      },
+      "country": "Country",
+      "optional": "optional",
+      "countryPlaceholder": "Germany",
+      "creating": "Creating organization...",
+      "create": "Create organization",
+      "toastSuccess": "{{name}} created! Welcome to Retrieva."
     }
   },
   "nav": {

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -62,6 +62,66 @@
         "number": "Un chiffre",
         "special": "Un caractère spécial (!@#$…)"
       }
+    },
+    "verifyEmail": {
+      "verifyingTitle": "Vérification de votre e-mail…",
+      "verifyingSubtitle": "Veuillez patienter pendant la vérification de votre adresse e-mail.",
+      "successTitle": "E-mail vérifié !",
+      "successSubtitle": "Votre e-mail a été vérifié avec succès. Vous pouvez désormais accéder à toutes les fonctionnalités.",
+      "goToDashboard": "Accéder au tableau de bord",
+      "failedTitle": "Échec de la vérification",
+      "goToLogin": "Aller à la connexion",
+      "needNew": "Besoin d'un nouvel e-mail de vérification ? Connectez-vous et demandez-en un depuis les paramètres de votre compte.",
+      "invalidLink": "Lien de vérification invalide. Veuillez demander un nouvel e-mail de vérification.",
+      "loading": "Chargement…"
+    },
+    "forgot": {
+      "title": "Mot de passe oublié ?",
+      "subtitle": "Saisissez votre e-mail et nous vous enverrons un lien de réinitialisation",
+      "successTitle": "Vérifiez votre e-mail",
+      "successSubtitle": "Si un compte existe pour cet e-mail, nous avons envoyé les instructions de réinitialisation du mot de passe.",
+      "tryAnother": "Essayer un autre e-mail",
+      "backToLogin": "Retour à la connexion",
+      "sending": "Envoi…",
+      "sendLink": "Envoyer le lien de réinitialisation"
+    },
+    "reset": {
+      "title": "Réinitialiser le mot de passe",
+      "subtitle": "Saisissez votre nouveau mot de passe ci-dessous",
+      "invalidTitle": "Lien invalide",
+      "invalidSubtitle": "Ce lien de réinitialisation du mot de passe est invalide ou a expiré.",
+      "invalidLinkError": "Lien de réinitialisation invalide. Veuillez demander une nouvelle réinitialisation du mot de passe.",
+      "requestNew": "Demander un nouveau lien de réinitialisation",
+      "successTitle": "Mot de passe réinitialisé !",
+      "successSubtitle": "Votre mot de passe a été réinitialisé avec succès. Vous pouvez désormais vous connecter avec votre nouveau mot de passe.",
+      "goToLogin": "Aller à la connexion",
+      "newPassword": "Nouveau mot de passe",
+      "newPasswordPlaceholder": "Saisissez le nouveau mot de passe",
+      "confirmNewPassword": "Confirmer le nouveau mot de passe",
+      "confirmNewPasswordPlaceholder": "Confirmez le nouveau mot de passe",
+      "resetting": "Réinitialisation…",
+      "backToLogin": "Retour à la connexion"
+    },
+    "onboarding": {
+      "title": "Créez votre organisation",
+      "subtitle": "Configurez le compte de votre entreprise pour gérer la conformité DORA de tous vos prestataires",
+      "orgName": "Nom de l'organisation",
+      "orgNamePlaceholder": "HDI Global SE",
+      "industry": "Secteur",
+      "industryPlaceholder": "Sélectionnez un secteur",
+      "industries": {
+        "insurance": "Assurance",
+        "banking": "Banque",
+        "investment": "Investissement / Gestion d'actifs",
+        "payments": "Paiements",
+        "other": "Autres services financiers"
+      },
+      "country": "Pays",
+      "optional": "facultatif",
+      "countryPlaceholder": "Allemagne",
+      "creating": "Création de l'organisation…",
+      "create": "Créer l'organisation",
+      "toastSuccess": "{{name}} créée ! Bienvenue sur Retrieva."
     }
   },
   "nav": {


### PR DESCRIPTION
i18n batch 5 — completes the auth surface: onboarding (org/industry/country + success toast), forgot-password, reset-password, verify-email. Adds auth.onboarding/forgot/reset/verifyEmail namespaces. Entire auth flow is now EN/FR. Build green, eslint clean, key-parity test passing. Next: dashboard feature areas.