### PR TITLE
feat(web): translate chat UI components — EN/FR (i18n batch 12b)

### DIFF
--- a/frontend/src/components/chat/chat-input.tsx
+++ b/frontend/src/components/chat/chat-input.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect, KeyboardEvent } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Send, Loader2, StopCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -22,9 +23,10 @@ export function ChatInput({
   isLoading = false,
   isStreaming = false,
   disabled = false,
-  placeholder = 'Ask a question about your knowledge base...',
+  placeholder,
   maxLength = 4000,
 }: ChatInputProps) {
+  const { t } = useTranslation();
   const [message, setMessage] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -84,7 +86,7 @@ export function ChatInput({
             value={message}
             onChange={(e) => setMessage(e.target.value.slice(0, maxLength))}
             onKeyDown={handleKeyDown}
-            placeholder={disabled ? 'You do not have permission to send messages' : placeholder}
+            placeholder={disabled ? t('chat.ui.input.disabledSend') : (placeholder ?? t('chat.ui.input.placeholder'))}
             disabled={disabled || isLoading}
             className={cn(
               'min-h-[52px] max-h-[200px] resize-none pr-24 py-3',
@@ -115,7 +117,7 @@ export function ChatInput({
                 onClick={handleStop}
               >
                 <StopCircle className="h-4 w-4" />
-                <span className="sr-only">Stop generating</span>
+                <span className="sr-only">{t('chat.ui.input.stop')}</span>
               </Button>
             ) : (
               <Button
@@ -130,7 +132,7 @@ export function ChatInput({
                 ) : (
                   <Send className="h-4 w-4" />
                 )}
-                <span className="sr-only">Send message</span>
+                <span className="sr-only">{t('chat.ui.input.send')}</span>
               </Button>
             )}
           </div>
@@ -138,8 +140,9 @@ export function ChatInput({
 
         {/* Help text */}
         <p className="mt-2 text-xs text-muted-foreground text-center">
-          Press <kbd className="px-1 py-0.5 bg-muted rounded text-[10px]">Enter</kbd> to send,{' '}
-          <kbd className="px-1 py-0.5 bg-muted rounded text-[10px]">Shift+Enter</kbd> for new line
+          {t('chat.ui.input.helpPress')}{' '}
+          <kbd className="px-1 py-0.5 bg-muted rounded text-[10px]">Enter</kbd> {t('chat.ui.input.helpToSend')}{' '}
+          <kbd className="px-1 py-0.5 bg-muted rounded text-[10px]">Shift+Enter</kbd> {t('chat.ui.input.helpNewLine')}
         </p>
       </div>
     </div>

--- a/frontend/src/components/chat/chat-interface.tsx
+++ b/frontend/src/components/chat/chat-interface.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTranslation } from 'react-i18next';
 import { AlertCircle, RefreshCw } from 'lucide-react';
 
 import { MessageList } from './message-list';
@@ -23,6 +24,7 @@ export function ChatInterface({
   onConversationCreated,
   onMessageAdded,
 }: ChatInterfaceProps) {
+  const { t } = useTranslation();
   const {
     activeWorkspace,
     canQuery,
@@ -63,7 +65,7 @@ export function ChatInterface({
                 className="ml-4 shrink-0"
               >
                 <RefreshCw className="h-3 w-3 mr-1" />
-                Retry
+                {t('chat.ui.retry')}
               </Button>
             )}
           </AlertDescription>
@@ -99,8 +101,8 @@ export function ChatInterface({
         disabled={!canQuery}
         placeholder={
           canQuery
-            ? 'Ask a question about your knowledge base...'
-            : 'You do not have permission to ask questions'
+            ? t('chat.ui.input.placeholder')
+            : t('chat.ui.input.disabledQuery')
         }
       />
     </div>

--- a/frontend/src/components/chat/conversation-list.tsx
+++ b/frontend/src/components/chat/conversation-list.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import {
   MessageSquare,
   Pin,
@@ -51,6 +52,7 @@ export function ConversationList({
   onNewConversation,
   selectedId,
 }: ConversationListProps) {
+  const { t } = useTranslation();
   const pathname = usePathname();
   const queryClient = useQueryClient();
   const activeWorkspace = useActiveWorkspace();
@@ -90,7 +92,7 @@ export function ConversationList({
       queryClient.invalidateQueries({ queryKey: ['conversations'] });
     },
     onError: () => {
-      toast.error('Failed to update conversation');
+      toast.error(t('chat.ui.sidebar.updateFailed'));
     },
   });
 
@@ -101,12 +103,12 @@ export function ConversationList({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['conversations'] });
-      toast.success('Conversation deleted');
+      toast.success(t('chat.list.toast.deleted'));
       setDeleteDialogOpen(false);
       setConversationToDelete(null);
     },
     onError: () => {
-      toast.error('Failed to delete conversation');
+      toast.error(t('chat.list.toast.deleteFailed'));
     },
   });
 
@@ -133,7 +135,7 @@ export function ConversationList({
   if (!activeWorkspace) {
     return (
       <div className="p-4 text-center text-sm text-muted-foreground">
-        Select a workspace to view conversations
+        {t('chat.selectWorkspaceConv')}
       </div>
     );
   }
@@ -148,14 +150,14 @@ export function ConversationList({
           size="sm"
         >
           <Plus className="h-4 w-4 mr-2" />
-          New Chat
+          {t('chat.list.newChat')}
         </Button>
 
         {/* Search */}
         <div className="relative">
           <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
-            placeholder="Search conversations..."
+            placeholder={t('chat.ui.sidebar.search')}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="pl-8 h-8 text-sm"
@@ -173,11 +175,11 @@ export function ConversationList({
           </div>
         ) : error ? (
           <div className="p-4 text-center text-sm text-destructive">
-            Failed to load conversations
+            {t('chat.list.failedLoad')}
           </div>
         ) : filteredConversations.length === 0 ? (
           <div className="p-4 text-center text-sm text-muted-foreground">
-            {search ? 'No conversations found' : 'No conversations yet'}
+            {search ? t('chat.ui.sidebar.noneFound') : t('chat.ui.sidebar.noneYet')}
           </div>
         ) : (
           <div className="p-2">
@@ -185,7 +187,7 @@ export function ConversationList({
             {pinnedConversations.length > 0 && (
               <div className="mb-4">
                 <p className="px-2 py-1 text-xs font-medium text-muted-foreground uppercase">
-                  Pinned
+                  {t('chat.ui.sidebar.pinned')}
                 </p>
                 {pinnedConversations.map((conversation) => (
                   <ConversationItem
@@ -212,7 +214,7 @@ export function ConversationList({
               <div>
                 {pinnedConversations.length > 0 && (
                   <p className="px-2 py-1 text-xs font-medium text-muted-foreground uppercase">
-                    Recent
+                    {t('chat.ui.sidebar.recent')}
                   </p>
                 )}
                 {unpinnedConversations.map((conversation) => (
@@ -242,14 +244,13 @@ export function ConversationList({
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete conversation?</AlertDialogTitle>
+            <AlertDialogTitle>{t('chat.list.deleteOne')}</AlertDialogTitle>
             <AlertDialogDescription>
-              This action cannot be undone. This will permanently delete the
-              conversation and all its messages.
+              {t('chat.ui.sidebar.deleteDesc')}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmDelete}
               className={destructiveActionClasses}
@@ -257,7 +258,7 @@ export function ConversationList({
               {deleteMutation.isPending ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
-                'Delete'
+                t('common.delete')
               )}
             </AlertDialogAction>
           </AlertDialogFooter>
@@ -281,6 +282,7 @@ function ConversationItem({
   onTogglePin,
   onDelete,
 }: ConversationItemProps) {
+  const { t } = useTranslation();
   const formattedDate = new Date(conversation.lastMessageAt).toLocaleDateString(
     undefined,
     { month: 'short', day: 'numeric' }
@@ -301,7 +303,7 @@ function ConversationItem({
         <div className="flex-1 min-w-0">
           <p className="text-sm font-medium truncate">{conversation.title}</p>
           <p className="text-xs text-muted-foreground">
-            {formattedDate} · {conversation.messageCount} messages
+            {formattedDate} · {t('chat.messageCount', { count: conversation.messageCount })}
           </p>
         </div>
         {conversation.isPinned && (
@@ -317,7 +319,7 @@ function ConversationItem({
             variant="ghost"
             size="icon"
             className="h-7 w-7 opacity-0 group-hover:opacity-100 focus:opacity-100 shrink-0"
-            aria-label={`Actions for conversation: ${conversation.title}`}
+            aria-label={t('chat.ui.sidebar.actionsAria', { title: conversation.title })}
           >
             <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
           </Button>
@@ -327,12 +329,12 @@ function ConversationItem({
             {conversation.isPinned ? (
               <>
                 <PinOff className="h-4 w-4 mr-2" />
-                Unpin
+                {t('chat.ui.sidebar.unpin')}
               </>
             ) : (
               <>
                 <Pin className="h-4 w-4 mr-2" />
-                Pin
+                {t('chat.ui.sidebar.pin')}
               </>
             )}
           </DropdownMenuItem>
@@ -341,7 +343,7 @@ function ConversationItem({
             className="text-destructive focus:text-destructive"
           >
             <Trash2 className="h-4 w-4 mr-2" />
-            Delete
+            {t('common.delete')}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/frontend/src/components/chat/message-bubble.tsx
+++ b/frontend/src/components/chat/message-bubble.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { User, Bot, Copy, Check, ThumbsUp, ThumbsDown, RefreshCw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -31,6 +32,7 @@ export function MessageBubble({
   onRegenerate,
   showActions = true,
 }: MessageBubbleProps) {
+  const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
   const isUser = message.role === 'user';
 
@@ -115,7 +117,7 @@ export function MessageBubble({
                     size="icon"
                     className="h-7 w-7"
                     onClick={handleCopy}
-                    aria-label={copied ? 'Copied to clipboard' : 'Copy message'}
+                    aria-label={copied ? t('chat.ui.bubble.copiedAria') : t('chat.ui.bubble.copyAria')}
                   >
                     {copied ? (
                       <Check className="h-3.5 w-3.5 text-green-500" aria-hidden="true" />
@@ -125,7 +127,7 @@ export function MessageBubble({
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>{copied ? 'Copied!' : 'Copy'}</p>
+                  <p>{copied ? t('chat.ui.bubble.copiedTooltip') : t('chat.ui.bubble.copyTooltip')}</p>
                 </TooltipContent>
               </Tooltip>
 
@@ -142,14 +144,14 @@ export function MessageBubble({
                           message.feedback === 'positive' && 'text-green-500'
                         )}
                         onClick={() => handleFeedback('positive')}
-                        aria-label="Mark as good response"
+                        aria-label={t('chat.ui.bubble.goodAria')}
                         aria-pressed={message.feedback === 'positive'}
                       >
                         <ThumbsUp className="h-3.5 w-3.5" aria-hidden="true" />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>Good response</p>
+                      <p>{t('chat.ui.bubble.goodTooltip')}</p>
                     </TooltipContent>
                   </Tooltip>
 
@@ -163,14 +165,14 @@ export function MessageBubble({
                           message.feedback === 'negative' && 'text-red-500'
                         )}
                         onClick={() => handleFeedback('negative')}
-                        aria-label="Mark as bad response"
+                        aria-label={t('chat.ui.bubble.badAria')}
                         aria-pressed={message.feedback === 'negative'}
                       >
                         <ThumbsDown className="h-3.5 w-3.5" aria-hidden="true" />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>Bad response</p>
+                      <p>{t('chat.ui.bubble.badTooltip')}</p>
                     </TooltipContent>
                   </Tooltip>
                 </>
@@ -185,13 +187,13 @@ export function MessageBubble({
                       size="icon"
                       className="h-7 w-7"
                       onClick={onRegenerate}
-                      aria-label="Regenerate response"
+                      aria-label={t('chat.ui.bubble.regenerateAria')}
                     >
                       <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>Regenerate</p>
+                    <p>{t('chat.ui.bubble.regenerateTooltip')}</p>
                   </TooltipContent>
                 </Tooltip>
               )}

--- a/frontend/src/components/chat/source-citations.tsx
+++ b/frontend/src/components/chat/source-citations.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronUp, FileText, ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -35,6 +36,7 @@ interface SourceCitationsProps {
 }
 
 export function SourceCitations({ sources, maxVisible = 3, messageId }: SourceCitationsProps) {
+  const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
   const [expandedSources, setExpandedSources] = useState<Set<string>>(new Set());
 
@@ -60,7 +62,7 @@ export function SourceCitations({ sources, maxVisible = 3, messageId }: SourceCi
       <div className="flex items-center gap-2 mb-2">
         <FileText className="h-3.5 w-3.5 text-muted-foreground" />
         <span className="text-xs font-medium text-muted-foreground">
-          Sources ({sources.length})
+          {t('chat.ui.sources.title', { count: sources.length })}
         </span>
       </div>
 
@@ -87,12 +89,12 @@ export function SourceCitations({ sources, maxVisible = 3, messageId }: SourceCi
           {isExpanded ? (
             <>
               <ChevronUp className="h-3 w-3 mr-1" />
-              Show less
+              {t('chat.ui.sources.showLess')}
             </>
           ) : (
             <>
               <ChevronDown className="h-3 w-3 mr-1" />
-              Show {sources.length - maxVisible} more sources
+              {t('chat.ui.sources.showMore', { count: sources.length - maxVisible })}
             </>
           )}
         </Button>
@@ -111,6 +113,7 @@ interface SourceCardProps {
 }
 
 function SourceCard({ source, index, isExpanded, onToggle, domId }: SourceCardProps) {
+  const { t } = useTranslation();
   const hasContent = source.content && source.content.length > 0;
   const truncatedContent =
     source.content && source.content.length > 200
@@ -140,7 +143,7 @@ function SourceCard({ source, index, isExpanded, onToggle, domId }: SourceCardPr
               <p className="text-sm font-medium truncate">{source.title}</p>
               {source.score !== undefined && (
                 <p className="text-xs text-muted-foreground">
-                  Relevance: {Math.round(source.score * 100)}%
+                  {t('chat.ui.sources.relevance', { pct: Math.round(source.score * 100) })}
                 </p>
               )}
             </div>

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -728,6 +728,49 @@
         "bulkDeleted": "{{count}} conversations deleted",
         "bulkDeleteFailed": "Failed to delete conversations"
       }
+    },
+    "ui": {
+      "retry": "Retry",
+      "input": {
+        "placeholder": "Ask a question about your knowledge base...",
+        "disabledSend": "You do not have permission to send messages",
+        "disabledQuery": "You do not have permission to ask questions",
+        "stop": "Stop generating",
+        "send": "Send message",
+        "helpPress": "Press",
+        "helpToSend": "to send,",
+        "helpNewLine": "for new line"
+      },
+      "sources": {
+        "title": "Sources ({{count}})",
+        "showLess": "Show less",
+        "showMore": "Show {{count}} more sources",
+        "relevance": "Relevance: {{pct}}%"
+      },
+      "bubble": {
+        "copyAria": "Copy message",
+        "copiedAria": "Copied to clipboard",
+        "copyTooltip": "Copy",
+        "copiedTooltip": "Copied!",
+        "goodAria": "Mark as good response",
+        "badAria": "Mark as bad response",
+        "goodTooltip": "Good response",
+        "badTooltip": "Bad response",
+        "regenerateAria": "Regenerate response",
+        "regenerateTooltip": "Regenerate"
+      },
+      "sidebar": {
+        "search": "Search conversations...",
+        "noneFound": "No conversations found",
+        "noneYet": "No conversations yet",
+        "pinned": "Pinned",
+        "recent": "Recent",
+        "actionsAria": "Actions for conversation: {{title}}",
+        "unpin": "Unpin",
+        "pin": "Pin",
+        "deleteDesc": "This action cannot be undone. This will permanently delete the conversation and all its messages.",
+        "updateFailed": "Failed to update conversation"
+      }
     }
   }
 }

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -728,6 +728,49 @@
         "bulkDeleted": "{{count}} conversations supprimées",
         "bulkDeleteFailed": "Échec de la suppression des conversations"
       }
+    },
+    "ui": {
+      "retry": "Réessayer",
+      "input": {
+        "placeholder": "Posez une question sur votre base de connaissances…",
+        "disabledSend": "Vous n'avez pas la permission d'envoyer des messages",
+        "disabledQuery": "Vous n'avez pas la permission de poser des questions",
+        "stop": "Arrêter la génération",
+        "send": "Envoyer le message",
+        "helpPress": "Appuyez sur",
+        "helpToSend": "pour envoyer,",
+        "helpNewLine": "pour un saut de ligne"
+      },
+      "sources": {
+        "title": "Sources ({{count}})",
+        "showLess": "Afficher moins",
+        "showMore": "Afficher {{count}} sources de plus",
+        "relevance": "Pertinence : {{pct}} %"
+      },
+      "bubble": {
+        "copyAria": "Copier le message",
+        "copiedAria": "Copié dans le presse-papiers",
+        "copyTooltip": "Copier",
+        "copiedTooltip": "Copié !",
+        "goodAria": "Marquer comme bonne réponse",
+        "badAria": "Marquer comme mauvaise réponse",
+        "goodTooltip": "Bonne réponse",
+        "badTooltip": "Mauvaise réponse",
+        "regenerateAria": "Régénérer la réponse",
+        "regenerateTooltip": "Régénérer"
+      },
+      "sidebar": {
+        "search": "Rechercher des conversations…",
+        "noneFound": "Aucune conversation trouvée",
+        "noneYet": "Aucune conversation pour le moment",
+        "pinned": "Épinglées",
+        "recent": "Récentes",
+        "actionsAria": "Actions pour la conversation : {{title}}",
+        "unpin": "Désépingler",
+        "pin": "Épingler",
+        "deleteDesc": "Cette action est irréversible. Elle supprimera définitivement la conversation et tous ses messages.",
+        "updateFailed": "Échec de la mise à jour de la conversation"
+      }
     }
   }
 }


### PR DESCRIPTION
i18n batch 12b — the `components/chat` UI: chat input (placeholder, Enter/Shift+Enter help, send/stop aria), source citations (Sources count, show more/less, relevance), message-bubble actions (copy/feedback/regenerate tooltips + aria-labels), chat-interface retry + placeholder, and the conversation sidebar (search, pinned/recent, pin/unpin, delete dialog). **Completes the chat feature area.** Adds the `chat.ui` namespace. Full frontend suite 513/513, build green, parity 594/594.

_Branch pushed via the GitHub Git Data API (local git-over-HTTPS push hangs on pack upload in this environment)._