### PR TITLE
feat(web): translate assessment detail + display panels — EN/FR (i18n batch 11a)

### DIFF
--- a/frontend/src/components/assessment/AssessmentProgressStepper.tsx
+++ b/frontend/src/components/assessment/AssessmentProgressStepper.tsx
@@ -1,20 +1,21 @@
 'use client';
 
+import { useTranslation } from 'react-i18next';
 import { CheckCircle2, Circle, Loader2, XCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { AssessmentStatus } from '@/lib/api/assessments';
 
 interface Step {
   key: AssessmentStatus;
-  label: string;
-  description: string;
+  labelKey: string;
+  descKey: string;
 }
 
 const STEPS: Step[] = [
-  { key: 'pending', label: 'Submitted', description: 'Assessment created' },
-  { key: 'indexing', label: 'Indexing', description: 'Parsing & embedding documents' },
-  { key: 'analyzing', label: 'Analyzing', description: 'Running DORA gap analysis' },
-  { key: 'complete', label: 'Complete', description: 'Report ready' },
+  { key: 'pending', labelKey: 'assessments.stepper.submitted', descKey: 'assessments.stepper.submittedDesc' },
+  { key: 'indexing', labelKey: 'assessments.stepper.indexing', descKey: 'assessments.stepper.indexingDesc' },
+  { key: 'analyzing', labelKey: 'assessments.stepper.analyzing', descKey: 'assessments.stepper.analyzingDesc' },
+  { key: 'complete', labelKey: 'assessments.stepper.complete', descKey: 'assessments.stepper.completeDesc' },
 ];
 
 const STATUS_ORDER: Record<AssessmentStatus, number> = {
@@ -31,6 +32,7 @@ interface AssessmentProgressStepperProps {
 }
 
 export function AssessmentProgressStepper({ status, statusMessage }: AssessmentProgressStepperProps) {
+  const { t } = useTranslation();
   const currentOrder = STATUS_ORDER[status];
   const isFailed = status === 'failed';
 
@@ -85,10 +87,10 @@ export function AssessmentProgressStepper({ status, statusMessage }: AssessmentP
                     (isDone || isActive) && !isFailed ? 'text-foreground' : 'text-muted-foreground'
                   )}
                 >
-                  {step.label}
+                  {t(step.labelKey)}
                 </p>
                 <p className="text-xs text-muted-foreground text-center hidden sm:block">
-                  {step.description}
+                  {t(step.descKey)}
                 </p>
               </div>
             </li>

--- a/frontend/src/components/assessment/FileUploadZone.tsx
+++ b/frontend/src/components/assessment/FileUploadZone.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
+import { useTranslation } from 'react-i18next';
 import { Upload, X, FileText, FileSpreadsheet } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -39,6 +40,7 @@ function formatSize(bytes: number) {
 }
 
 export function FileUploadZone({ files, onChange }: FileUploadZoneProps) {
+  const { t } = useTranslation();
   const onDrop = useCallback(
     (accepted: File[]) => {
       const withId = accepted.map((f) =>
@@ -77,14 +79,14 @@ export function FileUploadZone({ files, onChange }: FileUploadZoneProps) {
         <input {...getInputProps()} />
         <Upload className="mx-auto h-8 w-8 text-muted-foreground mb-3" />
         {isDragActive ? (
-          <p className="text-sm font-medium text-primary">Drop files here…</p>
+          <p className="text-sm font-medium text-primary">{t('assessments.upload.drop')}</p>
         ) : (
           <>
             <p className="text-sm font-medium">
-              Drag &amp; drop vendor documents here, or click to browse
+              {t('assessments.upload.prompt')}
             </p>
             <p className="text-xs text-muted-foreground mt-1">
-              PDF, XLSX, XLS, DOCX — max {MAX_SIZE_MB}MB per file, up to {MAX_FILES} files
+              {t('assessments.upload.hint', { size: MAX_SIZE_MB, count: MAX_FILES })}
             </p>
           </>
         )}

--- a/frontend/src/components/assessment/GapAnalysisTable.tsx
+++ b/frontend/src/components/assessment/GapAnalysisTable.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Table,
   TableBody,
@@ -22,17 +23,12 @@ const GAP_VARIANT: Record<GapLevel, 'default' | 'secondary' | 'destructive'> = {
   missing: 'destructive',
 };
 
-const GAP_LABEL: Record<GapLevel, string> = {
-  covered: 'Covered',
-  partial: 'Partial',
-  missing: 'Missing',
-};
-
 interface GapAnalysisTableProps {
   gaps: Gap[];
 }
 
 export function GapAnalysisTable({ gaps }: GapAnalysisTableProps) {
+  const { t } = useTranslation();
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
 
   const toggle = (idx: number) => {
@@ -46,7 +42,7 @@ export function GapAnalysisTable({ gaps }: GapAnalysisTableProps) {
 
   if (gaps.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground text-center py-8">No gaps recorded.</p>
+      <p className="text-sm text-muted-foreground text-center py-8">{t('assessments.gapTable.empty')}</p>
     );
   }
 
@@ -56,10 +52,10 @@ export function GapAnalysisTable({ gaps }: GapAnalysisTableProps) {
         <TableHeader>
           <TableRow>
             <TableHead className="w-8" />
-            <TableHead>Article</TableHead>
-            <TableHead>Domain</TableHead>
-            <TableHead className="hidden md:table-cell">Requirement</TableHead>
-            <TableHead>Gap</TableHead>
+            <TableHead>{t('assessments.gapTable.article')}</TableHead>
+            <TableHead>{t('assessments.gapTable.domain')}</TableHead>
+            <TableHead className="hidden md:table-cell">{t('assessments.gapTable.requirement')}</TableHead>
+            <TableHead>{t('assessments.gapTable.gap')}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -86,7 +82,7 @@ export function GapAnalysisTable({ gaps }: GapAnalysisTableProps) {
                     {gap.requirement}
                   </TableCell>
                   <TableCell>
-                    <Badge variant={GAP_VARIANT[gap.gapLevel]}>{GAP_LABEL[gap.gapLevel]}</Badge>
+                    <Badge variant={GAP_VARIANT[gap.gapLevel]}>{t(`assessments.gapTable.level.${gap.gapLevel}`)}</Badge>
                   </TableCell>
                 </TableRow>
 
@@ -97,19 +93,19 @@ export function GapAnalysisTable({ gaps }: GapAnalysisTableProps) {
                       <div className="space-y-3 text-sm">
                         <div>
                           <p className="font-medium text-xs uppercase tracking-wide text-muted-foreground mb-1">
-                            Requirement
+                            {t('assessments.gapTable.requirement')}
                           </p>
                           <p>{gap.requirement}</p>
                         </div>
                         <div>
                           <p className="font-medium text-xs uppercase tracking-wide text-muted-foreground mb-1">
-                            Vendor Coverage
+                            {t('assessments.gapTable.vendorCoverage')}
                           </p>
                           <p>{gap.vendorCoverage}</p>
                         </div>
                         <div>
                           <p className="font-medium text-xs uppercase tracking-wide text-muted-foreground mb-1">
-                            Recommendation
+                            {t('assessments.gapTable.recommendation')}
                           </p>
                           <p
                             className={cn(
@@ -123,7 +119,7 @@ export function GapAnalysisTable({ gaps }: GapAnalysisTableProps) {
                         {gap.sourceChunks.length > 0 && (
                           <div>
                             <p className="font-medium text-xs uppercase tracking-wide text-muted-foreground mb-1">
-                              Evidence chunks
+                              {t('assessments.gapTable.evidence')}
                             </p>
                             <ul className="list-disc list-inside space-y-1 text-xs text-muted-foreground">
                               {gap.sourceChunks.map((chunk, ci) => (

--- a/frontend/src/features/assessments/components/assessment-detail-page.tsx
+++ b/frontend/src/features/assessments/components/assessment-detail-page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, use, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery, useMutation } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
 import {
   ArrowLeft,
@@ -41,19 +42,8 @@ const RISK_VARIANT: Record<OverallRisk, 'default' | 'secondary' | 'destructive'>
   High: 'destructive',
 };
 
-const RISK_DESCRIPTION: Record<OverallRisk, string> = {
-  Low: 'The vendor demonstrates broad DORA compliance with minor gaps.',
-  Medium: 'Several DORA obligations are only partially addressed.',
-  High: 'Significant compliance gaps detected - remediation required before contract renewal.',
-};
-
-const RISK_DESCRIPTION_CONTRACT: Record<OverallRisk, string> = {
-  Low: 'The contract broadly satisfies DORA Article 30 mandatory clause requirements.',
-  Medium: 'Several Article 30 clauses are only partially addressed - renegotiation recommended.',
-  High: 'Critical Article 30 clause gaps detected - contract must be renegotiated before use.',
-};
-
 function NextStepsPanel({ assessment }: { assessment: Assessment }) {
+  const { t } = useTranslation();
   const router = useRouter();
   const isDora = assessment.framework === 'DORA';
   const risk = assessment.results?.overallRisk;
@@ -71,23 +61,24 @@ function NextStepsPanel({ assessment }: { assessment: Assessment }) {
           <CardHeader className="pb-2">
             <CardTitle className="text-base flex items-center gap-2">
               <XCircle className="h-5 w-5 text-destructive" />
-              Vendor Rejected - Progression Blocked
+              {t('assessments.detail.nextSteps.rejectTitle')}
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
             <p className="text-sm text-muted-foreground">
-              A formal <strong>Reject</strong> decision has been recorded. This vendor cannot be
-              onboarded under current controls. To reverse, record a new risk decision above.
+              {t('assessments.detail.nextSteps.rejectBody1')}
+              <strong>{t('assessments.detail.nextSteps.rejectWord')}</strong>
+              {t('assessments.detail.nextSteps.rejectBody2')}
             </p>
             {assessment.riskDecision.rationale && (
               <p className="text-sm text-muted-foreground italic">
-                Reason: &quot;{assessment.riskDecision.rationale}&quot;
+                {t('assessments.detail.nextSteps.rejectReason', { rationale: assessment.riskDecision.rationale })}
               </p>
             )}
             {wsId && (
               <Button size="sm" variant="outline" onClick={() => router.push(`/workspaces/${wsId}`)}>
                 <Building2 className="h-4 w-4 mr-1.5" />
-                Back to Vendor
+                {t('assessments.detail.nextSteps.backToVendor')}
               </Button>
             )}
           </CardContent>
@@ -105,24 +96,24 @@ function NextStepsPanel({ assessment }: { assessment: Assessment }) {
             ) : (
               <CheckCircle2 className="h-5 w-5 text-success" />
             )}
-            Next Step - Contract Review (Art. 30)
+            {t('assessments.detail.nextSteps.contractReviewTitle')}
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
           {isHighRisk ? (
             <p className="text-sm text-muted-foreground">
-              <strong>{missingN} critical gap(s)</strong> were found. Request a vendor remediation
-              plan before proceeding to contract review, or record a Conditional decision above.
+              <strong>{t('assessments.detail.nextSteps.highRiskCount', { count: missingN })}</strong>
+              {t('assessments.detail.nextSteps.highRiskTail')}
             </p>
           ) : (
             <p className="text-sm text-muted-foreground">
-              Gap analysis complete.
+              {t('assessments.detail.nextSteps.lowRiskComplete')}
               {' '}
               {partialN > 0
-                ? `${partialN} partial gap(s) should be addressed in the contract clauses.`
-                : 'No critical gaps found.'}
+                ? t('assessments.detail.nextSteps.lowRiskPartial', { count: partialN })
+                : t('assessments.detail.nextSteps.lowRiskNoCritical')}
               {' '}
-              Proceed to upload the ICT contract and verify all 12 mandatory DORA Article 30 clauses.
+              {t('assessments.detail.nextSteps.lowRiskTail')}
             </p>
           )}
           <div className="flex gap-2 flex-wrap">
@@ -133,13 +124,13 @@ function NextStepsPanel({ assessment }: { assessment: Assessment }) {
               }
             >
               <FileText className="h-4 w-4 mr-1.5" />
-              Review Contract (Art. 30)
+              {t('assessments.detail.nextSteps.reviewContract')}
               <ChevronRight className="h-3.5 w-3.5 ml-1" />
             </Button>
             {wsId && (
               <Button size="sm" variant="outline" onClick={() => router.push(`/workspaces/${wsId}`)}>
                 <Building2 className="h-4 w-4 mr-1.5" />
-                Back to Vendor
+                {t('assessments.detail.nextSteps.backToVendor')}
               </Button>
             )}
           </div>
@@ -166,29 +157,29 @@ function NextStepsPanel({ assessment }: { assessment: Assessment }) {
           ) : (
             <CheckCircle2 className="h-5 w-5 text-success" />
           )}
-          Contract Review Complete
+          {t('assessments.detail.nextSteps.contractCompleteTitle')}
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
         <p className="text-sm text-muted-foreground">
           {contractOk
-            ? 'All 12 mandatory DORA Article 30 clauses are satisfied. This contract is ready for execution.'
+            ? t('assessments.detail.nextSteps.contractOk')
             : clausesMissing > 0
-              ? `${clausesMissing} clause(s) are missing and must be added before execution.${clausesPartial > 0 ? ` ${clausesPartial} further clause(s) need strengthening.` : ''}`
-              : `${clausesPartial} clause(s) are partially addressed - renegotiation recommended before signature.`}
+              ? `${t('assessments.detail.nextSteps.contractMissing', { count: clausesMissing })}${clausesPartial > 0 ? t('assessments.detail.nextSteps.contractMissingPartialTail', { count: clausesPartial }) : ''}`
+              : t('assessments.detail.nextSteps.contractPartial', { count: clausesPartial })}
         </p>
         <div className="flex gap-2 flex-wrap">
           {wsId && (
             <Button size="sm" onClick={() => router.push(`/workspaces/${wsId}`)}>
               <Building2 className="h-4 w-4 mr-1.5" />
-              Back to Vendor Workspace
+              {t('assessments.detail.nextSteps.backToVendorWorkspace')}
               <ChevronRight className="h-3.5 w-3.5 ml-1" />
             </Button>
           )}
           {!contractOk && (
             <Button size="sm" variant="outline" onClick={() => router.push('/assessments/new')}>
               <FileSearch className="h-4 w-4 mr-1.5" />
-              Re-run with revised contract
+              {t('assessments.detail.nextSteps.rerunRevised')}
             </Button>
           )}
         </div>
@@ -202,6 +193,7 @@ interface AssessmentDetailPageProps {
 }
 
 export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
+  const { t } = useTranslation();
   const { id } = use(params);
   const router = useRouter();
 
@@ -271,16 +263,17 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
 
   useEffect(() => {
     if (prevStatus === 'complete') {
-      toast.success('Analysis complete - report ready');
+      toast.success(t('assessments.detail.toast.complete'));
     } else if (prevStatus === 'failed') {
-      toast.error('Assessment failed');
+      toast.error(t('assessments.detail.toast.failed'));
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prevStatus]);
 
   const downloadMutation = useMutation({
     mutationFn: () =>
       assessmentsApi.downloadReport(id, assessment?.vendorName ?? 'vendor', assessment?.framework),
-    onError: () => toast.error('Failed to download report'),
+    onError: () => toast.error(t('assessments.detail.toast.downloadFailed')),
   });
 
   if (isLoading) {
@@ -298,7 +291,7 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
       <div className="p-6 max-w-4xl mx-auto">
         <div className="flex items-center gap-2 text-destructive p-4 rounded-md border border-destructive/30 bg-destructive/10">
           <AlertCircle className="h-4 w-4 shrink-0" />
-          <p className="text-sm">Assessment not found or failed to load.</p>
+          <p className="text-sm">{t('assessments.detail.notFound')}</p>
         </div>
       </div>
     );
@@ -314,7 +307,7 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
       <div className="flex items-center gap-2">
         <Button variant="ghost" size="sm" className="-ml-2" onClick={() => router.push('/assessments')}>
           <ArrowLeft className="h-4 w-4 mr-1" />
-          Assessments
+          {t('assessments.detail.back')}
         </Button>
         {assessment.workspaceId && (
           <>
@@ -336,7 +329,7 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
           <div className="flex items-center gap-2 flex-wrap">
             <h1 className="page-title">{assessment.vendorName}</h1>
             <Badge variant="outline" className="text-xs">
-              {isA30 ? 'Art. 30 Contract Review' : 'DORA Gap Analysis'}
+              {isA30 ? t('assessments.detail.badgeA30') : t('assessments.detail.badgeDora')}
             </Badge>
             {isA30 && siblingA30 && (
               <NegotiationRoundBadge assessments={siblingA30} currentId={id} />
@@ -344,7 +337,7 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
           </div>
           <p className="text-muted-foreground">{assessment.name}</p>
           <p className="text-xs text-muted-foreground mt-1">
-            Created {format(new Date(assessment.createdAt), 'dd MMM yyyy HH:mm')}
+            {t('assessments.detail.createdAt', { date: format(new Date(assessment.createdAt), 'dd MMM yyyy HH:mm') })}
           </p>
         </div>
         {isComplete && (
@@ -354,7 +347,7 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
             ) : (
               <FileDown className="h-4 w-4 mr-2" />
             )}
-            Download Report (.docx)
+            {t('assessments.detail.download')}
           </Button>
         )}
       </div>
@@ -367,7 +360,7 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
       </div>
 
       <div className="rounded-lg border p-4 space-y-3">
-        <h2 className="text-sm font-semibold">Documents ({assessment.documents.length})</h2>
+        <h2 className="text-sm font-semibold">{t('assessments.detail.documents', { count: assessment.documents.length })}</h2>
         <ul className="space-y-2">
           {assessment.documents.map((doc, index) => (
             <li key={index} className="flex items-center gap-3 text-sm">
@@ -387,14 +380,14 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
                 variant={doc.status === 'indexed' ? 'default' : doc.status === 'failed' ? 'destructive' : 'outline'}
                 className="text-xs"
               >
-                {doc.status}
+                {t(`assessments.detail.docStatus.${doc.status}`, { defaultValue: doc.status })}
               </Badge>
               {doc.storageKey && (
                 <Button
                   variant="ghost"
                   size="icon"
                   className="h-6 w-6 shrink-0"
-                  title="Download document"
+                  title={t('assessments.detail.downloadDocTitle')}
                   onClick={() => assessmentsApi.downloadAssessmentFile(id, index, doc.fileName)}
                 >
                   <Download className="h-3.5 w-3.5" />
@@ -408,13 +401,13 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
       {isInProgress && (
         <div className="rounded-lg border border-dashed p-10 flex flex-col items-center text-center gap-3">
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-          <p className="font-medium">Analysis in progress</p>
+          <p className="font-medium">{t('assessments.detail.inProgressTitle')}</p>
           <p className="text-sm text-muted-foreground max-w-sm">
             {assessment.status === 'indexing'
-              ? 'Parsing and embedding your documents into the vector store...'
+              ? t('assessments.detail.inProgressIndexing')
               : isA30
-                ? 'Running contract clause review against all 12 Article 30 requirements...'
-                : 'Running the DORA gap analysis against all indexed content...'}
+                ? t('assessments.detail.inProgressA30')
+                : t('assessments.detail.inProgressDora')}
           </p>
         </div>
       )}
@@ -426,20 +419,20 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
           <div className="flex flex-col sm:flex-row gap-4">
             <div className="flex-1 rounded-lg border p-4 space-y-1">
               <p className="text-xs text-muted-foreground font-medium uppercase tracking-wide">
-                Overall Risk
+                {t('assessments.detail.overallRisk')}
               </p>
               <Badge variant={RISK_VARIANT[assessment.results.overallRisk]} className="text-sm px-3 py-1">
-                {assessment.results.overallRisk}
+                {t(`assessments.risk.${assessment.results.overallRisk}`)}
               </Badge>
               <p className="text-sm text-muted-foreground">
                 {isA30
-                  ? RISK_DESCRIPTION_CONTRACT[assessment.results.overallRisk]
-                  : RISK_DESCRIPTION[assessment.results.overallRisk]}
+                  ? t(`assessments.detail.riskDescContract.${assessment.results.overallRisk}`)
+                  : t(`assessments.detail.riskDescDora.${assessment.results.overallRisk}`)}
               </p>
             </div>
             <div className="flex-1 rounded-lg border p-4 space-y-2">
               <p className="text-xs text-muted-foreground font-medium uppercase tracking-wide">
-                Summary
+                {t('assessments.detail.summary')}
               </p>
               <p className="text-sm">{assessment.results.summary}</p>
             </div>
@@ -447,9 +440,9 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
 
           <div className="grid grid-cols-3 gap-4">
             {[
-              { label: isA30 ? 'Total clauses' : 'Total gaps', value: isA30 ? 12 : assessment.results.gaps.length },
-              { label: 'Missing', value: gapCounts.missing, className: 'text-destructive' },
-              { label: 'Partial', value: gapCounts.partial, className: 'text-warning' },
+              { label: isA30 ? t('assessments.detail.totalClauses') : t('assessments.detail.totalGaps'), value: isA30 ? 12 : assessment.results.gaps.length },
+              { label: t('assessments.detail.missing'), value: gapCounts.missing, className: 'text-destructive' },
+              { label: t('assessments.detail.partial'), value: gapCounts.partial, className: 'text-warning' },
             ].map((stat) => (
               <div key={stat.label} className="rounded-lg border p-4 text-center">
                 <p className={`text-3xl font-bold ${stat.className ?? ''}`}>{stat.value}</p>
@@ -471,7 +464,7 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
 
           <div className="space-y-3">
             <h2 className="text-lg font-semibold">
-              {isA30 ? 'Article 30 Clause Scorecard' : 'Gap Analysis'}
+              {isA30 ? t('assessments.detail.scorecardA30') : t('assessments.detail.scorecardDora')}
             </h2>
             {isA30 ? (
               <Art30ClauseScorecardWithSignoff assessment={assessment} />
@@ -481,11 +474,10 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
           </div>
 
           <p className="text-xs text-muted-foreground">
-            Report generated at
-            {' '}
-            {format(new Date(assessment.results.generatedAt), 'dd MMM yyyy HH:mm')}
-            {' · '}
-            Domains analyzed: {assessment.results.domainsAnalyzed.join(', ')}
+            {t('assessments.detail.generatedAt', {
+              date: format(new Date(assessment.results.generatedAt), 'dd MMM yyyy HH:mm'),
+              domains: assessment.results.domainsAnalyzed.join(', '),
+            })}
           </p>
 
           {!isA30 && (
@@ -500,7 +492,7 @@ export function AssessmentDetailPage({ params }: AssessmentDetailPageProps) {
         <div className="flex items-center gap-2 text-destructive p-4 rounded-md border border-destructive/30 bg-destructive/10">
           <AlertCircle className="h-4 w-4 shrink-0" />
           <p className="text-sm">
-            {assessment.statusMessage || 'Assessment failed. Please try again with different documents.'}
+            {assessment.statusMessage || t('assessments.detail.failedFallback')}
           </p>
         </div>
       )}

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -488,6 +488,104 @@
       "start": "Start Assessment",
       "uploading": "Uploading…",
       "toastCreated": "Assessment created — indexing documents…"
+    },
+    "detail": {
+      "back": "Assessments",
+      "badgeA30": "Art. 30 Contract Review",
+      "badgeDora": "DORA Gap Analysis",
+      "createdAt": "Created {{date}}",
+      "download": "Download Report (.docx)",
+      "documents": "Documents ({{count}})",
+      "downloadDocTitle": "Download document",
+      "docStatus": {
+        "pending": "pending",
+        "indexing": "indexing",
+        "indexed": "indexed",
+        "failed": "failed"
+      },
+      "inProgressTitle": "Analysis in progress",
+      "inProgressIndexing": "Parsing and embedding your documents into the vector store…",
+      "inProgressA30": "Running contract clause review against all 12 Article 30 requirements…",
+      "inProgressDora": "Running the DORA gap analysis against all indexed content…",
+      "overallRisk": "Overall Risk",
+      "summary": "Summary",
+      "totalGaps": "Total gaps",
+      "totalClauses": "Total clauses",
+      "missing": "Missing",
+      "partial": "Partial",
+      "scorecardA30": "Article 30 Clause Scorecard",
+      "scorecardDora": "Gap Analysis",
+      "generatedAt": "Report generated at {{date}} · Domains analyzed: {{domains}}",
+      "notFound": "Assessment not found or failed to load.",
+      "failedFallback": "Assessment failed. Please try again with different documents.",
+      "riskDescDora": {
+        "Low": "The vendor demonstrates broad DORA compliance with minor gaps.",
+        "Medium": "Several DORA obligations are only partially addressed.",
+        "High": "Significant compliance gaps detected — remediation required before contract renewal."
+      },
+      "riskDescContract": {
+        "Low": "The contract broadly satisfies DORA Article 30 mandatory clause requirements.",
+        "Medium": "Several Article 30 clauses are only partially addressed — renegotiation recommended.",
+        "High": "Critical Article 30 clause gaps detected — contract must be renegotiated before use."
+      },
+      "toast": {
+        "complete": "Analysis complete — report ready",
+        "failed": "Assessment failed",
+        "downloadFailed": "Failed to download report"
+      },
+      "nextSteps": {
+        "rejectTitle": "Vendor Rejected — Progression Blocked",
+        "rejectBody1": "A formal ",
+        "rejectWord": "Reject",
+        "rejectBody2": " decision has been recorded. This vendor cannot be onboarded under current controls. To reverse, record a new risk decision above.",
+        "rejectReason": "Reason: \"{{rationale}}\"",
+        "backToVendor": "Back to Vendor",
+        "contractReviewTitle": "Next Step — Contract Review (Art. 30)",
+        "highRiskCount": "{{count}} critical gap(s)",
+        "highRiskTail": " were found. Request a vendor remediation plan before proceeding to contract review, or record a Conditional decision above.",
+        "lowRiskComplete": "Gap analysis complete.",
+        "lowRiskPartial": "{{count}} partial gap(s) should be addressed in the contract clauses.",
+        "lowRiskNoCritical": "No critical gaps found.",
+        "lowRiskTail": "Proceed to upload the ICT contract and verify all 12 mandatory DORA Article 30 clauses.",
+        "reviewContract": "Review Contract (Art. 30)",
+        "contractCompleteTitle": "Contract Review Complete",
+        "contractOk": "All 12 mandatory DORA Article 30 clauses are satisfied. This contract is ready for execution.",
+        "contractMissing": "{{count}} clause(s) are missing and must be added before execution.",
+        "contractMissingPartialTail": " {{count}} further clause(s) need strengthening.",
+        "contractPartial": "{{count}} clause(s) are partially addressed — renegotiation recommended before signature.",
+        "backToVendorWorkspace": "Back to Vendor Workspace",
+        "rerunRevised": "Re-run with revised contract"
+      }
+    },
+    "stepper": {
+      "submitted": "Submitted",
+      "submittedDesc": "Assessment created",
+      "indexing": "Indexing",
+      "indexingDesc": "Parsing & embedding documents",
+      "analyzing": "Analyzing",
+      "analyzingDesc": "Running DORA gap analysis",
+      "complete": "Complete",
+      "completeDesc": "Report ready"
+    },
+    "upload": {
+      "drop": "Drop files here…",
+      "prompt": "Drag & drop vendor documents here, or click to browse",
+      "hint": "PDF, XLSX, XLS, DOCX — max {{size}}MB per file, up to {{count}} files"
+    },
+    "gapTable": {
+      "empty": "No gaps recorded.",
+      "article": "Article",
+      "domain": "Domain",
+      "requirement": "Requirement",
+      "gap": "Gap",
+      "vendorCoverage": "Vendor Coverage",
+      "recommendation": "Recommendation",
+      "evidence": "Evidence chunks",
+      "level": {
+        "covered": "Covered",
+        "partial": "Partial",
+        "missing": "Missing"
+      }
     }
   }
 }

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -488,6 +488,104 @@
       "start": "Lancer l'évaluation",
       "uploading": "Téléversement…",
       "toastCreated": "Évaluation créée — indexation des documents…"
+    },
+    "detail": {
+      "back": "Évaluations",
+      "badgeA30": "Revue de contrat (art. 30)",
+      "badgeDora": "Analyse d'écart DORA",
+      "createdAt": "Créée le {{date}}",
+      "download": "Télécharger le rapport (.docx)",
+      "documents": "Documents ({{count}})",
+      "downloadDocTitle": "Télécharger le document",
+      "docStatus": {
+        "pending": "en attente",
+        "indexing": "indexation",
+        "indexed": "indexé",
+        "failed": "échoué"
+      },
+      "inProgressTitle": "Analyse en cours",
+      "inProgressIndexing": "Analyse et vectorisation de vos documents dans la base vectorielle…",
+      "inProgressA30": "Revue des clauses contractuelles au regard des 12 exigences de l'article 30…",
+      "inProgressDora": "Analyse d'écart DORA sur l'ensemble du contenu indexé…",
+      "overallRisk": "Risque global",
+      "summary": "Synthèse",
+      "totalGaps": "Total des écarts",
+      "totalClauses": "Total des clauses",
+      "missing": "Manquant",
+      "partial": "Partiel",
+      "scorecardA30": "Grille des clauses de l'article 30",
+      "scorecardDora": "Analyse d'écart",
+      "generatedAt": "Rapport généré le {{date}} · Domaines analysés : {{domains}}",
+      "notFound": "Évaluation introuvable ou échec du chargement.",
+      "failedFallback": "L'évaluation a échoué. Veuillez réessayer avec d'autres documents.",
+      "riskDescDora": {
+        "Low": "Le fournisseur démontre une large conformité à DORA avec des écarts mineurs.",
+        "Medium": "Plusieurs obligations DORA ne sont que partiellement satisfaites.",
+        "High": "Écarts de conformité importants détectés — remédiation requise avant le renouvellement du contrat."
+      },
+      "riskDescContract": {
+        "Low": "Le contrat satisfait globalement les clauses obligatoires de l'article 30 de DORA.",
+        "Medium": "Plusieurs clauses de l'article 30 ne sont que partiellement traitées — renégociation recommandée.",
+        "High": "Écarts critiques sur les clauses de l'article 30 — le contrat doit être renégocié avant utilisation."
+      },
+      "toast": {
+        "complete": "Analyse terminée — rapport prêt",
+        "failed": "L'évaluation a échoué",
+        "downloadFailed": "Échec du téléchargement du rapport"
+      },
+      "nextSteps": {
+        "rejectTitle": "Fournisseur rejeté — progression bloquée",
+        "rejectBody1": "Une décision formelle de ",
+        "rejectWord": "Rejet",
+        "rejectBody2": " a été enregistrée. Ce fournisseur ne peut pas être intégré dans le cadre des contrôles actuels. Pour annuler, enregistrez une nouvelle décision de risque ci-dessus.",
+        "rejectReason": "Motif : « {{rationale}} »",
+        "backToVendor": "Retour au fournisseur",
+        "contractReviewTitle": "Étape suivante — Revue de contrat (art. 30)",
+        "highRiskCount": "{{count}} écart(s) critique(s)",
+        "highRiskTail": " ont été détectés. Demandez un plan de remédiation au fournisseur avant la revue de contrat, ou enregistrez une décision conditionnelle ci-dessus.",
+        "lowRiskComplete": "Analyse d'écart terminée.",
+        "lowRiskPartial": "{{count}} écart(s) partiel(s) devraient être traités dans les clauses du contrat.",
+        "lowRiskNoCritical": "Aucun écart critique détecté.",
+        "lowRiskTail": "Importez le contrat TIC et vérifiez les 12 clauses obligatoires de l'article 30 de DORA.",
+        "reviewContract": "Revoir le contrat (art. 30)",
+        "contractCompleteTitle": "Revue de contrat terminée",
+        "contractOk": "Les 12 clauses obligatoires de l'article 30 de DORA sont satisfaites. Ce contrat est prêt à être exécuté.",
+        "contractMissing": "{{count}} clause(s) manquante(s) doivent être ajoutées avant l'exécution.",
+        "contractMissingPartialTail": " {{count}} clause(s) supplémentaire(s) nécessitent un renforcement.",
+        "contractPartial": "{{count}} clause(s) partiellement traitée(s) — renégociation recommandée avant signature.",
+        "backToVendorWorkspace": "Retour à l'espace fournisseur",
+        "rerunRevised": "Relancer avec le contrat révisé"
+      }
+    },
+    "stepper": {
+      "submitted": "Soumise",
+      "submittedDesc": "Évaluation créée",
+      "indexing": "Indexation",
+      "indexingDesc": "Analyse et vectorisation des documents",
+      "analyzing": "Analyse",
+      "analyzingDesc": "Analyse d'écart DORA en cours",
+      "complete": "Terminée",
+      "completeDesc": "Rapport prêt"
+    },
+    "upload": {
+      "drop": "Déposez les fichiers ici…",
+      "prompt": "Glissez-déposez les documents du fournisseur ici, ou cliquez pour parcourir",
+      "hint": "PDF, XLSX, XLS, DOCX — max {{size}} Mo par fichier, jusqu'à {{count}} fichiers"
+    },
+    "gapTable": {
+      "empty": "Aucun écart enregistré.",
+      "article": "Article",
+      "domain": "Domaine",
+      "requirement": "Exigence",
+      "gap": "Écart",
+      "vendorCoverage": "Couverture fournisseur",
+      "recommendation": "Recommandation",
+      "evidence": "Extraits de preuve",
+      "level": {
+        "covered": "Couvert",
+        "partial": "Partiel",
+        "missing": "Manquant"
+      }
     }
   }
 }

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -6,6 +6,11 @@
 
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
+import i18n from '@/shared/i18n/config';
+
+// Initialize the app i18n instance in English so components that call
+// useTranslation()/t() render their real copy (not raw keys) in component tests.
+i18n.changeLanguage('en');
 
 // Mock next/navigation
 vi.mock('next/navigation', () => ({


### PR DESCRIPTION
i18n batch 11a — assessment **detail page** + 3 display sub-panels (progress stepper, file-upload zone, gap-analysis table). Covers the next-steps panel (DORA reject / contract-review / contract-complete branches with interpolated gap & clause counts), risk descriptions, documents list, results tiles, scorecard heading and generated-at line. Adds `detail`/`stepper`/`upload`/`gapTable` keys to the `assessments` namespace. Also inits app i18n (en) in the test setup so component tests render real copy. Build green, eslint clean, frontend suite 513/513, parity passing. Batch 11b (RiskScoringPanel + ClauseSignoffPanel) follows.