### PR TITLE
feat(web): translate risk-scoring + clause-signoff panels — EN/FR (i18n batch 11b)

### DIFF
--- a/frontend/src/components/assessment/ClauseSignoffPanel.tsx
+++ b/frontend/src/components/assessment/ClauseSignoffPanel.tsx
@@ -12,6 +12,7 @@
 import { useState } from 'react';
 import { format } from 'date-fns';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { CheckCircle2, XCircle, AlertTriangle, MinusCircle, ChevronDown, ChevronUp } from 'lucide-react';
 
@@ -23,27 +24,41 @@ import type { Assessment, Gap, ClauseSignoff, ClauseSignoffStatus } from '@/lib/
 
 // ── Art. 30 clauses constant (must match gapAnalysisAgent.js) ─────────────────
 
+// `category` stays in English: it drives the gap-matching heuristic below.
+// `textId`/`category` map to i18n keys for display only.
 export const ART30_CLAUSES = [
-  { ref: 'Art.30(2)(a)', category: 'Service Description',   text: 'Clear and complete description of all ICT services and functions to be provided' },
-  { ref: 'Art.30(2)(b)', category: 'Data Governance',       text: 'Locations (countries/regions) where data will be processed and stored' },
-  { ref: 'Art.30(2)(c)', category: 'Security & Resilience', text: 'Provisions on availability, authenticity, integrity and confidentiality of data' },
-  { ref: 'Art.30(2)(d)', category: 'Data Governance',       text: 'Provisions for accessibility, return, recovery and secure deletion of data on exit' },
-  { ref: 'Art.30(2)(e)', category: 'Subcontracting',        text: 'Full description of all subcontractors and their data processing locations' },
-  { ref: 'Art.30(2)(f)', category: 'Business Continuity',   text: 'ICT service continuity conditions including service level objective amendments' },
-  { ref: 'Art.30(2)(g)', category: 'Business Continuity',   text: "Business continuity plan provisions relevant to the financial entity's services" },
-  { ref: 'Art.30(2)(h)', category: 'Termination & Exit',    text: 'Termination rights of the financial entity including adequate notice periods' },
-  { ref: 'Art.30(3)(a)', category: 'Service Description',   text: 'Full service level descriptions with quantitative and qualitative performance targets' },
-  { ref: 'Art.30(3)(b)', category: 'Regulatory Compliance', text: 'Advance notification obligations for material changes to ICT services' },
-  { ref: 'Art.30(3)(c)', category: 'Audit & Inspection',    text: 'Right to carry out full audits and on-site inspections of the ICT provider' },
-  { ref: 'Art.30(3)(d)', category: 'Security & Resilience', text: 'Obligation to assist the financial entity in ICT-related incident management' },
+  { ref: 'Art.30(2)(a)', textId: '2a', category: 'Service Description',   text: 'Clear and complete description of all ICT services and functions to be provided' },
+  { ref: 'Art.30(2)(b)', textId: '2b', category: 'Data Governance',       text: 'Locations (countries/regions) where data will be processed and stored' },
+  { ref: 'Art.30(2)(c)', textId: '2c', category: 'Security & Resilience', text: 'Provisions on availability, authenticity, integrity and confidentiality of data' },
+  { ref: 'Art.30(2)(d)', textId: '2d', category: 'Data Governance',       text: 'Provisions for accessibility, return, recovery and secure deletion of data on exit' },
+  { ref: 'Art.30(2)(e)', textId: '2e', category: 'Subcontracting',        text: 'Full description of all subcontractors and their data processing locations' },
+  { ref: 'Art.30(2)(f)', textId: '2f', category: 'Business Continuity',   text: 'ICT service continuity conditions including service level objective amendments' },
+  { ref: 'Art.30(2)(g)', textId: '2g', category: 'Business Continuity',   text: "Business continuity plan provisions relevant to the financial entity's services" },
+  { ref: 'Art.30(2)(h)', textId: '2h', category: 'Termination & Exit',    text: 'Termination rights of the financial entity including adequate notice periods' },
+  { ref: 'Art.30(3)(a)', textId: '3a', category: 'Service Description',   text: 'Full service level descriptions with quantitative and qualitative performance targets' },
+  { ref: 'Art.30(3)(b)', textId: '3b', category: 'Regulatory Compliance', text: 'Advance notification obligations for material changes to ICT services' },
+  { ref: 'Art.30(3)(c)', textId: '3c', category: 'Audit & Inspection',    text: 'Right to carry out full audits and on-site inspections of the ICT provider' },
+  { ref: 'Art.30(3)(d)', textId: '3d', category: 'Security & Resilience', text: 'Obligation to assist the financial entity in ICT-related incident management' },
 ] as const;
+
+// English category → i18n key slug (display only)
+const CATEGORY_KEY: Record<string, string> = {
+  'Service Description': 'serviceDescription',
+  'Data Governance': 'dataGovernance',
+  'Security & Resilience': 'securityResilience',
+  'Subcontracting': 'subcontracting',
+  'Business Continuity': 'businessContinuity',
+  'Termination & Exit': 'terminationExit',
+  'Regulatory Compliance': 'regulatoryCompliance',
+  'Audit & Inspection': 'auditInspection',
+};
 
 // ── Sign-off config ────────────────────────────────────────────────────────────
 
