### PR TITLE
feat(web): translate assessments list + new form — EN/FR (i18n batch 10)

### DIFF
--- a/frontend/src/app/(dashboard)/assessments/new/page.tsx
+++ b/frontend/src/app/(dashboard)/assessments/new/page.tsx
@@ -6,6 +6,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
 import { ArrowLeft, Loader2, RotateCcw } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -36,15 +37,20 @@ interface FileWithId extends File {
   id: string;
 }
 
-function buildAssessmentName(vendor: string, fw: 'DORA' | 'CONTRACT_A30'): string {
+function buildAssessmentName(
+  vendor: string,
+  typeLabel: string,
+  locale: string,
+  vendorFallback: string,
+): string {
   const now = new Date();
-  const month = now.toLocaleString('en-US', { month: 'short' });
+  const month = now.toLocaleString(locale === 'fr' ? 'fr-FR' : 'en-US', { month: 'short' });
   const year = now.getFullYear();
-  const type = fw === 'CONTRACT_A30' ? 'Art.30 Contract Review' : 'DORA Gap Analysis';
-  return `${vendor.trim() || 'Vendor'} — ${type} ${month} ${year}`;
+  return `${vendor.trim() || vendorFallback} — ${typeLabel} ${month} ${year}`;
 }
 
 export default function NewAssessmentPage() {
+  const { t, i18n } = useTranslation();
   const router = useRouter();
   const activeWorkspace = useActiveWorkspace();
   const [files, setFiles] = useState<FileWithId[]>([]);
@@ -58,6 +64,16 @@ export default function NewAssessmentPage() {
 
   const vendorName = form.watch('vendorName');
 
+  const computeName = () =>
+    buildAssessmentName(
+      vendorName,
+      framework === 'CONTRACT_A30'
+        ? t('assessments.form.nameTypeA30')
+        : t('assessments.form.nameTypeDora'),
+      i18n.language,
+      t('assessments.form.vendorFallback'),
+    );
+
   // Seed vendorName (and auto name) once the workspace is available
   useEffect(() => {
     if (!activeWorkspace?.name) return;
@@ -68,13 +84,13 @@ export default function NewAssessmentPage() {
   // Auto-regenerate assessment name whenever vendor or framework changes
   useEffect(() => {
     if (!nameIsAuto) return;
-    form.setValue('name', buildAssessmentName(vendorName, framework));
+    form.setValue('name', computeName());
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [vendorName, framework, nameIsAuto]);
+  }, [vendorName, framework, nameIsAuto, i18n.language]);
 
   const createMutation = useMutation({
     mutationFn: async (values: FormValues) => {
-      if (files.length === 0) throw new Error('Please upload at least one document.');
+      if (files.length === 0) throw new Error(t('assessments.form.uploadAtLeastOne'));
       const formData = new FormData();
       formData.append('name', values.name);
       formData.append('vendorName', values.vendorName);
@@ -85,7 +101,7 @@ export default function NewAssessmentPage() {
     },
     onSuccess: (res) => {
       const id = res.data?.assessment?._id;
-      toast.success('Assessment created — indexing documents…');
+      toast.success(t('assessments.form.toastCreated'));
       router.push(id ? `/assessments/${id}` : '/assessments');
     },
     onError: (err) => {
@@ -96,7 +112,7 @@ export default function NewAssessmentPage() {
   if (!activeWorkspace) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-muted-foreground">Select a workspace first</p>
+        <p className="text-muted-foreground">{t('assessments.form.selectWorkspace')}</p>
       </div>
     );
   }
@@ -111,18 +127,20 @@ export default function NewAssessmentPage() {
         onClick={() => router.push('/assessments')}
       >
         <ArrowLeft className="h-4 w-4 mr-1" />
-        Assessments
+        {t('assessments.form.back')}
       </Button>
 
       {/* Header */}
       <div>
         <h1 className="font-display text-3xl font-semibold tracking-tight">
-          {framework === 'CONTRACT_A30' ? 'New Contract Review (Art. 30)' : 'New DORA Assessment'}
+          {framework === 'CONTRACT_A30'
+            ? t('assessments.form.titleA30')
+            : t('assessments.form.titleDora')}
         </h1>
         <p className="text-muted-foreground mt-1">
           {framework === 'CONTRACT_A30'
-            ? 'Upload the ICT contract to check all 12 mandatory DORA Article 30 clauses.'
-            : 'Upload vendor ICT documentation to run a gap analysis against Regulation (EU) 2022/2554.'}
+            ? t('assessments.form.subtitleA30')
+            : t('assessments.form.subtitleDora')}
         </p>
       </div>
 
@@ -134,7 +152,7 @@ export default function NewAssessmentPage() {
         >
           {/* Framework toggle */}
           <div className="space-y-2">
-            <p className="text-sm font-medium leading-none">Assessment type</p>
+            <p className="text-sm font-medium leading-none">{t('assessments.form.type')}</p>
             <div className="flex gap-2">
               <Button
                 type="button"
@@ -142,7 +160,7 @@ export default function NewAssessmentPage() {
                 size="sm"
                 onClick={() => setFramework('DORA')}
               >
-                Gap Analysis (Art. 28/29)
+                {t('assessments.form.typeDora')}
               </Button>
               <Button
                 type="button"
@@ -150,7 +168,7 @@ export default function NewAssessmentPage() {
                 size="sm"
                 onClick={() => setFramework('CONTRACT_A30')}
               >
-                Contract Review (Art. 30)
+                {t('assessments.form.typeA30')}
               </Button>
             </div>
           </div>
@@ -160,12 +178,12 @@ export default function NewAssessmentPage() {
             name="vendorName"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Vendor name</FormLabel>
+                <FormLabel>{t('assessments.form.vendorName')}</FormLabel>
                 <FormControl>
-                  <Input placeholder="e.g. Acme Cloud Services" {...field} />
+                  <Input placeholder={t('assessments.form.vendorNamePlaceholder')} {...field} />
                 </FormControl>
                 <FormDescription>
-                  Pre-filled from your workspace. Edit if needed.
+                  {t('assessments.form.vendorNameDesc')}
                 </FormDescription>
                 <FormMessage />
               </FormItem>
@@ -178,18 +196,18 @@ export default function NewAssessmentPage() {
             render={({ field }) => (
               <FormItem>
                 <div className="flex items-center justify-between">
-                  <FormLabel>Assessment name</FormLabel>
+                  <FormLabel>{t('assessments.form.name')}</FormLabel>
                   {!nameIsAuto && (
                     <button
                       type="button"
                       className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
                       onClick={() => {
                         setNameIsAuto(true);
-                        form.setValue('name', buildAssessmentName(vendorName, framework));
+                        form.setValue('name', computeName());
                       }}
                     >
                       <RotateCcw className="h-3 w-3" />
-                      Reset to auto
+                      {t('assessments.form.resetAuto')}
                     </button>
                   )}
                 </div>
@@ -204,8 +222,8 @@ export default function NewAssessmentPage() {
                 </FormControl>
                 <FormDescription>
                   {nameIsAuto
-                    ? 'Auto-generated from vendor name and assessment type.'
-                    : 'Custom label — edit freely or reset to auto.'}
+                    ? t('assessments.form.nameDescAuto')
+                    : t('assessments.form.nameDescCustom')}
                 </FormDescription>
                 <FormMessage />
               </FormItem>
@@ -215,12 +233,14 @@ export default function NewAssessmentPage() {
           {/* File upload */}
           <div className="space-y-2">
             <p className="text-sm font-medium leading-none">
-              {framework === 'CONTRACT_A30' ? 'Contract document' : 'Vendor documents'}
+              {framework === 'CONTRACT_A30'
+                ? t('assessments.form.docsA30')
+                : t('assessments.form.docsDora')}
             </p>
             <FileUploadZone files={files} onChange={setFiles} />
             {files.length === 0 && createMutation.isError && (
               <p className="text-xs text-destructive">
-                Please upload at least one document.
+                {t('assessments.form.uploadAtLeastOne')}
               </p>
             )}
           </div>
@@ -232,7 +252,7 @@ export default function NewAssessmentPage() {
               onClick={() => router.push('/assessments')}
               disabled={createMutation.isPending}
             >
-              Cancel
+              {t('common.cancel')}
             </Button>
             <Button
               type="submit"
@@ -241,10 +261,10 @@ export default function NewAssessmentPage() {
               {createMutation.isPending ? (
                 <>
                   <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Uploading…
+                  {t('assessments.form.uploading')}
                 </>
               ) : (
-                'Start Assessment'
+                t('assessments.form.start')
               )}
             </Button>
           </div>

--- a/frontend/src/features/assessments/components/assessments-page.tsx
+++ b/frontend/src/features/assessments/components/assessments-page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
 import { Plus, ShieldCheck, Trash2, FileDown, AlertCircle, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
@@ -49,6 +50,7 @@ const RISK_VARIANT: Record<OverallRisk, 'default' | 'secondary' | 'destructive'>
 };
 
 export function AssessmentsPage() {
+  const { t } = useTranslation();
   const router = useRouter();
   const queryClient = useQueryClient();
   const activeWorkspace = useActiveWorkspace();
@@ -63,23 +65,23 @@ export function AssessmentsPage() {
   const deleteMutation = useMutation({
     mutationFn: (id: string) => assessmentsApi.delete(id),
     onSuccess: () => {
-      toast.success('Assessment deleted');
+      toast.success(t('assessments.toast.deleted'));
       queryClient.invalidateQueries({ queryKey: ['assessments'] });
     },
-    onError: () => toast.error('Failed to delete assessment'),
+    onError: () => toast.error(t('assessments.toast.deleteFailed')),
     onSettled: () => setDeletingId(null),
   });
 
   const downloadMutation = useMutation({
     mutationFn: ({ id, vendorName, framework }: { id: string; vendorName: string; framework: Assessment['framework'] }) =>
       assessmentsApi.downloadReport(id, vendorName, framework),
-    onError: () => toast.error('Failed to download report'),
+    onError: () => toast.error(t('assessments.toast.downloadFailed')),
   });
 
   if (!activeWorkspace) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-muted-foreground">Select a workspace to view assessments</p>
+        <p className="text-muted-foreground">{t('assessments.selectWorkspace')}</p>
       </div>
     );
   }
@@ -88,14 +90,14 @@ export function AssessmentsPage() {
     <div className="p-6 space-y-6">
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="page-title">DORA Assessments</h1>
+          <h1 className="page-title">{t('assessments.title')}</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Third-party ICT risk assessments under Regulation (EU) 2022/2554
+            {t('assessments.subtitle')}
           </p>
         </div>
         <Button onClick={() => router.push('/assessments/new')}>
           <Plus className="h-4 w-4 mr-2" />
-          New Assessment
+          {t('assessments.newButton')}
         </Button>
       </div>
 
@@ -108,28 +110,28 @@ export function AssessmentsPage() {
       ) : isError ? (
         <div className="flex items-center gap-2 text-destructive p-4 rounded-md border border-destructive/30 bg-destructive/10">
           <AlertCircle className="h-4 w-4 shrink-0" />
-          <p className="text-sm">Failed to load assessments.</p>
+          <p className="text-sm">{t('assessments.loadError')}</p>
         </div>
       ) : data?.length === 0 ? (
         <EmptyState
           icon={ShieldCheck}
-          heading="No gap analyses yet"
-          description="Upload vendor ICT documentation to identify DORA Article 28/29 compliance gaps using AI-powered analysis."
-          cta="Run your first gap analysis"
+          heading={t('assessments.empty.heading')}
+          description={t('assessments.empty.description')}
+          cta={t('assessments.empty.cta')}
           onAction={() => router.push('/assessments/new')}
-          hint="Supported formats: PDF, Word. Results include gap findings, risk level, and remediation recommendations."
+          hint={t('assessments.empty.hint')}
         />
       ) : (
         <div className="rounded-md border overflow-hidden">
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Vendor</TableHead>
-                <TableHead>Assessment</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Risk</TableHead>
-                <TableHead>Created</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
+                <TableHead>{t('assessments.cols.vendor')}</TableHead>
+                <TableHead>{t('assessments.cols.assessment')}</TableHead>
+                <TableHead>{t('assessments.cols.status')}</TableHead>
+                <TableHead>{t('assessments.cols.risk')}</TableHead>
+                <TableHead>{t('assessments.cols.created')}</TableHead>
+                <TableHead className="text-right">{t('assessments.cols.actions')}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -143,7 +145,7 @@ export function AssessmentsPage() {
                   <TableCell className="text-muted-foreground">
                     {assessment.name}
                     {assessment.framework === 'CONTRACT_A30' && (
-                      <Badge variant="outline" className="text-xs ml-2">Art. 30</Badge>
+                      <Badge variant="outline" className="text-xs ml-2">{t('assessments.art30Badge')}</Badge>
                     )}
                   </TableCell>
                   <TableCell>
@@ -151,13 +153,13 @@ export function AssessmentsPage() {
                       {(assessment.status === 'indexing' || assessment.status === 'analyzing') ? (
                         <Loader2 className="h-3 w-3 mr-1 animate-spin" />
                       ) : null}
-                      {assessment.status}
+                      {t(`assessments.status.${assessment.status}`)}
                     </Badge>
                   </TableCell>
                   <TableCell>
                     {assessment.results?.overallRisk ? (
                       <Badge variant={RISK_VARIANT[assessment.results.overallRisk]}>
-                        {assessment.results.overallRisk}
+                        {t(`assessments.risk.${assessment.results.overallRisk}`)}
                       </Badge>
                     ) : (
                       <span className="text-muted-foreground text-sm">-</span>
@@ -176,7 +178,7 @@ export function AssessmentsPage() {
                           variant="ghost"
                           size="icon"
                           className="h-7 w-7"
-                          title="Download report"
+                          title={t('assessments.downloadReportTitle')}
                           onClick={() => downloadMutation.mutate({
                             id: assessment._id,
                             vendorName: assessment.vendorName,
@@ -193,7 +195,7 @@ export function AssessmentsPage() {
                             variant="ghost"
                             size="icon"
                             className="h-7 w-7 text-destructive hover:text-destructive"
-                            title="Delete assessment"
+                            title={t('assessments.deleteTitle')}
                             onClick={() => setDeletingId(assessment._id)}
                           >
                             <Trash2 className="h-4 w-4" />
@@ -201,15 +203,16 @@ export function AssessmentsPage() {
                         </AlertDialogTrigger>
                         <AlertDialogContent>
                           <AlertDialogHeader>
-                            <AlertDialogTitle>Delete assessment?</AlertDialogTitle>
+                            <AlertDialogTitle>{t('assessments.deleteConfirmTitle')}</AlertDialogTitle>
                             <AlertDialogDescription>
-                              This will permanently remove the assessment for{' '}
-                              <strong>{assessment.vendorName}</strong> and all indexed documents. This action cannot be undone.
+                              {t('assessments.deleteConfirmDesc1')}
+                              <strong>{assessment.vendorName}</strong>
+                              {t('assessments.deleteConfirmDesc2')}
                             </AlertDialogDescription>
                           </AlertDialogHeader>
                           <AlertDialogFooter>
                             <AlertDialogCancel onClick={() => setDeletingId(null)}>
-                              Cancel
+                              {t('common.cancel')}
                             </AlertDialogCancel>
                             <AlertDialogAction
                               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
@@ -219,7 +222,7 @@ export function AssessmentsPage() {
                               {deleteMutation.isPending && deletingId === assessment._id ? (
                                 <Loader2 className="h-4 w-4 animate-spin mr-2" />
                               ) : null}
-                              Delete
+                              {t('common.delete')}
                             </AlertDialogAction>
                           </AlertDialogFooter>
                         </AlertDialogContent>

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -418,5 +418,76 @@
         "desc": "Generate regulator-ready outputs including the Register of Information and gap remediation artefacts."
       }
     }
+  },
+  "assessments": {
+    "selectWorkspace": "Select a workspace to view assessments",
+    "title": "DORA Assessments",
+    "subtitle": "Third-party ICT risk assessments under Regulation (EU) 2022/2554",
+    "newButton": "New Assessment",
+    "loadError": "Failed to load assessments.",
+    "empty": {
+      "heading": "No gap analyses yet",
+      "description": "Upload vendor ICT documentation to identify DORA Article 28/29 compliance gaps using AI-powered analysis.",
+      "cta": "Run your first gap analysis",
+      "hint": "Supported formats: PDF, Word. Results include gap findings, risk level, and remediation recommendations."
+    },
+    "cols": {
+      "vendor": "Vendor",
+      "assessment": "Assessment",
+      "status": "Status",
+      "risk": "Risk",
+      "created": "Created",
+      "actions": "Actions"
+    },
+    "status": {
+      "pending": "pending",
+      "indexing": "indexing",
+      "analyzing": "analyzing",
+      "complete": "complete",
+      "failed": "failed"
+    },
+    "risk": {
+      "Low": "Low",
+      "Medium": "Medium",
+      "High": "High"
+    },
+    "art30Badge": "Art. 30",
+    "downloadReportTitle": "Download report",
+    "deleteTitle": "Delete assessment",
+    "deleteConfirmTitle": "Delete assessment?",
+    "deleteConfirmDesc1": "This will permanently remove the assessment for ",
+    "deleteConfirmDesc2": " and all indexed documents. This action cannot be undone.",
+    "toast": {
+      "deleted": "Assessment deleted",
+      "deleteFailed": "Failed to delete assessment",
+      "downloadFailed": "Failed to download report"
+    },
+    "form": {
+      "selectWorkspace": "Select a workspace first",
+      "back": "Assessments",
+      "titleDora": "New DORA Assessment",
+      "titleA30": "New Contract Review (Art. 30)",
+      "subtitleDora": "Upload vendor ICT documentation to run a gap analysis against Regulation (EU) 2022/2554.",
+      "subtitleA30": "Upload the ICT contract to check all 12 mandatory DORA Article 30 clauses.",
+      "type": "Assessment type",
+      "typeDora": "Gap Analysis (Art. 28/29)",
+      "typeA30": "Contract Review (Art. 30)",
+      "vendorName": "Vendor name",
+      "vendorNamePlaceholder": "e.g. Acme Cloud Services",
+      "vendorNameDesc": "Pre-filled from your workspace. Edit if needed.",
+      "name": "Assessment name",
+      "resetAuto": "Reset to auto",
+      "nameDescAuto": "Auto-generated from vendor name and assessment type.",
+      "nameDescCustom": "Custom label — edit freely or reset to auto.",
+      "nameTypeDora": "DORA Gap Analysis",
+      "nameTypeA30": "Art.30 Contract Review",
+      "vendorFallback": "Vendor",
+      "docsDora": "Vendor documents",
+      "docsA30": "Contract document",
+      "uploadAtLeastOne": "Please upload at least one document.",
+      "start": "Start Assessment",
+      "uploading": "Uploading…",
+      "toastCreated": "Assessment created — indexing documents…"
+    }
   }
 }

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -418,5 +418,76 @@
         "desc": "Générez des livrables prêts pour le régulateur, dont le Registre d'information et les artefacts de remédiation des écarts."
       }
     }
+  },
+  "assessments": {
+    "selectWorkspace": "Sélectionnez un espace de travail pour voir les évaluations",
+    "title": "Évaluations DORA",
+    "subtitle": "Évaluations des risques liés aux TIC de tiers au titre du règlement (UE) 2022/2554",
+    "newButton": "Nouvelle évaluation",
+    "loadError": "Échec du chargement des évaluations.",
+    "empty": {
+      "heading": "Aucune analyse d'écart pour le moment",
+      "description": "Importez la documentation TIC du fournisseur pour identifier les écarts de conformité aux articles 28/29 de DORA grâce à l'analyse assistée par IA.",
+      "cta": "Lancez votre première analyse d'écart",
+      "hint": "Formats pris en charge : PDF, Word. Les résultats incluent les écarts détectés, le niveau de risque et des recommandations de remédiation."
+    },
+    "cols": {
+      "vendor": "Fournisseur",
+      "assessment": "Évaluation",
+      "status": "Statut",
+      "risk": "Risque",
+      "created": "Créée le",
+      "actions": "Actions"
+    },
+    "status": {
+      "pending": "en attente",
+      "indexing": "indexation",
+      "analyzing": "analyse",
+      "complete": "terminée",
+      "failed": "échouée"
+    },
+    "risk": {
+      "Low": "Faible",
+      "Medium": "Moyen",
+      "High": "Élevé"
+    },
+    "art30Badge": "Art. 30",
+    "downloadReportTitle": "Télécharger le rapport",
+    "deleteTitle": "Supprimer l'évaluation",
+    "deleteConfirmTitle": "Supprimer l'évaluation ?",
+    "deleteConfirmDesc1": "Cette action supprimera définitivement l'évaluation pour ",
+    "deleteConfirmDesc2": " ainsi que tous les documents indexés. Cette action est irréversible.",
+    "toast": {
+      "deleted": "Évaluation supprimée",
+      "deleteFailed": "Échec de la suppression de l'évaluation",
+      "downloadFailed": "Échec du téléchargement du rapport"
+    },
+    "form": {
+      "selectWorkspace": "Sélectionnez d'abord un espace de travail",
+      "back": "Évaluations",
+      "titleDora": "Nouvelle évaluation DORA",
+      "titleA30": "Nouvelle revue de contrat (art. 30)",
+      "subtitleDora": "Importez la documentation TIC du fournisseur pour lancer une analyse d'écart au regard du règlement (UE) 2022/2554.",
+      "subtitleA30": "Importez le contrat TIC pour vérifier les 12 clauses obligatoires de l'article 30 de DORA.",
+      "type": "Type d'évaluation",
+      "typeDora": "Analyse d'écart (art. 28/29)",
+      "typeA30": "Revue de contrat (art. 30)",
+      "vendorName": "Nom du fournisseur",
+      "vendorNamePlaceholder": "ex. Acme Cloud Services",
+      "vendorNameDesc": "Pré-rempli depuis votre espace de travail. Modifiez si nécessaire.",
+      "name": "Nom de l'évaluation",
+      "resetAuto": "Réinitialiser en auto",
+      "nameDescAuto": "Généré automatiquement à partir du nom du fournisseur et du type d'évaluation.",
+      "nameDescCustom": "Libellé personnalisé — modifiez librement ou réinitialisez en auto.",
+      "nameTypeDora": "Analyse d'écart DORA",
+      "nameTypeA30": "Revue de contrat art. 30",
+      "vendorFallback": "Fournisseur",
+      "docsDora": "Documents du fournisseur",
+      "docsA30": "Document contractuel",
+      "uploadAtLeastOne": "Veuillez importer au moins un document.",
+      "start": "Lancer l'évaluation",
+      "uploading": "Téléversement…",
+      "toastCreated": "Évaluation créée — indexation des documents…"
+    }
   }
 }


### PR DESCRIPTION
i18n batch 10 — assessments **list** + **new-assessment form**: title/subtitle, empty state, table headers, status + risk badges, delete dialog, download/delete tooltips, and the full new-assessment form (framework toggle, vendor/name fields, file-upload labels, toasts) → t(). Adds the `assessments` namespace. The auto-generated assessment name is now locale-aware (French month + translated type label). Build green, eslint clean, parity 57/57.