### PR TITLE
feat(web): translate chat feature pages — EN/FR (i18n batch 12a)

### DIFF
--- a/frontend/src/features/chat/components/chat-empty-state.tsx
+++ b/frontend/src/features/chat/components/chat-empty-state.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTranslation } from 'react-i18next';
 import { AlertCircle, MessageSquarePlus } from 'lucide-react';
 
 import { Alert, AlertDescription } from '@/shared/ui/alert';
@@ -11,18 +12,14 @@ interface ChatEmptyStateProps {
   onExampleClick: (question: string) => void;
 }
 
-const exampleQuestions = [
-  'How does authentication work?',
-  'What are the main features?',
-  'Summarize the documentation',
-  'How do I get started?',
-];
+const exampleQuestionKeys = ['chat.empty.q1', 'chat.empty.q2', 'chat.empty.q3', 'chat.empty.q4'];
 
 export function ChatEmptyState({
   workspaceName,
   canQuery,
   onExampleClick,
 }: ChatEmptyStateProps) {
+  const { t } = useTranslation();
   return (
     <div className="flex-1 flex flex-col items-center justify-center p-6">
       <div className="text-center max-w-md">
@@ -30,36 +27,39 @@ export function ChatEmptyState({
           <MessageSquarePlus className="h-6 w-6 text-primary" />
         </div>
         <h2 className="text-xl font-semibold mb-2">
-          {workspaceName ? `Welcome to ${workspaceName}` : 'Start a Conversation'}
+          {workspaceName ? t('chat.empty.welcome', { name: workspaceName }) : t('chat.empty.start')}
         </h2>
         <p className="text-muted-foreground mb-6">
-          Ask questions about your knowledge base and get AI-powered answers with source citations.
+          {t('chat.empty.subtitle')}
         </p>
 
         {!canQuery && (
           <Alert className="mb-4">
             <AlertCircle className="h-4 w-4" />
             <AlertDescription>
-              You have read-only access. Contact the workspace owner for query permissions.
+              {t('chat.empty.readOnly')}
             </AlertDescription>
           </Alert>
         )}
 
         {canQuery && (
           <div className="space-y-2">
-            <p className="text-sm text-muted-foreground mb-3">Try asking:</p>
+            <p className="text-sm text-muted-foreground mb-3">{t('chat.empty.tryAsking')}</p>
             <div className="flex flex-wrap gap-2 justify-center">
-              {exampleQuestions.map((question) => (
-                <Button
-                  key={question}
-                  variant="outline"
-                  size="sm"
-                  onClick={() => onExampleClick(question)}
-                  className="text-xs"
-                >
-                  {question}
-                </Button>
-              ))}
+              {exampleQuestionKeys.map((key) => {
+                const question = t(key);
+                return (
+                  <Button
+                    key={key}
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onExampleClick(question)}
+                    className="text-xs"
+                  >
+                    {question}
+                  </Button>
+                );
+              })}
             </div>
           </div>
         )}

--- a/frontend/src/features/chat/components/conversation-page.tsx
+++ b/frontend/src/features/chat/components/conversation-page.tsx
@@ -2,6 +2,7 @@
 
 import { use } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import { Loader2, ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 
@@ -16,6 +17,7 @@ interface ConversationPageProps {
 }
 
 export function ConversationPage({ params }: ConversationPageProps) {
+  const { t } = useTranslation();
   const { id } = use(params);
   const activeWorkspace = useActiveWorkspace();
   const { data: workspaces = [], isLoading: workspacesLoading } = useWorkspaceListQuery();
@@ -65,11 +67,11 @@ export function ConversationPage({ params }: ConversationPageProps) {
   if (error || !data) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-4">
-        <p className="text-destructive">Failed to load conversation</p>
+        <p className="text-destructive">{t('chat.conversation.failedLoad')}</p>
         <Link href="/conversations">
           <Button variant="outline">
             <ArrowLeft className="h-4 w-4 mr-2" />
-            Back to Conversations
+            {t('chat.conversation.back')}
           </Button>
         </Link>
       </div>
@@ -79,15 +81,15 @@ export function ConversationPage({ params }: ConversationPageProps) {
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-3 border-b px-4 py-2">
-        <Link href="/conversations" aria-label="Back to conversations list">
-          <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Back to conversations">
+        <Link href="/conversations" aria-label={t('chat.conversation.backAriaList')}>
+          <Button variant="ghost" size="icon" className="h-8 w-8" aria-label={t('chat.conversation.backAria')}>
             <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Button>
         </Link>
         <div className="flex-1 min-w-0">
           <h1 className="text-sm font-medium truncate">{data.conversation.title}</h1>
           <p className="text-xs text-muted-foreground">
-            {data.conversation.messageCount} messages
+            {t('chat.messageCount', { count: data.conversation.messageCount })}
           </p>
         </div>
       </div>

--- a/frontend/src/features/chat/components/conversations-page.tsx
+++ b/frontend/src/features/chat/components/conversations-page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import {
   MessageSquare,
   Pin,
@@ -37,6 +38,7 @@ import { destructiveActionClasses } from '@/lib/styles/status-colors';
 import type { Conversation } from '@/types';
 
 export function ConversationsPage() {
+  const { t } = useTranslation();
   const router = useRouter();
   const queryClient = useQueryClient();
   const activeWorkspace = useActiveWorkspace();
@@ -59,11 +61,11 @@ export function ConversationsPage() {
     mutationFn: (id: string) => conversationsApi.delete(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['conversations'] });
-      toast.success('Conversation deleted');
+      toast.success(t('chat.list.toast.deleted'));
       setConversationToDelete(null);
     },
     onError: () => {
-      toast.error('Failed to delete conversation');
+      toast.error(t('chat.list.toast.deleteFailed'));
     },
   });
 
@@ -71,13 +73,13 @@ export function ConversationsPage() {
     mutationFn: (ids: string[]) => conversationsApi.bulkDelete(ids),
     onSuccess: (response) => {
       queryClient.invalidateQueries({ queryKey: ['conversations'] });
-      toast.success(`${response.data?.deletedCount || 0} conversations deleted`);
+      toast.success(t('chat.list.toast.bulkDeleted', { count: response.data?.deletedCount || 0 }));
       setSelectedIds(new Set());
       setIsSelectionMode(false);
       setDeleteDialogOpen(false);
     },
     onError: () => {
-      toast.error('Failed to delete conversations');
+      toast.error(t('chat.list.toast.bulkDeleteFailed'));
     },
   });
 
@@ -130,8 +132,8 @@ export function ConversationsPage() {
       <div className="flex h-full items-center justify-center">
         <p className="text-muted-foreground">
           {workspaces.length === 0
-            ? 'Create a workspace to get started'
-            : 'Select a workspace to view conversations'}
+            ? t('chat.createWorkspace')
+            : t('chat.selectWorkspaceConv')}
         </p>
       </div>
     );
@@ -141,9 +143,9 @@ export function ConversationsPage() {
     <div className="p-6 max-w-5xl mx-auto">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="page-title">Conversations</h1>
+          <h1 className="page-title">{t('chat.list.title')}</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            View and manage your chat history
+            {t('chat.list.subtitle')}
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -160,19 +162,19 @@ export function ConversationsPage() {
               {isSelectionMode ? (
                 <>
                   <X className="h-4 w-4 mr-2" />
-                  Cancel
+                  {t('common.cancel')}
                 </>
               ) : (
                 <>
                   <CheckSquare className="h-4 w-4 mr-2" />
-                  Select
+                  {t('chat.list.select')}
                 </>
               )}
             </Button>
           )}
           <Button onClick={() => router.push('/chat')}>
             <Plus className="h-4 w-4 mr-2" />
-            New Chat
+            {t('chat.list.newChat')}
           </Button>
         </div>
       </div>
@@ -180,9 +182,9 @@ export function ConversationsPage() {
       {isSelectionMode && selectedIds.size > 0 && (
         <div className="mb-4 p-3 bg-muted rounded-lg flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <span className="text-sm font-medium">{selectedIds.size} selected</span>
-            <Button variant="ghost" size="sm" onClick={selectAll}>Select All</Button>
-            <Button variant="ghost" size="sm" onClick={deselectAll}>Deselect All</Button>
+            <span className="text-sm font-medium">{t('chat.list.selectedCount', { count: selectedIds.size })}</span>
+            <Button variant="ghost" size="sm" onClick={selectAll}>{t('chat.list.selectAll')}</Button>
+            <Button variant="ghost" size="sm" onClick={deselectAll}>{t('chat.list.deselectAll')}</Button>
           </div>
           <Button
             variant="destructive"
@@ -195,7 +197,7 @@ export function ConversationsPage() {
             ) : (
               <Trash2 className="h-4 w-4 mr-2" />
             )}
-            Delete Selected
+            {t('chat.list.deleteSelected')}
           </Button>
         </div>
       )}
@@ -213,16 +215,16 @@ export function ConversationsPage() {
         </div>
       ) : error ? (
         <div className="text-center py-12">
-          <p className="text-destructive">Failed to load conversations</p>
+          <p className="text-destructive">{t('chat.list.failedLoad')}</p>
         </div>
       ) : conversations.length === 0 ? (
         <EmptyState
           icon={MessageSquare}
-          heading="No conversations yet"
-          description="Ask AI questions about your vendor documents - every answer is grounded in the documents you have uploaded, with citations showing exactly where each finding came from."
-          cta="Start a conversation"
+          heading={t('chat.list.empty.heading')}
+          description={t('chat.list.empty.description')}
+          cta={t('chat.list.empty.cta')}
           onAction={() => router.push('/chat')}
-          hint={'Try: "What are the gaps in [vendor]\'s ISO 27001 policy?" or "Does the contract include Art. 30 audit rights?"'}
+          hint={t('chat.list.empty.hint')}
         />
       ) : (
         <div className="space-y-6">
@@ -230,7 +232,7 @@ export function ConversationsPage() {
             <div>
               <h2 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-2">
                 <Pin className="h-4 w-4" />
-                Pinned ({pinnedConversations.length})
+                {t('chat.list.pinned', { count: pinnedConversations.length })}
               </h2>
               <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                 {pinnedConversations.map((conversation) => (
@@ -264,7 +266,7 @@ export function ConversationsPage() {
                           <div className="flex items-center gap-4 text-sm text-muted-foreground">
                             <span className="flex items-center gap-1">
                               <MessageCircle className="h-3.5 w-3.5" />
-                              {conversation.messageCount} messages
+                              {t('chat.messageCount', { count: conversation.messageCount })}
                             </span>
                             <span className="flex items-center gap-1">
                               <Calendar className="h-3.5 w-3.5" />
@@ -294,7 +296,7 @@ export function ConversationsPage() {
             <div>
               <h2 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-2">
                 <MessageCircle className="h-4 w-4" />
-                Recent ({recentConversations.length})
+                {t('chat.list.recent', { count: recentConversations.length })}
               </h2>
               <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                 {recentConversations.map((conversation) => (
@@ -327,7 +329,7 @@ export function ConversationsPage() {
                           <div className="flex items-center gap-4 text-sm text-muted-foreground">
                             <span className="flex items-center gap-1">
                               <MessageCircle className="h-3.5 w-3.5" />
-                              {conversation.messageCount} messages
+                              {t('chat.messageCount', { count: conversation.messageCount })}
                             </span>
                             <span className="flex items-center gap-1">
                               <Calendar className="h-3.5 w-3.5" />
@@ -359,12 +361,12 @@ export function ConversationsPage() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              {conversationToDelete ? 'Delete conversation?' : `Delete ${selectedIds.size} conversations?`}
+              {conversationToDelete ? t('chat.list.deleteOne') : t('chat.list.deleteMany', { count: selectedIds.size })}
             </AlertDialogTitle>
             <AlertDialogDescription>
               {conversationToDelete
-                ? 'This conversation will be permanently deleted. This action cannot be undone.'
-                : `These ${selectedIds.size} conversations will be permanently deleted. This action cannot be undone.`}
+                ? t('chat.list.deleteOneDesc')
+                : t('chat.list.deleteManyDesc', { count: selectedIds.size })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -374,7 +376,7 @@ export function ConversationsPage() {
                 setConversationToDelete(null);
               }}
             >
-              Cancel
+              {t('common.cancel')}
             </AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmDelete}
@@ -384,7 +386,7 @@ export function ConversationsPage() {
               {(deleteMutation.isPending || bulkDeleteMutation.isPending) ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
-                'Delete'
+                t('common.delete')
               )}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/frontend/src/features/chat/components/new-chat-page.tsx
+++ b/frontend/src/features/chat/components/new-chat-page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { Loader2, MessageSquarePlus } from 'lucide-react';
 
 import { ChatInterface } from '@/components/chat';
@@ -11,6 +12,7 @@ import type { Conversation } from '@/types';
 // ChatInterface creates the conversation on first send, then onConversationCreated
 // redirects the user to /conversations/<id> so the URL reflects the saved session.
 export function NewChatPage() {
+  const { t } = useTranslation();
   const router = useRouter();
   const activeWorkspace = useActiveWorkspace();
   const { isLoading: workspacesLoading } = useWorkspaceListQuery();
@@ -30,7 +32,7 @@ export function NewChatPage() {
   if (!activeWorkspace) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-muted-foreground">Select a workspace to start a conversation</p>
+        <p className="text-muted-foreground">{t('chat.selectWorkspaceStart')}</p>
       </div>
     );
   }
@@ -39,7 +41,7 @@ export function NewChatPage() {
     <div className="flex h-full flex-col">
       <div className="flex items-center border-b px-4 py-2">
         <MessageSquarePlus className="h-4 w-4 mr-2 text-muted-foreground" />
-        <h1 className="text-sm font-medium">New Conversation</h1>
+        <h1 className="text-sm font-medium">{t('chat.newConversation')}</h1>
       </div>
       <div className="flex-1 overflow-hidden">
         <ChatInterface onConversationCreated={handleConversationCreated} />

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -675,5 +675,59 @@
       "reviewedCount": "{{reviewed}} / {{total}} signed off"
     },
     "round": "Round {{n}} of {{total}}"
+  },
+  "chat": {
+    "newConversation": "New Conversation",
+    "selectWorkspaceStart": "Select a workspace to start a conversation",
+    "selectWorkspaceConv": "Select a workspace to view conversations",
+    "createWorkspace": "Create a workspace to get started",
+    "messageCount_one": "{{count}} message",
+    "messageCount_other": "{{count}} messages",
+    "conversation": {
+      "failedLoad": "Failed to load conversation",
+      "back": "Back to Conversations",
+      "backAriaList": "Back to conversations list",
+      "backAria": "Back to conversations"
+    },
+    "empty": {
+      "welcome": "Welcome to {{name}}",
+      "start": "Start a Conversation",
+      "subtitle": "Ask questions about your knowledge base and get AI-powered answers with source citations.",
+      "readOnly": "You have read-only access. Contact the workspace owner for query permissions.",
+      "tryAsking": "Try asking:",
+      "q1": "How does authentication work?",
+      "q2": "What are the main features?",
+      "q3": "Summarize the documentation",
+      "q4": "How do I get started?"
+    },
+    "list": {
+      "title": "Conversations",
+      "subtitle": "View and manage your chat history",
+      "select": "Select",
+      "newChat": "New Chat",
+      "selectedCount": "{{count}} selected",
+      "selectAll": "Select All",
+      "deselectAll": "Deselect All",
+      "deleteSelected": "Delete Selected",
+      "failedLoad": "Failed to load conversations",
+      "pinned": "Pinned ({{count}})",
+      "recent": "Recent ({{count}})",
+      "empty": {
+        "heading": "No conversations yet",
+        "description": "Ask AI questions about your vendor documents - every answer is grounded in the documents you have uploaded, with citations showing exactly where each finding came from.",
+        "cta": "Start a conversation",
+        "hint": "Try: \"What are the gaps in [vendor]'s ISO 27001 policy?\" or \"Does the contract include Art. 30 audit rights?\""
+      },
+      "deleteOne": "Delete conversation?",
+      "deleteMany": "Delete {{count}} conversations?",
+      "deleteOneDesc": "This conversation will be permanently deleted. This action cannot be undone.",
+      "deleteManyDesc": "These {{count}} conversations will be permanently deleted. This action cannot be undone.",
+      "toast": {
+        "deleted": "Conversation deleted",
+        "deleteFailed": "Failed to delete conversation",
+        "bulkDeleted": "{{count}} conversations deleted",
+        "bulkDeleteFailed": "Failed to delete conversations"
+      }
+    }
   }
 }

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -675,5 +675,59 @@
       "reviewedCount": "{{reviewed}} / {{total}} validées"
     },
     "round": "Cycle {{n}} sur {{total}}"
+  },
+  "chat": {
+    "newConversation": "Nouvelle conversation",
+    "selectWorkspaceStart": "Sélectionnez un espace de travail pour démarrer une conversation",
+    "selectWorkspaceConv": "Sélectionnez un espace de travail pour voir les conversations",
+    "createWorkspace": "Créez un espace de travail pour commencer",
+    "messageCount_one": "{{count}} message",
+    "messageCount_other": "{{count}} messages",
+    "conversation": {
+      "failedLoad": "Échec du chargement de la conversation",
+      "back": "Retour aux conversations",
+      "backAriaList": "Retour à la liste des conversations",
+      "backAria": "Retour aux conversations"
+    },
+    "empty": {
+      "welcome": "Bienvenue dans {{name}}",
+      "start": "Démarrer une conversation",
+      "subtitle": "Posez des questions sur votre base de connaissances et obtenez des réponses assistées par IA avec citations des sources.",
+      "readOnly": "Vous disposez d'un accès en lecture seule. Contactez le propriétaire de l'espace de travail pour obtenir les droits d'interrogation.",
+      "tryAsking": "Essayez de demander :",
+      "q1": "Comment fonctionne l'authentification ?",
+      "q2": "Quelles sont les principales fonctionnalités ?",
+      "q3": "Résume la documentation",
+      "q4": "Comment démarrer ?"
+    },
+    "list": {
+      "title": "Conversations",
+      "subtitle": "Consultez et gérez votre historique de conversations",
+      "select": "Sélectionner",
+      "newChat": "Nouvelle conversation",
+      "selectedCount": "{{count}} sélectionnée(s)",
+      "selectAll": "Tout sélectionner",
+      "deselectAll": "Tout désélectionner",
+      "deleteSelected": "Supprimer la sélection",
+      "failedLoad": "Échec du chargement des conversations",
+      "pinned": "Épinglées ({{count}})",
+      "recent": "Récentes ({{count}})",
+      "empty": {
+        "heading": "Aucune conversation pour le moment",
+        "description": "Posez à l'IA des questions sur vos documents fournisseurs — chaque réponse est ancrée dans les documents que vous avez importés, avec des citations indiquant exactement d'où provient chaque constat.",
+        "cta": "Démarrer une conversation",
+        "hint": "Essayez : « Quels sont les écarts dans la politique ISO 27001 de [fournisseur] ? » ou « Le contrat inclut-il les droits d'audit de l'art. 30 ? »"
+      },
+      "deleteOne": "Supprimer la conversation ?",
+      "deleteMany": "Supprimer {{count}} conversations ?",
+      "deleteOneDesc": "Cette conversation sera définitivement supprimée. Cette action est irréversible.",
+      "deleteManyDesc": "Ces {{count}} conversations seront définitivement supprimées. Cette action est irréversible.",
+      "toast": {
+        "deleted": "Conversation supprimée",
+        "deleteFailed": "Échec de la suppression de la conversation",
+        "bulkDeleted": "{{count}} conversations supprimées",
+        "bulkDeleteFailed": "Échec de la suppression des conversations"
+      }
+    }
   }
 }


### PR DESCRIPTION
i18n batch 12a — chat **feature pages**: conversations list (header, selection mode, pinned/recent groups, single + bulk delete dialogs, toasts), conversation view, new-chat page, and the chat empty state (incl. example questions). Adds the `chat` namespace (list/empty/conversation + pluralised message count). Build green, eslint clean, parity 561/561. Batch 12b (the `components/chat` UI: input, message bubbles, sources, streaming) follows.

_Note: branch pushed via the GitHub Git Data API — local git-over-HTTPS push was hanging on the pack-upload POST in this environment._