-const SIGNOFF_CONFIG: Record<ClauseSignoffStatus, { label: string; icon: React.ElementType; badgeClass: string; variant: 'default' | 'destructive' | 'outline' }> = {
-  accepted: { label: 'Accepted',  icon: CheckCircle2,  badgeClass: 'bg-green-100 text-green-800 border-green-200 hover:bg-green-100', variant: 'default' },
-  rejected: { label: 'Rejected',  icon: XCircle,       badgeClass: '', variant: 'destructive' },
-  waived:   { label: 'Waived',    icon: MinusCircle,   badgeClass: 'bg-slate-100 text-slate-700 border-slate-200 hover:bg-slate-100', variant: 'outline' },
+const SIGNOFF_CONFIG: Record<ClauseSignoffStatus, { labelKey: string; icon: React.ElementType; badgeClass: string; variant: 'default' | 'destructive' | 'outline' }> = {
+  accepted: { labelKey: 'assessments.signoff.accepted',  icon: CheckCircle2,  badgeClass: 'bg-green-100 text-green-800 border-green-200 hover:bg-green-100', variant: 'default' },
+  rejected: { labelKey: 'assessments.signoff.rejected',  icon: XCircle,       badgeClass: '', variant: 'destructive' },
+  waived:   { labelKey: 'assessments.signoff.waived',    icon: MinusCircle,   badgeClass: 'bg-slate-100 text-slate-700 border-slate-200 hover:bg-slate-100', variant: 'outline' },
 };
 
 // ── Negotiation round indicator ───────────────────────────────────────────────
@@ -55,6 +70,7 @@ export function NegotiationRoundBadge({
   assessments: Assessment[];
   currentId: string;
 }) {
+  const { t } = useTranslation();
   const sorted = [...assessments].sort(
     (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
   );
@@ -64,7 +80,7 @@ export function NegotiationRoundBadge({
 
   return (
     <Badge variant="outline" className="text-xs font-medium">
-      Round {roundN} of {total}
+      {t('assessments.round', { n: roundN, total })}
     </Badge>
   );
 }
@@ -82,6 +98,7 @@ function ClauseSignoffRow({
   signoff: ClauseSignoff | undefined;
   assessmentId: string;
 }) {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [expanded, setExpanded] = useState(false);
   const [note, setNote]         = useState('');
@@ -91,11 +108,15 @@ function ClauseSignoffRow({
       assessmentsApi.setClauseSignoff(assessmentId, clause.ref, status, note),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['assessment', assessmentId] });
-      toast.success(`Clause ${clause.ref} ${note ? 'noted and ' : ''}signed off`);
+      toast.success(
+        note
+          ? t('assessments.signoff.toastNotedAnd', { ref: clause.ref })
+          : t('assessments.signoff.toastSignedOff', { ref: clause.ref })
+      );
       setExpanded(false);
       setNote('');
     },
-    onError: () => toast.error('Sign-off failed'),
+    onError: () => toast.error(t('assessments.signoff.toastFailed')),
   });
 
   const gapLevel = gap?.gapLevel ?? 'covered';
@@ -119,23 +140,23 @@ function ClauseSignoffRow({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <span className="font-mono text-xs font-semibold text-muted-foreground">{clause.ref}</span>
-            <Badge variant="outline" className="text-xs">{clause.category}</Badge>
+            <Badge variant="outline" className="text-xs">{t(`assessments.clauses.categories.${CATEGORY_KEY[clause.category]}`)}</Badge>
             <Badge
               variant={gapLevel === 'covered' ? 'default' : gapLevel === 'partial' ? 'secondary' : 'destructive'}
-              className="text-xs capitalize"
+              className="text-xs"
             >
-              {gapLevel}
+              {t(`assessments.gapTable.level.${gapLevel}`)}
             </Badge>
             {signoff && (
               <Badge
                 variant={SIGNOFF_CONFIG[signoff.status].variant}
                 className={`text-xs ml-auto ${SIGNOFF_CONFIG[signoff.status].badgeClass}`}
               >
-                {SIGNOFF_CONFIG[signoff.status].label}
+                {t(SIGNOFF_CONFIG[signoff.status].labelKey)}
               </Badge>
             )}
           </div>
-          <p className="text-sm mt-1">{clause.text}</p>
+          <p className="text-sm mt-1">{t(`assessments.clauses.text.${clause.textId}`, { defaultValue: clause.text })}</p>
           {gap?.recommendation && gapLevel !== 'covered' && (
             <p className={`text-xs mt-1 ${gapLevel === 'missing' ? 'text-destructive' : 'text-amber-600 dark:text-amber-400'}`}>
               → {gap.recommendation}
@@ -143,8 +164,12 @@ function ClauseSignoffRow({
           )}
           {signoff && (
             <p className="text-xs text-muted-foreground mt-1">
-              {SIGNOFF_CONFIG[signoff.status].label} by {signoff.signedByName || 'compliance officer'}{' '}
-              · {format(new Date(signoff.signedAt), 'dd MMM yyyy')}{signoff.note ? ` — "${signoff.note}"` : ''}
+              {t('assessments.signoff.signedBy', {
+                label: t(SIGNOFF_CONFIG[signoff.status].labelKey),
+                name: signoff.signedByName || t('assessments.decision.complianceOfficer'),
+                date: format(new Date(signoff.signedAt), 'dd MMM yyyy'),
+              })}
+              {signoff.note ? t('assessments.signoff.noteSuffix', { note: signoff.note }) : ''}
             </p>
           )}
         </div>
@@ -161,7 +186,7 @@ function ClauseSignoffRow({
       {expanded && (
         <div className="mt-3 ml-7 space-y-2">
           <Input
-            placeholder="Optional note (e.g. 'Accepted pending SLA amendment')"
+            placeholder={t('assessments.signoff.notePlaceholder')}
             value={note}
             onChange={(e) => setNote(e.target.value)}
             className="h-8 text-xs"
@@ -180,12 +205,12 @@ function ClauseSignoffRow({
                   className="h-7 px-2.5 text-xs"
                 >
                   <Icon className="h-3 w-3 mr-1" />
-                  {cfg.label}
+                  {t(cfg.labelKey)}
                 </Button>
               );
             })}
             <Button size="sm" variant="ghost" className="h-7 px-2 text-xs" onClick={() => setExpanded(false)}>
-              Cancel
+              {t('common.cancel')}
             </Button>
           </div>
         </div>
@@ -201,6 +226,7 @@ export function Art30ClauseScorecardWithSignoff({
 }: {
   assessment: Assessment;
 }) {
+  const { t } = useTranslation();
   const gaps         = assessment.results?.gaps ?? [];
   const signoffs     = assessment.clauseSignoffs ?? [];
   const assessmentId = assessment._id;
@@ -225,16 +251,16 @@ export function Art30ClauseScorecardWithSignoff({
       {/* Summary row */}
       <div className="flex items-center gap-4 text-sm flex-wrap">
         <span className="flex items-center gap-1.5 text-green-600 font-medium">
-          <CheckCircle2 className="h-4 w-4" /> {covered} covered
+          <CheckCircle2 className="h-4 w-4" /> {t('assessments.signoff.summaryCovered', { count: covered })}
         </span>
         <span className="flex items-center gap-1.5 text-amber-600 font-medium">
-          <AlertTriangle className="h-4 w-4" /> {partial} partial
+          <AlertTriangle className="h-4 w-4" /> {t('assessments.signoff.summaryPartial', { count: partial })}
         </span>
         <span className="flex items-center gap-1.5 text-destructive font-medium">
-          <XCircle className="h-4 w-4" /> {missing} missing
+          <XCircle className="h-4 w-4" /> {t('assessments.signoff.summaryMissing', { count: missing })}
         </span>
         <span className="ml-auto text-xs text-muted-foreground">
-          {reviewed} / {ART30_CLAUSES.length} signed off
+          {t('assessments.signoff.reviewedCount', { reviewed, total: ART30_CLAUSES.length })}
         </span>
       </div>
 

--- a/frontend/src/components/assessment/RiskScoringPanel.tsx
+++ b/frontend/src/components/assessment/RiskScoringPanel.tsx
@@ -12,6 +12,7 @@
 import { Fragment, useState } from 'react';
 import { format } from 'date-fns';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import {
   CheckCircle2,
@@ -59,6 +60,7 @@ export function ResidualRiskMatrix({
   workspace: WorkspaceWithMembership | null;
   qScore?: number | null;
 }) {
+  const { t } = useTranslation();
   const gaps = assessment.results?.gaps ?? null;
   const m = buildRiskMatrix(
     workspace?.vendorTier,
@@ -86,17 +88,17 @@ export function ResidualRiskMatrix({
   const fnSum     = activeFns.reduce((s, fn) => s + (FUNCTION_WEIGHT[fn] ?? 0), 0);
 
   const ctrlLabel =
-    m.controlEffectiveness >= 67 ? 'High (>66%)' :
-    m.controlEffectiveness >= 33 ? 'Medium (33–66%)' :
-    'Low (<33%)';
+    m.controlEffectiveness >= 67 ? t('assessments.matrix.ctrlHigh') :
+    m.controlEffectiveness >= 33 ? t('assessments.matrix.ctrlMed') :
+    t('assessments.matrix.ctrlLow');
 
   return (
     <Card>
       <CardHeader className="pb-2">
         <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wide flex items-center gap-2">
           <ShieldCheck className="h-4 w-4" />
-          Residual Risk Matrix
-          <span className="ml-auto text-xs font-normal normal-case">DORA Art. 28(3)</span>
+          {t('assessments.matrix.title')}
+          <span className="ml-auto text-xs font-normal normal-case">{t('assessments.matrix.ref')}</span>
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -105,60 +107,60 @@ export function ResidualRiskMatrix({
         <div className="grid grid-cols-3 items-center gap-3">
           {/* Inherent */}
           <div className={`rounded-lg border p-3 text-center ${RISK_BG[m.inherentRisk]}`}>
-            <p className="text-xs text-muted-foreground mb-1">Inherent</p>
+            <p className="text-xs text-muted-foreground mb-1">{t('assessments.matrix.inherent')}</p>
             <p className={`text-2xl font-bold tabular-nums ${RISK_COLOR[m.inherentRisk]}`}>
               {m.inherentScore}
               <span className="text-sm font-normal text-muted-foreground">/100</span>
             </p>
-            <p className={`text-xs font-semibold mt-0.5 ${RISK_COLOR[m.inherentRisk]}`}>{m.inherentRisk}</p>
+            <p className={`text-xs font-semibold mt-0.5 ${RISK_COLOR[m.inherentRisk]}`}>{t(`assessments.risk.${m.inherentRisk}`)}</p>
           </div>
 
           {/* Operator */}
           <div className="flex flex-col items-center gap-1 text-muted-foreground">
             <span className="text-lg">×</span>
             <span className="text-xs text-center leading-tight">
-              {Math.round(m.residualFactor * 100)}%<br />remaining
+              {Math.round(m.residualFactor * 100)}%<br />{t('assessments.matrix.remaining')}
             </span>
           </div>
 
           {/* Residual */}
           <div className={`rounded-lg border p-3 text-center ${RISK_BG[doraRisk]}`}>
-            <p className="text-xs text-muted-foreground mb-1">Residual</p>
+            <p className="text-xs text-muted-foreground mb-1">{t('assessments.matrix.residual')}</p>
             <p className={`text-2xl font-bold tabular-nums ${RISK_COLOR[doraRisk]}`}>
               {m.residualScore}
               <span className="text-sm font-normal text-muted-foreground">/100</span>
             </p>
-            <p className={`text-xs font-semibold mt-0.5 ${RISK_COLOR[doraRisk]}`}>{doraRisk}</p>
+            <p className={`text-xs font-semibold mt-0.5 ${RISK_COLOR[doraRisk]}`}>{t(`assessments.risk.${doraRisk}`)}</p>
           </div>
         </div>
 
         {/* ── Input breakdown ── */}
         <div className="rounded-md bg-muted/40 border px-3 py-2.5 text-xs space-y-1.5">
-          <p className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">Input Breakdown</p>
+          <p className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">{t('assessments.matrix.inputBreakdown')}</p>
 
           {/* Tier row */}
           <div className="flex justify-between">
-            <span>Tier ({workspace?.vendorTier ?? 'standard'})</span>
-            <span className="font-mono text-muted-foreground">base {TIER_BASE[workspace?.vendorTier ?? 'standard']}/100</span>
+            <span>{t('assessments.matrix.tier', { tier: workspace?.vendorTier ?? 'standard' })}</span>
+            <span className="font-mono text-muted-foreground">{t('assessments.matrix.base', { base: TIER_BASE[workspace?.vendorTier ?? 'standard'] })}</span>
           </div>
 
           {/* Functions */}
           {activeFns.length > 0 && (
             <div className="flex justify-between">
-              <span>{activeFns.length} ICT function{activeFns.length !== 1 ? 's' : ''}</span>
+              <span>{t('assessments.matrix.functions', { count: activeFns.length })}</span>
               <span className="font-mono text-muted-foreground">+{fnSum}</span>
             </div>
           )}
 
           <div className="border-t pt-1 flex justify-between font-medium">
-            <span>Inherent score</span>
+            <span>{t('assessments.matrix.inherentScore')}</span>
             <span className={`font-mono ${RISK_COLOR[m.inherentRisk]}`}>{m.inherentScore}/100</span>
           </div>
 
           {/* Domain coverage */}
           {m.domainCoverage !== null && (
             <div className="flex justify-between">
-              <span>DORA gap coverage</span>
+              <span>{t('assessments.matrix.gapCoverage')}</span>
               <span className="font-mono text-muted-foreground">{m.domainCoverage}%</span>
             </div>
           )}
@@ -166,13 +168,13 @@ export function ResidualRiskMatrix({
           {/* Q score */}
           {m.qScore !== null && (
             <div className="flex justify-between">
-              <span>Questionnaire score</span>
+              <span>{t('assessments.matrix.qScore')}</span>
               <span className="font-mono text-muted-foreground">{m.qScore}/100</span>
             </div>
           )}
 
           <div className="border-t pt-1 flex justify-between font-medium">
-            <span>Control effectiveness</span>
+            <span>{t('assessments.matrix.controlEffectiveness')}</span>
             <span className={`font-mono ${m.controlEffectiveness >= 67 ? 'text-green-600' : m.controlEffectiveness >= 33 ? 'text-amber-600' : 'text-destructive'}`}>
               {m.controlEffectiveness}% · {ctrlLabel}
             </span>
@@ -180,24 +182,28 @@ export function ResidualRiskMatrix({
 
           {!m.hasData && (
             <p className="text-muted-foreground italic">
-              No questionnaire or DORA data yet — control effectiveness defaults to 0%.
+              {t('assessments.matrix.noData')}
             </p>
           )}
         </div>
 
         {/* ── 3×3 Heat map ── */}
         <div>
-          <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1.5">Risk Matrix</p>
+          <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1.5">{t('assessments.matrix.riskMatrix')}</p>
           <div className="grid grid-cols-4 gap-1 text-[10px] text-center">
             {/* Header row */}
             <div />
-            {(['Low controls', 'Med controls', 'High controls'] as const).map((h) => (
-              <div key={h} className="text-muted-foreground font-medium py-0.5">{h}</div>
+            {([
+              ['ctrlColLow', 'assessments.matrix.ctrlColLow'],
+              ['ctrlColMed', 'assessments.matrix.ctrlColMed'],
+              ['ctrlColHigh', 'assessments.matrix.ctrlColHigh'],
+            ] as const).map(([id, key]) => (
+              <div key={id} className="text-muted-foreground font-medium py-0.5">{t(key)}</div>
             ))}
             {/* Data rows */}
             {(['High', 'Medium', 'Low'] as const).map((inhRisk, rIdx) => (
               <Fragment key={inhRisk}>
-                <div className="text-muted-foreground font-medium flex items-center justify-end pr-1">{inhRisk}</div>
+                <div className="text-muted-foreground font-medium flex items-center justify-end pr-1">{t(`assessments.risk.${inhRisk}`)}</div>
                 {[0, 1, 2].map((cIdx) => {
                   const cell = HEAT[rIdx][cIdx];
                   const isActive = rIdx === inherentRow && cIdx === ctrlCol;
@@ -211,7 +217,7 @@ export function ResidualRiskMatrix({
                         ${isActive ? 'ring-2 ring-primary scale-105 shadow-sm' : 'opacity-60'}
                       `}
                     >
-                      {cell}
+                      {t(`assessments.risk.${cell}`)}
                     </div>
                   );
                 })}
@@ -222,9 +228,7 @@ export function ResidualRiskMatrix({
 
         {/* ── Methodology footnote ── */}
         <p className="text-[10px] text-muted-foreground leading-relaxed">
-          Inherent score = tier base + ICT function weights (DORA Art. 28). Control effectiveness
-          = Q-score × 40% + gap coverage × 60%. Residual factor floor: 15% (risk is never fully
-          eliminated). Formula is deterministic and auditable per Art. 28(3).
+          {t('assessments.matrix.methodology')}
         </p>
       </CardContent>
     </Card>
@@ -239,6 +243,7 @@ export const InherentResidualPanel = ResidualRiskMatrix;
 // ── 2. Weighted domain breakdown ──────────────────────────────────────────────
 
 export function WeightedDomainChart({ assessment }: { assessment: Assessment }) {
+  const { t } = useTranslation();
   const gaps = assessment.results?.gaps ?? [];
   if (gaps.length === 0) return null;
 
@@ -270,10 +275,10 @@ export function WeightedDomainChart({ assessment }: { assessment: Assessment }) 
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
           <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
-            Weighted Domain Coverage
+            {t('assessments.domainChart.title')}
           </CardTitle>
           <span className={`text-sm font-bold ${overallScore >= 70 ? 'text-green-600' : overallScore >= 40 ? 'text-amber-600' : 'text-destructive'}`}>
-            {overallScore}% weighted
+            {t('assessments.domainChart.weighted', { pct: overallScore })}
           </span>
         </div>
       </CardHeader>
@@ -283,7 +288,7 @@ export function WeightedDomainChart({ assessment }: { assessment: Assessment }) 
             <div className="flex items-center justify-between text-xs mb-1">
               <span className="font-medium truncate">{domain}</span>
               <span className="text-muted-foreground ml-2 shrink-0">
-                {Math.round(score)}% · {Math.round(weight * 100)}% weight
+                {t('assessments.domainChart.scoreWeight', { score: Math.round(score), weight: Math.round(weight * 100) })}
               </span>
             </div>
             <div className="h-2 bg-muted rounded-full overflow-hidden">
@@ -308,22 +313,19 @@ export function WeightedDomainChart({ assessment }: { assessment: Assessment }) 
 
 const DECISION_CONFIG = {
   proceed: {
-    label: 'Proceed',
-    description: 'Vendor risk is acceptable. Proceed to contract review.',
+    labelKey: 'assessments.decision.proceed',
     icon: CheckCircle2,
     color: 'text-green-600',
     badgeClass: 'bg-green-100 text-green-800 border-green-200 hover:bg-green-100',
   },
   conditional: {
-    label: 'Proceed with Conditions',
-    description: 'Acceptable with conditions. Remediation plan required before contract execution.',
+    labelKey: 'assessments.decision.conditional',
     icon: AlertTriangle,
     color: 'text-amber-600',
     badgeClass: 'bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100',
   },
   reject: {
-    label: 'Reject',
-    description: 'Residual risk too high. Vendor cannot be onboarded under current controls.',
+    labelKey: 'assessments.decision.reject',
     icon: XCircle,
     color: 'text-destructive',
     badgeClass: '',
@@ -337,6 +339,7 @@ export function FormalRiskDecision({
   assessment: Assessment;
   assessmentId: string;
 }) {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [rationale, setRationale]         = useState('');
   const [pendingDecision, setPending]     = useState<RiskDecisionValue | null>(null);
@@ -346,11 +349,11 @@ export function FormalRiskDecision({
       assessmentsApi.setRiskDecision(assessmentId, decision, rat),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['assessment', assessmentId] });
-      toast.success('Risk decision recorded');
+      toast.success(t('assessments.decision.toastRecorded'));
       setPending(null);
       setRationale('');
     },
-    onError: () => toast.error('Failed to record decision'),
+    onError: () => toast.error(t('assessments.decision.toastFailed')),
   });
 
   const existing: RiskDecision | null | undefined = assessment.riskDecision;
@@ -359,7 +362,7 @@ export function FormalRiskDecision({
     <Card>
       <CardHeader className="pb-2">
         <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
-          Formal Risk Decision
+          {t('assessments.decision.title')}
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
@@ -375,13 +378,13 @@ export function FormalRiskDecision({
                     <Icon className={`h-5 w-5 shrink-0 ${cfg.color}`} />
                     <div className="flex-1">
                       <Badge className={`text-xs ${cfg.badgeClass}`} variant={existing.decision === 'reject' ? 'destructive' : 'outline'}>
-                        {cfg.label}
+                        {t(cfg.labelKey)}
                       </Badge>
                       {existing.rationale && (
                         <p className="text-sm text-muted-foreground mt-1">&quot;{existing.rationale}&quot;</p>
                       )}
                       <p className="text-xs text-muted-foreground mt-1">
-                        Recorded by {existing.setByName || 'compliance officer'} · {format(new Date(existing.setAt), 'dd MMM yyyy HH:mm')}
+                        {t('assessments.decision.recordedBy', { name: existing.setByName || t('assessments.decision.complianceOfficer'), date: format(new Date(existing.setAt), 'dd MMM yyyy HH:mm') })}
                       </p>
                     </div>
                   </>
@@ -389,13 +392,12 @@ export function FormalRiskDecision({
               })()}
             </div>
             <p className="text-xs text-muted-foreground">
-              To change this decision, record a new one below.
+              {t('assessments.decision.changeHint')}
             </p>
           </>
         ) : (
           <p className="text-sm text-muted-foreground">
-            No formal decision recorded yet. Record your compliance decision to proceed to the next
-            step or formally reject this vendor.
+            {t('assessments.decision.none')}
           </p>
         )}
 
@@ -413,7 +415,7 @@ export function FormalRiskDecision({
                   onClick={() => setPending(d)}
                 >
                   <Icon className="h-3.5 w-3.5 mr-1.5" />
-                  {cfg.label}
+                  {t(cfg.labelKey)}
                 </Button>
               );
             })}
@@ -421,10 +423,11 @@ export function FormalRiskDecision({
         ) : (
           <div className="space-y-2">
             <p className="text-sm font-medium">
-              Recording: <span className={DECISION_CONFIG[pendingDecision].color}>{DECISION_CONFIG[pendingDecision].label}</span>
+              {t('assessments.decision.recording')}{' '}
+              <span className={DECISION_CONFIG[pendingDecision].color}>{t(DECISION_CONFIG[pendingDecision].labelKey)}</span>
             </p>
             <Textarea
-              placeholder="Rationale (optional) — e.g. 'Acceptable subject to ISO 27001 renewal by Q3'"
+              placeholder={t('assessments.decision.rationalePlaceholder')}
               value={rationale}
               onChange={(e) => setRationale(e.target.value)}
               className="text-sm h-20 resize-none"
@@ -436,10 +439,10 @@ export function FormalRiskDecision({
                 disabled={mutation.isPending}
                 onClick={() => mutation.mutate({ decision: pendingDecision, rat: rationale })}
               >
-                {mutation.isPending ? 'Saving…' : 'Confirm'}
+                {mutation.isPending ? t('assessments.decision.saving') : t('assessments.decision.confirm')}
               </Button>
               <Button size="sm" variant="ghost" onClick={() => { setPending(null); setRationale(''); }}>
-                Cancel
+                {t('common.cancel')}
               </Button>
             </div>
           </div>

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -586,6 +586,94 @@
         "partial": "Partial",
         "missing": "Missing"
       }
-    }
+    },
+    "matrix": {
+      "title": "Residual Risk Matrix",
+      "ref": "DORA Art. 28(3)",
+      "inherent": "Inherent",
+      "residual": "Residual",
+      "remaining": "remaining",
+      "inputBreakdown": "Input Breakdown",
+      "tier": "Tier ({{tier}})",
+      "base": "base {{base}}/100",
+      "functions_one": "{{count}} ICT function",
+      "functions_other": "{{count}} ICT functions",
+      "inherentScore": "Inherent score",
+      "gapCoverage": "DORA gap coverage",
+      "qScore": "Questionnaire score",
+      "controlEffectiveness": "Control effectiveness",
+      "ctrlHigh": "High (>66%)",
+      "ctrlMed": "Medium (33–66%)",
+      "ctrlLow": "Low (<33%)",
+      "noData": "No questionnaire or DORA data yet — control effectiveness defaults to 0%.",
+      "riskMatrix": "Risk Matrix",
+      "ctrlColLow": "Low controls",
+      "ctrlColMed": "Med controls",
+      "ctrlColHigh": "High controls",
+      "methodology": "Inherent score = tier base + ICT function weights (DORA Art. 28). Control effectiveness = Q-score × 40% + gap coverage × 60%. Residual factor floor: 15% (risk is never fully eliminated). Formula is deterministic and auditable per Art. 28(3)."
+    },
+    "domainChart": {
+      "title": "Weighted Domain Coverage",
+      "weighted": "{{pct}}% weighted",
+      "scoreWeight": "{{score}}% · {{weight}}% weight"
+    },
+    "decision": {
+      "title": "Formal Risk Decision",
+      "proceed": "Proceed",
+      "conditional": "Proceed with Conditions",
+      "reject": "Reject",
+      "toastRecorded": "Risk decision recorded",
+      "toastFailed": "Failed to record decision",
+      "recordedBy": "Recorded by {{name}} · {{date}}",
+      "complianceOfficer": "compliance officer",
+      "changeHint": "To change this decision, record a new one below.",
+      "none": "No formal decision recorded yet. Record your compliance decision to proceed to the next step or formally reject this vendor.",
+      "recording": "Recording:",
+      "rationalePlaceholder": "Rationale (optional) — e.g. 'Acceptable subject to ISO 27001 renewal by Q3'",
+      "saving": "Saving…",
+      "confirm": "Confirm"
+    },
+    "clauses": {
+      "categories": {
+        "serviceDescription": "Service Description",
+        "dataGovernance": "Data Governance",
+        "securityResilience": "Security & Resilience",
+        "subcontracting": "Subcontracting",
+        "businessContinuity": "Business Continuity",
+        "terminationExit": "Termination & Exit",
+        "regulatoryCompliance": "Regulatory Compliance",
+        "auditInspection": "Audit & Inspection"
+      },
+      "text": {
+        "2a": "Clear and complete description of all ICT services and functions to be provided",
+        "2b": "Locations (countries/regions) where data will be processed and stored",
+        "2c": "Provisions on availability, authenticity, integrity and confidentiality of data",
+        "2d": "Provisions for accessibility, return, recovery and secure deletion of data on exit",
+        "2e": "Full description of all subcontractors and their data processing locations",
+        "2f": "ICT service continuity conditions including service level objective amendments",
+        "2g": "Business continuity plan provisions relevant to the financial entity's services",
+        "2h": "Termination rights of the financial entity including adequate notice periods",
+        "3a": "Full service level descriptions with quantitative and qualitative performance targets",
+        "3b": "Advance notification obligations for material changes to ICT services",
+        "3c": "Right to carry out full audits and on-site inspections of the ICT provider",
+        "3d": "Obligation to assist the financial entity in ICT-related incident management"
+      }
+    },
+    "signoff": {
+      "accepted": "Accepted",
+      "rejected": "Rejected",
+      "waived": "Waived",
+      "toastSignedOff": "Clause {{ref}} signed off",
+      "toastNotedAnd": "Clause {{ref}} noted and signed off",
+      "toastFailed": "Sign-off failed",
+      "signedBy": "{{label}} by {{name}} · {{date}}",
+      "noteSuffix": " — \"{{note}}\"",
+      "notePlaceholder": "Optional note (e.g. 'Accepted pending SLA amendment')",
+      "summaryCovered": "{{count}} covered",
+      "summaryPartial": "{{count}} partial",
+      "summaryMissing": "{{count}} missing",
+      "reviewedCount": "{{reviewed}} / {{total}} signed off"
+    },
+    "round": "Round {{n}} of {{total}}"
   }
 }

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -586,6 +586,94 @@
         "partial": "Partiel",
         "missing": "Manquant"
       }
-    }
+    },
+    "matrix": {
+      "title": "Matrice de risque résiduel",
+      "ref": "DORA art. 28(3)",
+      "inherent": "Inhérent",
+      "residual": "Résiduel",
+      "remaining": "restant",
+      "inputBreakdown": "Détail des entrées",
+      "tier": "Catégorie ({{tier}})",
+      "base": "base {{base}}/100",
+      "functions_one": "{{count}} fonction TIC",
+      "functions_other": "{{count}} fonctions TIC",
+      "inherentScore": "Score inhérent",
+      "gapCoverage": "Couverture des écarts DORA",
+      "qScore": "Score du questionnaire",
+      "controlEffectiveness": "Efficacité des contrôles",
+      "ctrlHigh": "Élevée (>66 %)",
+      "ctrlMed": "Moyenne (33–66 %)",
+      "ctrlLow": "Faible (<33 %)",
+      "noData": "Aucune donnée questionnaire ou DORA pour l'instant — l'efficacité des contrôles est fixée à 0 % par défaut.",
+      "riskMatrix": "Matrice de risque",
+      "ctrlColLow": "Contrôles faibles",
+      "ctrlColMed": "Contrôles moyens",
+      "ctrlColHigh": "Contrôles élevés",
+      "methodology": "Score inhérent = base de catégorie + pondérations des fonctions TIC (DORA art. 28). Efficacité des contrôles = score Q × 40 % + couverture des écarts × 60 %. Plancher du facteur résiduel : 15 % (le risque n'est jamais totalement éliminé). La formule est déterministe et auditable selon l'art. 28(3)."
+    },
+    "domainChart": {
+      "title": "Couverture pondérée par domaine",
+      "weighted": "{{pct}} % pondéré",
+      "scoreWeight": "{{score}} % · poids {{weight}} %"
+    },
+    "decision": {
+      "title": "Décision de risque formelle",
+      "proceed": "Poursuivre",
+      "conditional": "Poursuivre sous conditions",
+      "reject": "Rejeter",
+      "toastRecorded": "Décision de risque enregistrée",
+      "toastFailed": "Échec de l'enregistrement de la décision",
+      "recordedBy": "Enregistrée par {{name}} · {{date}}",
+      "complianceOfficer": "responsable conformité",
+      "changeHint": "Pour modifier cette décision, enregistrez-en une nouvelle ci-dessous.",
+      "none": "Aucune décision formelle enregistrée pour l'instant. Enregistrez votre décision de conformité pour passer à l'étape suivante ou rejeter formellement ce fournisseur.",
+      "recording": "Enregistrement :",
+      "rationalePlaceholder": "Justification (facultatif) — ex. « Acceptable sous réserve du renouvellement ISO 27001 d'ici le T3 »",
+      "saving": "Enregistrement…",
+      "confirm": "Confirmer"
+    },
+    "clauses": {
+      "categories": {
+        "serviceDescription": "Description du service",
+        "dataGovernance": "Gouvernance des données",
+        "securityResilience": "Sécurité et résilience",
+        "subcontracting": "Sous-traitance",
+        "businessContinuity": "Continuité d'activité",
+        "terminationExit": "Résiliation et sortie",
+        "regulatoryCompliance": "Conformité réglementaire",
+        "auditInspection": "Audit et inspection"
+      },
+      "text": {
+        "2a": "Description claire et complète de tous les services et fonctions TIC à fournir",
+        "2b": "Lieux (pays/régions) où les données seront traitées et stockées",
+        "2c": "Dispositions relatives à la disponibilité, l'authenticité, l'intégrité et la confidentialité des données",
+        "2d": "Dispositions pour l'accessibilité, la restitution, la récupération et la suppression sécurisée des données à la sortie",
+        "2e": "Description complète de tous les sous-traitants et de leurs lieux de traitement des données",
+        "2f": "Conditions de continuité des services TIC, y compris les modifications des objectifs de niveau de service",
+        "2g": "Dispositions du plan de continuité d'activité pertinentes pour les services de l'entité financière",
+        "2h": "Droits de résiliation de l'entité financière, y compris des délais de préavis adéquats",
+        "3a": "Descriptions complètes des niveaux de service avec des objectifs de performance quantitatifs et qualitatifs",
+        "3b": "Obligations de notification préalable des modifications substantielles des services TIC",
+        "3c": "Droit de réaliser des audits complets et des inspections sur site du prestataire TIC",
+        "3d": "Obligation d'assister l'entité financière dans la gestion des incidents liés aux TIC"
+      }
+    },
+    "signoff": {
+      "accepted": "Acceptée",
+      "rejected": "Rejetée",
+      "waived": "Dérogée",
+      "toastSignedOff": "Clause {{ref}} validée",
+      "toastNotedAnd": "Clause {{ref}} annotée et validée",
+      "toastFailed": "Échec de la validation",
+      "signedBy": "{{label}} par {{name}} · {{date}}",
+      "noteSuffix": " — « {{note}} »",
+      "notePlaceholder": "Note facultative (ex. « Acceptée sous réserve d'un avenant SLA »)",
+      "summaryCovered": "{{count}} couvertes",
+      "summaryPartial": "{{count}} partielles",
+      "summaryMissing": "{{count}} manquantes",
+      "reviewedCount": "{{reviewed}} / {{total}} validées"
+    },
+    "round": "Cycle {{n}} sur {{total}}"
   }
 }


### PR DESCRIPTION
i18n batch 11b — the two interactive assessment panels: **RiskScoringPanel** (residual risk matrix incl. heatmap/input-breakdown/methodology, weighted domain chart, formal risk decision) and **ClauseSignoffPanel** (all 12 Art. 30 clause texts + 8 categories, sign-off states, negotiation-round badge, scorecard summary). `category` stays English to keep the gap-matching heuristic intact; display goes through a category-key map. **Completes the assessments feature area.** Adds matrix/domainChart/decision/clauses/signoff/round keys. Build green, eslint clean, frontend suite 513/513 (incl. risk-scoring-panel test), parity 519/519.