### PR TITLE
feat(web): translate questionnaires list — EN/FR (i18n batch 7)

### DIFF
--- a/frontend/src/features/questionnaires/components/questionnaires-page.tsx
+++ b/frontend/src/features/questionnaires/components/questionnaires-page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
 import { Plus, ClipboardList, Trash2, Copy, Check, Loader2, AlertCircle, FileSpreadsheet } from 'lucide-react';
 import { toast } from 'sonner';
@@ -44,15 +45,6 @@ const STATUS_VARIANT: Record<QuestionnaireStatus, 'default' | 'secondary' | 'des
   failed: 'destructive',
 };
 
-const STATUS_LABEL: Record<QuestionnaireStatus, string> = {
-  draft: 'Draft',
-  sent: 'Sent',
-  partial: 'Responding',
-  complete: 'Complete',
-  expired: 'Expired',
-  failed: 'Failed',
-};
-
 function ScoreCell({ q }: { q: VendorQuestionnaire }) {
   if (q.status !== 'complete' || q.overallScore === undefined) {
     return <span className="text-muted-foreground">-</span>;
@@ -68,6 +60,7 @@ function ScoreCell({ q }: { q: VendorQuestionnaire }) {
 }
 
 export function QuestionnairesPage() {
+  const { t } = useTranslation();
   const router = useRouter();
   const queryClient = useQueryClient();
   const activeWorkspace = useActiveWorkspace();
@@ -83,23 +76,23 @@ export function QuestionnairesPage() {
   const deleteMutation = useMutation({
     mutationFn: (id: string) => questionnairesApi.delete(id),
     onSuccess: () => {
-      toast.success('Questionnaire deleted');
+      toast.success(t('questionnaires.toast.deleted'));
       queryClient.invalidateQueries({ queryKey: ['questionnaires'] });
     },
-    onError: () => toast.error('Failed to delete questionnaire'),
+    onError: () => toast.error(t('questionnaires.toast.deleteFailed')),
     onSettled: () => setDeletingId(null),
   });
 
   const exportMutation = useMutation({
     mutationFn: () => workspacesApi.exportRoi(),
-    onError: () => toast.error('Export failed', {
-      description: 'Could not generate the RoI workbook.',
+    onError: () => toast.error(t('questionnaires.toast.exportFailed'), {
+      description: t('questionnaires.toast.exportFailedDesc'),
     }),
   });
 
   const copyVendorLink = (questionnaire: VendorQuestionnaire) => {
     if (!questionnaire.token) {
-      toast.error('No link yet - send the questionnaire first');
+      toast.error(t('questionnaires.toast.noLink'));
       return;
     }
 
@@ -107,7 +100,7 @@ export function QuestionnairesPage() {
     const link = `${baseUrl}/q/${questionnaire.token}`;
     navigator.clipboard.writeText(link).then(() => {
       setCopiedId(questionnaire._id);
-      toast.success('Vendor link copied to clipboard');
+      toast.success(t('questionnaires.toast.linkCopied'));
       setTimeout(() => setCopiedId(null), 2000);
     });
   };
@@ -115,7 +108,7 @@ export function QuestionnairesPage() {
   if (!activeWorkspace) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-muted-foreground">Select a workspace first</p>
+        <p className="text-muted-foreground">{t('questionnaires.selectWorkspace')}</p>
       </div>
     );
   }
@@ -126,11 +119,9 @@ export function QuestionnairesPage() {
         <div>
           <h1 className="page-title flex items-center gap-2">
             <ClipboardList className="h-6 w-6" />
-            Questionnaires
+            {t('questionnaires.title')}
           </h1>
-          <p className="text-muted-foreground mt-1">
-            DORA Art.28/30 vendor due diligence questionnaires
-          </p>
+          <p className="text-muted-foreground mt-1">{t('questionnaires.subtitle')}</p>
         </div>
         <div className="flex items-center gap-2">
           <Button
@@ -143,11 +134,11 @@ export function QuestionnairesPage() {
             ) : (
               <FileSpreadsheet className="h-4 w-4 mr-2" />
             )}
-            Export RoI (Excel)
+            {t('questionnaires.exportRoi')}
           </Button>
           <Button onClick={() => router.push('/questionnaires/new')}>
             <Plus className="h-4 w-4 mr-2" />
-            Send Questionnaire
+            {t('questionnaires.send')}
           </Button>
         </div>
       </div>
@@ -161,27 +152,27 @@ export function QuestionnairesPage() {
       ) : isError ? (
         <div className="flex items-center gap-2 text-destructive p-4">
           <AlertCircle className="h-5 w-5" />
-          <span>Failed to load questionnaires. Please refresh.</span>
+          <span>{t('questionnaires.loadError')}</span>
         </div>
       ) : !data || data.length === 0 ? (
         <EmptyState
           icon={ClipboardList}
-          heading="No questionnaires sent"
-          description="Send a structured Art. 28/30 due diligence questionnaire to a vendor. They complete it via a secure link - no Retrieva account required."
-          cta="Send a questionnaire"
+          heading={t('questionnaires.empty.heading')}
+          description={t('questionnaires.empty.description')}
+          cta={t('questionnaires.empty.cta')}
           onAction={() => router.push('/questionnaires/new')}
-          hint="Completed responses are automatically scored and feed into the Risk Register."
+          hint={t('questionnaires.empty.hint')}
         />
       ) : (
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Vendor</TableHead>
-              <TableHead>Email</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Score</TableHead>
-              <TableHead>Sent</TableHead>
-              <TableHead className="text-right">Actions</TableHead>
+              <TableHead>{t('questionnaires.cols.vendor')}</TableHead>
+              <TableHead>{t('questionnaires.cols.email')}</TableHead>
+              <TableHead>{t('questionnaires.cols.status')}</TableHead>
+              <TableHead>{t('questionnaires.cols.score')}</TableHead>
+              <TableHead>{t('questionnaires.cols.sent')}</TableHead>
+              <TableHead className="text-right">{t('questionnaires.cols.actions')}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -198,7 +189,7 @@ export function QuestionnairesPage() {
                     {(questionnaire.status === 'sent' || questionnaire.status === 'partial') && (
                       <Loader2 className="h-3 w-3 animate-spin" />
                     )}
-                    {STATUS_LABEL[questionnaire.status]}
+                    {t(`questionnaires.status.${questionnaire.status}`)}
                   </Badge>
                 </TableCell>
                 <TableCell>
@@ -212,7 +203,7 @@ export function QuestionnairesPage() {
                     <Button
                       variant="ghost"
                       size="icon"
-                      title="Copy vendor link"
+                      title={t('questionnaires.copyLink')}
                       onClick={() => copyVendorLink(questionnaire)}
                     >
                       {copiedId === questionnaire._id ? (
@@ -227,7 +218,7 @@ export function QuestionnairesPage() {
                         <Button
                           variant="ghost"
                           size="icon"
-                          title="Delete questionnaire"
+                          title={t('questionnaires.deleteTitle')}
                           onClick={() => setDeletingId(questionnaire._id)}
                         >
                           <Trash2 className="h-4 w-4 text-muted-foreground hover:text-destructive" />
@@ -235,16 +226,16 @@ export function QuestionnairesPage() {
                       </AlertDialogTrigger>
                       <AlertDialogContent>
                         <AlertDialogHeader>
-                          <AlertDialogTitle>Delete questionnaire?</AlertDialogTitle>
+                          <AlertDialogTitle>{t('questionnaires.deleteConfirmTitle')}</AlertDialogTitle>
                           <AlertDialogDescription>
-                            This will permanently delete the questionnaire for{' '}
-                            <strong>{questionnaire.vendorName}</strong> and all collected responses.
-                            This cannot be undone.
+                            {t('questionnaires.deleteConfirmDesc1')}
+                            <strong>{questionnaire.vendorName}</strong>
+                            {t('questionnaires.deleteConfirmDesc2')}
                           </AlertDialogDescription>
                         </AlertDialogHeader>
                         <AlertDialogFooter>
                           <AlertDialogCancel onClick={() => setDeletingId(null)}>
-                            Cancel
+                            {t('common.cancel')}
                           </AlertDialogCancel>
                           <AlertDialogAction
                             onClick={() => deleteMutation.mutate(questionnaire._id)}
@@ -253,7 +244,7 @@ export function QuestionnairesPage() {
                             {deleteMutation.isPending && deletingId === questionnaire._id ? (
                               <Loader2 className="h-4 w-4 animate-spin" />
                             ) : (
-                              'Delete'
+                              t('common.delete')
                             )}
                           </AlertDialogAction>
                         </AlertDialogFooter>

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -5,7 +5,9 @@
     "startFree": "Start Free",
     "pricing": "Pricing",
     "contactSales": "Contact Sales",
-    "startFreeTrial": "Start free trial"
+    "startFreeTrial": "Start free trial",
+    "cancel": "Cancel",
+    "delete": "Delete"
   },
   "language": {
     "label": "Language",
@@ -195,6 +197,49 @@
       "certs": "Certs",
       "nextReview": "Next Review",
       "compliance": "Compliance"
+    }
+  },
+  "questionnaires": {
+    "title": "Questionnaires",
+    "subtitle": "DORA Art.28/30 vendor due diligence questionnaires",
+    "exportRoi": "Export RoI (Excel)",
+    "send": "Send Questionnaire",
+    "selectWorkspace": "Select a workspace first",
+    "loadError": "Failed to load questionnaires. Please refresh.",
+    "copyLink": "Copy vendor link",
+    "deleteTitle": "Delete questionnaire",
+    "deleteConfirmTitle": "Delete questionnaire?",
+    "deleteConfirmDesc1": "This will permanently delete the questionnaire for ",
+    "deleteConfirmDesc2": " and all collected responses. This cannot be undone.",
+    "status": {
+      "draft": "Draft",
+      "sent": "Sent",
+      "partial": "Responding",
+      "complete": "Complete",
+      "expired": "Expired",
+      "failed": "Failed"
+    },
+    "cols": {
+      "vendor": "Vendor",
+      "email": "Email",
+      "status": "Status",
+      "score": "Score",
+      "sent": "Sent",
+      "actions": "Actions"
+    },
+    "empty": {
+      "heading": "No questionnaires sent",
+      "description": "Send a structured Art. 28/30 due diligence questionnaire to a vendor. They complete it via a secure link - no Retrieva account required.",
+      "cta": "Send a questionnaire",
+      "hint": "Completed responses are automatically scored and feed into the Risk Register."
+    },
+    "toast": {
+      "deleted": "Questionnaire deleted",
+      "deleteFailed": "Failed to delete questionnaire",
+      "exportFailed": "Export failed",
+      "exportFailedDesc": "Could not generate the RoI workbook.",
+      "noLink": "No link yet - send the questionnaire first",
+      "linkCopied": "Vendor link copied to clipboard"
     }
   },
   "landing": {

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -5,7 +5,9 @@
     "startFree": "Commencer gratuitement",
     "pricing": "Tarifs",
     "contactSales": "Contacter le service commercial",
-    "startFreeTrial": "Démarrer l'essai gratuit"
+    "startFreeTrial": "Démarrer l'essai gratuit",
+    "cancel": "Annuler",
+    "delete": "Supprimer"
   },
   "language": {
     "label": "Langue",
@@ -195,6 +197,49 @@
       "certs": "Certif.",
       "nextReview": "Prochaine revue",
       "compliance": "Conformité"
+    }
+  },
+  "questionnaires": {
+    "title": "Questionnaires",
+    "subtitle": "Questionnaires de due diligence fournisseurs (DORA art. 28/30)",
+    "exportRoi": "Exporter le RoI (Excel)",
+    "send": "Envoyer un questionnaire",
+    "selectWorkspace": "Sélectionnez d'abord un espace de travail",
+    "loadError": "Échec du chargement des questionnaires. Veuillez actualiser.",
+    "copyLink": "Copier le lien fournisseur",
+    "deleteTitle": "Supprimer le questionnaire",
+    "deleteConfirmTitle": "Supprimer le questionnaire ?",
+    "deleteConfirmDesc1": "Cela supprimera définitivement le questionnaire de ",
+    "deleteConfirmDesc2": " et toutes les réponses collectées. Cette action est irréversible.",
+    "status": {
+      "draft": "Brouillon",
+      "sent": "Envoyé",
+      "partial": "En cours",
+      "complete": "Terminé",
+      "expired": "Expiré",
+      "failed": "Échoué"
+    },
+    "cols": {
+      "vendor": "Fournisseur",
+      "email": "E-mail",
+      "status": "Statut",
+      "score": "Score",
+      "sent": "Envoyé le",
+      "actions": "Actions"
+    },
+    "empty": {
+      "heading": "Aucun questionnaire envoyé",
+      "description": "Envoyez un questionnaire de due diligence structuré (art. 28/30) à un fournisseur. Il le complète via un lien sécurisé — aucun compte Retrieva requis.",
+      "cta": "Envoyer un questionnaire",
+      "hint": "Les réponses complétées sont notées automatiquement et alimentent le registre des risques."
+    },
+    "toast": {
+      "deleted": "Questionnaire supprimé",
+      "deleteFailed": "Échec de la suppression du questionnaire",
+      "exportFailed": "Échec de l'export",
+      "exportFailedDesc": "Impossible de générer le classeur RoI.",
+      "noLink": "Pas encore de lien — envoyez d'abord le questionnaire",
+      "linkCopied": "Lien fournisseur copié dans le presse-papiers"
     }
   },
   "landing": {


### PR DESCRIPTION
i18n batch 7 — questionnaires list page: header, export/send buttons, status labels, table headers, empty state, delete-confirm dialog, toasts. Adds questionnaires namespace + reusable common.cancel/common.delete. Build green, eslint clean, key-parity test passing. Next: questionnaire detail + new form.