### PR TITLE
feat(web): translate settings profile/security/MFA — EN/FR (i18n batch 13a)

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -5,6 +5,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
 import { Loader2, User, Mail, Shield, Bell, CheckCircle, AlertCircle, Users, CreditCard } from 'lucide-react';
 import Link from 'next/link';
 import { toast } from 'sonner';
@@ -45,6 +46,7 @@ const RESEND_COOLDOWN_SECONDS = 60;
 type ProfileFormData = z.infer<typeof profileSchema>;
 
 export default function SettingsPage() {
+  const { t } = useTranslation();
   const user = useAuthStore((state) => state.user);
   const updateUser = useAuthStore((state) => state.updateUser);
 
@@ -116,10 +118,10 @@ export default function SettingsPage() {
       if (updatedUser) {
         updateUser(updatedUser);
       }
-      toast.success('Profile updated successfully');
+      toast.success(t('settings.profile.toastUpdated'));
     },
     onError: () => {
-      toast.error('Failed to update profile');
+      toast.error(t('settings.profile.toastFailed'));
     },
   });
 
@@ -130,7 +132,7 @@ export default function SettingsPage() {
     },
     onSuccess: () => {
       startResendCooldown();
-      toast.success('Verification email sent! Check your inbox.');
+      toast.success(t('settings.emailVerify.toastSent'));
     },
     onError: (error: unknown) => {
       if (axios.isAxiosError(error) && error.response) {
@@ -138,22 +140,22 @@ export default function SettingsPage() {
         if (error.response.status === 429) {
           startResendCooldown();
           const message = error.response.data?.message ??
-            'Please wait before requesting another verification email.';
+            t('settings.emailVerify.toastWaitDefault');
           toast.error(message);
           return;
         }
         // Handle already verified (400) or other errors with backend message
         if (error.response.status === 400) {
-          const message = error.response.data?.message ?? 'Unable to send verification email';
+          const message = error.response.data?.message ?? t('settings.emailVerify.toastUnable');
           toast.info(message); // Use info toast for "already verified" messages
           return;
         }
         // Handle other errors with backend message if available
-        const message = error.response.data?.message ?? 'Failed to send verification email';
+        const message = error.response.data?.message ?? t('settings.emailVerify.toastSendFailed');
         toast.error(message);
         return;
       }
-      toast.error('Failed to send verification email');
+      toast.error(t('settings.emailVerify.toastSendFailed'));
     },
   });
 
@@ -170,9 +172,9 @@ export default function SettingsPage() {
     <div className="p-6 max-w-3xl mx-auto">
       {/* Header */}
       <div className="mb-6">
-        <h1 className="font-display text-3xl font-semibold tracking-tight">Settings</h1>
+        <h1 className="font-display text-3xl font-semibold tracking-tight">{t('settings.title')}</h1>
         <p className="text-muted-foreground">
-          Manage your account settings and preferences
+          {t('settings.subtitle')}
         </p>
       </div>
 
@@ -181,10 +183,10 @@ export default function SettingsPage() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <User className="h-5 w-5" />
-            Profile
+            {t('settings.profile.title')}
           </CardTitle>
           <CardDescription>
-            Your personal information and profile settings
+            {t('settings.profile.desc')}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -210,7 +212,7 @@ export default function SettingsPage() {
                 name="name"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Name</FormLabel>
+                    <FormLabel>{t('settings.profile.name')}</FormLabel>
                     <FormControl>
                       <Input {...field} />
                     </FormControl>
@@ -223,12 +225,12 @@ export default function SettingsPage() {
                 name="email"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Email</FormLabel>
+                    <FormLabel>{t('settings.profile.email')}</FormLabel>
                     <FormControl>
                       <Input type="email" {...field} disabled />
                     </FormControl>
                     <FormDescription>
-                      Email cannot be changed. Contact support if you need to update it.
+                      {t('settings.profile.emailDesc')}
                     </FormDescription>
                     <FormMessage />
                   </FormItem>
@@ -241,7 +243,7 @@ export default function SettingsPage() {
                 {updateProfileMutation.isPending && (
                   <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                 )}
-                Save Changes
+                {t('settings.profile.save')}
               </Button>
             </form>
           </Form>
@@ -254,20 +256,19 @@ export default function SettingsPage() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Mail className="h-5 w-5" />
-              Email Verification
+              {t('settings.emailVerify.title')}
               <Badge variant="outline" className="ml-2 text-warning border-warning/50">
                 <AlertCircle className="h-3 w-3 mr-1" />
-                Not Verified
+                {t('settings.emailVerify.notVerified')}
               </Badge>
             </CardTitle>
             <CardDescription>
-              Please verify your email address to access all features
+              {t('settings.emailVerify.notVerifiedDesc')}
             </CardDescription>
           </CardHeader>
           <CardContent>
             <p className="text-sm text-muted-foreground mb-4">
-              We sent a verification email to <strong>{user?.email}</strong>.
-              Click the link in the email to verify your account.
+              {t('settings.emailVerify.sentTo1')}<strong>{user?.email}</strong>{t('settings.emailVerify.sentTo2')}
             </p>
             <Button
               variant="outline"
@@ -280,12 +281,12 @@ export default function SettingsPage() {
                 <Mail className="h-4 w-4 mr-2" />
               )}
               {cooldownRemaining > 0
-                ? `Please wait ${cooldownRemaining}s`
-                : 'Resend Verification Email'}
+                ? t('settings.emailVerify.pleaseWait', { seconds: cooldownRemaining })
+                : t('settings.emailVerify.resend')}
             </Button>
             {cooldownRemaining > 0 && (
               <p className="text-xs text-muted-foreground mt-2">
-                Requests are limited to once per minute to protect your verification link.
+                {t('settings.emailVerify.rateLimitNote')}
               </p>
             )}
           </CardContent>
@@ -297,16 +298,16 @@ export default function SettingsPage() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Mail className="h-5 w-5" />
-              Email Verification
+              {t('settings.emailVerify.title')}
               <Badge variant="default" className="ml-2 bg-success">
                 <CheckCircle className="h-3 w-3 mr-1" />
-                Verified
+                {t('settings.emailVerify.verified')}
               </Badge>
             </CardTitle>
           </CardHeader>
           <CardContent>
             <p className="text-sm text-muted-foreground">
-              Your email address has been verified.
+              {t('settings.emailVerify.verifiedDesc')}
             </p>
           </CardContent>
         </Card>
@@ -317,18 +318,18 @@ export default function SettingsPage() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Bell className="h-5 w-5" />
-            Notifications
+            {t('settings.notifications.title')}
           </CardTitle>
           <CardDescription>
-            Choose what notifications you want to receive
+            {t('settings.notifications.desc')}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="flex items-center justify-between">
             <div>
-              <p className="font-medium">Email Notifications</p>
+              <p className="font-medium">{t('settings.notifications.email')}</p>
               <p className="text-sm text-muted-foreground">
-                Receive notifications via email
+                {t('settings.notifications.emailDesc')}
               </p>
             </div>
             <Switch
@@ -344,9 +345,9 @@ export default function SettingsPage() {
           <Separator />
           <div className="flex items-center justify-between">
             <div>
-              <p className="font-medium">Sync Alerts</p>
+              <p className="font-medium">{t('settings.notifications.sync')}</p>
               <p className="text-sm text-muted-foreground">
-                Get notified when document syncs complete or fail
+                {t('settings.notifications.syncDesc')}
               </p>
             </div>
             <Switch
@@ -362,9 +363,9 @@ export default function SettingsPage() {
           <Separator />
           <div className="flex items-center justify-between">
             <div>
-              <p className="font-medium">Weekly Digest</p>
+              <p className="font-medium">{t('settings.notifications.digest')}</p>
               <p className="text-sm text-muted-foreground">
-                Receive a weekly summary of activity
+                {t('settings.notifications.digestDesc')}
               </p>
             </div>
             <Switch
@@ -385,15 +386,15 @@ export default function SettingsPage() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Users className="h-5 w-5" />
-            Team
+            {t('settings.teamLink.title')}
           </CardTitle>
           <CardDescription>
-            Invite colleagues, manage roles, and control who can access the compliance platform
+            {t('settings.teamLink.desc')}
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Link href="/settings/team">
-            <Button variant="outline">Manage Team</Button>
+            <Button variant="outline">{t('settings.teamLink.manage')}</Button>
           </Link>
         </CardContent>
       </Card>
@@ -403,15 +404,15 @@ export default function SettingsPage() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Shield className="h-5 w-5" />
-            Security
+            {t('settings.securityLink.title')}
           </CardTitle>
           <CardDescription>
-            Manage your password and security settings
+            {t('settings.securityLink.desc')}
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Link href="/settings/security">
-            <Button variant="outline">Manage Security Settings</Button>
+            <Button variant="outline">{t('settings.securityLink.manage')}</Button>
           </Link>
         </CardContent>
       </Card>
@@ -421,15 +422,15 @@ export default function SettingsPage() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <CreditCard className="h-5 w-5" />
-            Billing
+            {t('settings.billingLink.title')}
           </CardTitle>
           <CardDescription>
-            Manage your subscription and payment methods
+            {t('settings.billingLink.desc')}
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Link href="/settings/billing">
-            <Button variant="outline">Manage billing</Button>
+            <Button variant="outline">{t('settings.billingLink.manage')}</Button>
           </Link>
         </CardContent>
       </Card>

--- a/frontend/src/app/(dashboard)/settings/security/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/security/page.tsx
@@ -4,6 +4,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
 import { ArrowLeft, Loader2, Shield, Key, Clock } from 'lucide-react';
 import Link from 'next/link';
 import { toast } from 'sonner';
@@ -51,6 +52,7 @@ const changePasswordSchema = z
 type ChangePasswordFormData = z.infer<typeof changePasswordSchema>;
 
 export default function SecuritySettingsPage() {
+  const { t } = useTranslation();
   const user = useAuthStore((state) => state.user);
 
   const form = useForm<ChangePasswordFormData>({
@@ -70,16 +72,16 @@ export default function SecuritySettingsPage() {
       });
     },
     onSuccess: () => {
-      toast.success('Password changed successfully');
+      toast.success(t('settings.security.toastChanged'));
       form.reset();
     },
     onError: () => {
-      toast.error('Failed to change password. Please check your current password.');
+      toast.error(t('settings.security.toastChangeFailed'));
     },
   });
 
   const formatDate = (dateString?: string) => {
-    if (!dateString) return 'Never';
+    if (!dateString) return t('settings.security.never');
     return new Date(dateString).toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
@@ -95,7 +97,7 @@ export default function SecuritySettingsPage() {
       <Link href="/settings">
         <Button variant="ghost" size="sm" className="mb-4">
           <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Settings
+          {t('settings.security.back')}
         </Button>
       </Link>
 
@@ -103,10 +105,10 @@ export default function SecuritySettingsPage() {
       <div className="mb-6">
         <h1 className="font-display text-3xl font-semibold tracking-tight flex items-center gap-2">
           <Shield className="h-6 w-6" />
-          Security Settings
+          {t('settings.security.title')}
         </h1>
         <p className="text-muted-foreground">
-          Manage your account security and authentication
+          {t('settings.security.subtitle')}
         </p>
       </div>
 
@@ -115,24 +117,24 @@ export default function SecuritySettingsPage() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base">
             <Clock className="h-4 w-4" />
-            Account Activity
+            {t('settings.security.activity')}
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="flex justify-between">
-            <span className="text-muted-foreground">Last Login</span>
+            <span className="text-muted-foreground">{t('settings.security.lastLogin')}</span>
             <span className="font-medium">{formatDate(user?.lastLogin)}</span>
           </div>
           <Separator />
           <div className="flex justify-between">
-            <span className="text-muted-foreground">Account Created</span>
+            <span className="text-muted-foreground">{t('settings.security.accountCreated')}</span>
             <span className="font-medium">{formatDate(user?.createdAt)}</span>
           </div>
           <Separator />
           <div className="flex justify-between">
-            <span className="text-muted-foreground">Email Verified</span>
+            <span className="text-muted-foreground">{t('settings.security.emailVerified')}</span>
             <span className="font-medium">
-              {user?.isEmailVerified ? 'Yes' : 'No'}
+              {user?.isEmailVerified ? t('settings.security.yes') : t('settings.security.no')}
             </span>
           </div>
         </CardContent>
@@ -143,10 +145,10 @@ export default function SecuritySettingsPage() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Key className="h-5 w-5" />
-            Change Password
+            {t('settings.security.changePassword')}
           </CardTitle>
           <CardDescription>
-            Update your password to keep your account secure
+            {t('settings.security.changePasswordDesc')}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -162,7 +164,7 @@ export default function SecuritySettingsPage() {
                 name="currentPassword"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Current Password</FormLabel>
+                    <FormLabel>{t('settings.security.currentPassword')}</FormLabel>
                     <FormControl>
                       <Input type="password" {...field} />
                     </FormControl>
@@ -175,12 +177,12 @@ export default function SecuritySettingsPage() {
                 name="newPassword"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>New Password</FormLabel>
+                    <FormLabel>{t('settings.security.newPassword')}</FormLabel>
                     <FormControl>
                       <Input type="password" {...field} />
                     </FormControl>
                     <FormDescription>
-                      Must be at least 8 characters with uppercase, lowercase, and number
+                      {t('settings.security.newPasswordDesc')}
                     </FormDescription>
                     <FormMessage />
                   </FormItem>
@@ -191,7 +193,7 @@ export default function SecuritySettingsPage() {
                 name="confirmPassword"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Confirm New Password</FormLabel>
+                    <FormLabel>{t('settings.security.confirmPassword')}</FormLabel>
                     <FormControl>
                       <Input type="password" {...field} />
                     </FormControl>
@@ -206,7 +208,7 @@ export default function SecuritySettingsPage() {
                 {changePasswordMutation.isPending && (
                   <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                 )}
-                Update Password
+                {t('settings.security.update')}
               </Button>
             </form>
           </Form>

--- a/frontend/src/features/settings/components/mfa-section.tsx
+++ b/frontend/src/features/settings/components/mfa-section.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import { Loader2, ShieldCheck, ShieldOff, Copy } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -26,6 +27,7 @@ import type { MfaSetupResponse } from '@/types';
  * → MFA enabled, recovery codes shown once. Disable requires password + a code.
  */
 export function MfaSection() {
+  const { t } = useTranslation();
   const user = useAuthStore((state) => state.user);
   const setUser = useAuthStore((state) => state.setUser);
   const enabled = !!user?.mfaEnabled;
@@ -52,7 +54,7 @@ export function MfaSection() {
       setSetup(null);
       setCode('');
       if (user) setUser({ ...user, mfaEnabled: true });
-      toast.success('Two-factor authentication enabled');
+      toast.success(t('settings.mfa.toastEnabled'));
     },
     onError: (err) => toast.error(getErrorMessage(err)),
   });
@@ -63,7 +65,7 @@ export function MfaSection() {
       if (user) setUser({ ...user, mfaEnabled: false });
       setDisablePassword('');
       setDisableCode('');
-      toast.success('Two-factor authentication disabled');
+      toast.success(t('settings.mfa.toastDisabled'));
     },
     onError: (err) => toast.error(getErrorMessage(err)),
   });
@@ -71,7 +73,7 @@ export function MfaSection() {
   const copyRecoveryCodes = () => {
     if (recoveryCodes) {
       navigator.clipboard?.writeText(recoveryCodes.join('\n'));
-      toast.success('Recovery codes copied');
+      toast.success(t('settings.mfa.toastCopied'));
     }
   };
 
@@ -84,12 +86,12 @@ export function MfaSection() {
           ) : (
             <ShieldOff className="h-5 w-5 text-muted-foreground" />
           )}
-          Two-Factor Authentication
+          {t('settings.mfa.title')}
         </CardTitle>
         <CardDescription>
           {enabled
-            ? 'Your account is protected with an authenticator app.'
-            : 'Add a second step at sign-in using an authenticator app (TOTP).'}
+            ? t('settings.mfa.descEnabled')
+            : t('settings.mfa.descDisabled')}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -97,8 +99,7 @@ export function MfaSection() {
         {recoveryCodes && (
           <div className="rounded-md border border-amber-300 bg-amber-50 p-4 space-y-3 dark:bg-amber-950/30">
             <p className="text-sm font-medium">
-              Save these recovery codes now — they are shown only once. Each can be used once
-              if you lose your device.
+              {t('settings.mfa.recoveryNote')}
             </p>
             <div className="grid grid-cols-2 gap-2 font-mono text-sm">
               {recoveryCodes.map((rc) => (
@@ -107,7 +108,7 @@ export function MfaSection() {
             </div>
             <Button type="button" variant="outline" size="sm" onClick={copyRecoveryCodes}>
               <Copy className="mr-2 h-4 w-4" />
-              Copy codes
+              {t('settings.mfa.copyCodes')}
             </Button>
           </div>
         )}
@@ -116,16 +117,16 @@ export function MfaSection() {
         {!enabled && !setup && (
           <Button onClick={() => setupMutation.mutate()} disabled={setupMutation.isPending}>
             {setupMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            Set up two-factor authentication
+            {t('settings.mfa.setup')}
           </Button>
         )}
 
         {!enabled && setup && (
           <div className="space-y-4">
             <div className="space-y-1">
-              <p className="text-sm font-medium">1. Add this account to your authenticator app</p>
+              <p className="text-sm font-medium">{t('settings.mfa.step1')}</p>
               <p className="text-xs text-muted-foreground">
-                Scan the otpauth URL as a QR code, or enter the secret manually:
+                {t('settings.mfa.step1Desc')}
               </p>
               <code className="block break-all rounded bg-muted px-2 py-1 text-xs">
                 {setup.secret}
@@ -136,11 +137,11 @@ export function MfaSection() {
             </div>
             <Separator />
             <div className="space-y-2">
-              <p className="text-sm font-medium">2. Enter the 6-digit code to confirm</p>
+              <p className="text-sm font-medium">{t('settings.mfa.step2')}</p>
               <Input
                 inputMode="numeric"
                 autoComplete="one-time-code"
-                placeholder="123456"
+                placeholder={t('settings.mfa.codePlaceholder')}
                 value={code}
                 onChange={(e) => setCode(e.target.value)}
                 disabled={enableMutation.isPending}
@@ -151,7 +152,7 @@ export function MfaSection() {
                   disabled={enableMutation.isPending || code.trim().length < 6}
                 >
                   {enableMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                  Enable
+                  {t('settings.mfa.enable')}
                 </Button>
                 <Button
                   variant="ghost"
@@ -161,7 +162,7 @@ export function MfaSection() {
                   }}
                   disabled={enableMutation.isPending}
                 >
-                  Cancel
+                  {t('common.cancel')}
                 </Button>
               </div>
             </div>
@@ -172,12 +173,12 @@ export function MfaSection() {
         {enabled && (
           <div className="space-y-3">
             <p className="text-sm text-muted-foreground">
-              To disable, confirm your password and a current code.
+              {t('settings.mfa.disablePrompt')}
             </p>
             <Input
               type="password"
               autoComplete="current-password"
-              placeholder="Current password"
+              placeholder={t('settings.mfa.currentPasswordPlaceholder')}
               value={disablePassword}
               onChange={(e) => setDisablePassword(e.target.value)}
               disabled={disableMutation.isPending}
@@ -185,7 +186,7 @@ export function MfaSection() {
             <Input
               inputMode="numeric"
               autoComplete="one-time-code"
-              placeholder="6-digit code or recovery code"
+              placeholder={t('settings.mfa.disableCodePlaceholder')}
               value={disableCode}
               onChange={(e) => setDisableCode(e.target.value)}
               disabled={disableMutation.isPending}
@@ -200,7 +201,7 @@ export function MfaSection() {
               }
             >
               {disableMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              Disable two-factor authentication
+              {t('settings.mfa.disable')}
             </Button>
           </div>
         )}

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -772,5 +772,101 @@
         "updateFailed": "Failed to update conversation"
       }
     }
+  },
+  "settings": {
+    "title": "Settings",
+    "subtitle": "Manage your account settings and preferences",
+    "profile": {
+      "title": "Profile",
+      "desc": "Your personal information and profile settings",
+      "name": "Name",
+      "email": "Email",
+      "emailDesc": "Email cannot be changed. Contact support if you need to update it.",
+      "save": "Save Changes",
+      "toastUpdated": "Profile updated successfully",
+      "toastFailed": "Failed to update profile"
+    },
+    "emailVerify": {
+      "title": "Email Verification",
+      "notVerified": "Not Verified",
+      "verified": "Verified",
+      "notVerifiedDesc": "Please verify your email address to access all features",
+      "sentTo1": "We sent a verification email to ",
+      "sentTo2": ". Click the link in the email to verify your account.",
+      "resend": "Resend Verification Email",
+      "pleaseWait": "Please wait {{seconds}}s",
+      "rateLimitNote": "Requests are limited to once per minute to protect your verification link.",
+      "verifiedDesc": "Your email address has been verified.",
+      "toastSent": "Verification email sent! Check your inbox.",
+      "toastSendFailed": "Failed to send verification email",
+      "toastWaitDefault": "Please wait before requesting another verification email.",
+      "toastUnable": "Unable to send verification email"
+    },
+    "notifications": {
+      "title": "Notifications",
+      "desc": "Choose what notifications you want to receive",
+      "email": "Email Notifications",
+      "emailDesc": "Receive notifications via email",
+      "sync": "Sync Alerts",
+      "syncDesc": "Get notified when document syncs complete or fail",
+      "digest": "Weekly Digest",
+      "digestDesc": "Receive a weekly summary of activity"
+    },
+    "teamLink": {
+      "title": "Team",
+      "desc": "Invite colleagues, manage roles, and control who can access the compliance platform",
+      "manage": "Manage Team"
+    },
+    "securityLink": {
+      "title": "Security",
+      "desc": "Manage your password and security settings",
+      "manage": "Manage Security Settings"
+    },
+    "billingLink": {
+      "title": "Billing",
+      "desc": "Manage your subscription and payment methods",
+      "manage": "Manage billing"
+    },
+    "security": {
+      "back": "Back to Settings",
+      "title": "Security Settings",
+      "subtitle": "Manage your account security and authentication",
+      "activity": "Account Activity",
+      "lastLogin": "Last Login",
+      "accountCreated": "Account Created",
+      "emailVerified": "Email Verified",
+      "never": "Never",
+      "yes": "Yes",
+      "no": "No",
+      "changePassword": "Change Password",
+      "changePasswordDesc": "Update your password to keep your account secure",
+      "currentPassword": "Current Password",
+      "newPassword": "New Password",
+      "newPasswordDesc": "Must be at least 8 characters with uppercase, lowercase, and number",
+      "confirmPassword": "Confirm New Password",
+      "update": "Update Password",
+      "toastChanged": "Password changed successfully",
+      "toastChangeFailed": "Failed to change password. Please check your current password."
+    },
+    "mfa": {
+      "title": "Two-Factor Authentication",
+      "descEnabled": "Your account is protected with an authenticator app.",
+      "descDisabled": "Add a second step at sign-in using an authenticator app (TOTP).",
+      "recoveryNote": "Save these recovery codes now — they are shown only once. Each can be used once if you lose your device.",
+      "copyCodes": "Copy codes",
+      "setup": "Set up two-factor authentication",
+      "step1": "1. Add this account to your authenticator app",
+      "step1Desc": "Scan the otpauth URL as a QR code, or enter the secret manually:",
+      "step2": "2. Enter the 6-digit code to confirm",
+      "codePlaceholder": "123456",
+      "enable": "Enable",
+      "disablePrompt": "To disable, confirm your password and a current code.",
+      "currentPasswordPlaceholder": "Current password",
+      "disableCodePlaceholder": "6-digit code or recovery code",
+      "disable": "Disable two-factor authentication",
+      "toastEnabled": "Two-factor authentication enabled",
+      "toastDisabled": "Two-factor authentication disabled",
+      "toastCopied": "Recovery codes copied"
+    }
   }
 }

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -772,5 +772,101 @@
         "updateFailed": "Échec de la mise à jour de la conversation"
       }
     }
+  },
+  "settings": {
+    "title": "Paramètres",
+    "subtitle": "Gérez les paramètres et préférences de votre compte",
+    "profile": {
+      "title": "Profil",
+      "desc": "Vos informations personnelles et paramètres de profil",
+      "name": "Nom",
+      "email": "E-mail",
+      "emailDesc": "L'e-mail ne peut pas être modifié. Contactez le support si vous devez le mettre à jour.",
+      "save": "Enregistrer les modifications",
+      "toastUpdated": "Profil mis à jour avec succès",
+      "toastFailed": "Échec de la mise à jour du profil"
+    },
+    "emailVerify": {
+      "title": "Vérification de l'e-mail",
+      "notVerified": "Non vérifié",
+      "verified": "Vérifié",
+      "notVerifiedDesc": "Veuillez vérifier votre adresse e-mail pour accéder à toutes les fonctionnalités",
+      "sentTo1": "Nous avons envoyé un e-mail de vérification à ",
+      "sentTo2": ". Cliquez sur le lien dans l'e-mail pour vérifier votre compte.",
+      "resend": "Renvoyer l'e-mail de vérification",
+      "pleaseWait": "Veuillez patienter {{seconds}} s",
+      "rateLimitNote": "Les demandes sont limitées à une par minute pour protéger votre lien de vérification.",
+      "verifiedDesc": "Votre adresse e-mail a été vérifiée.",
+      "toastSent": "E-mail de vérification envoyé ! Vérifiez votre boîte de réception.",
+      "toastSendFailed": "Échec de l'envoi de l'e-mail de vérification",
+      "toastWaitDefault": "Veuillez patienter avant de demander un nouvel e-mail de vérification.",
+      "toastUnable": "Impossible d'envoyer l'e-mail de vérification"
+    },
+    "notifications": {
+      "title": "Notifications",
+      "desc": "Choisissez les notifications que vous souhaitez recevoir",
+      "email": "Notifications par e-mail",
+      "emailDesc": "Recevez des notifications par e-mail",
+      "sync": "Alertes de synchronisation",
+      "syncDesc": "Soyez averti lorsque les synchronisations de documents aboutissent ou échouent",
+      "digest": "Récapitulatif hebdomadaire",
+      "digestDesc": "Recevez un résumé hebdomadaire de l'activité"
+    },
+    "teamLink": {
+      "title": "Équipe",
+      "desc": "Invitez des collègues, gérez les rôles et contrôlez l'accès à la plateforme de conformité",
+      "manage": "Gérer l'équipe"
+    },
+    "securityLink": {
+      "title": "Sécurité",
+      "desc": "Gérez votre mot de passe et vos paramètres de sécurité",
+      "manage": "Gérer les paramètres de sécurité"
+    },
+    "billingLink": {
+      "title": "Facturation",
+      "desc": "Gérez votre abonnement et vos moyens de paiement",
+      "manage": "Gérer la facturation"
+    },
+    "security": {
+      "back": "Retour aux paramètres",
+      "title": "Paramètres de sécurité",
+      "subtitle": "Gérez la sécurité et l'authentification de votre compte",
+      "activity": "Activité du compte",
+      "lastLogin": "Dernière connexion",
+      "accountCreated": "Compte créé le",
+      "emailVerified": "E-mail vérifié",
+      "never": "Jamais",
+      "yes": "Oui",
+      "no": "Non",
+      "changePassword": "Changer le mot de passe",
+      "changePasswordDesc": "Mettez à jour votre mot de passe pour sécuriser votre compte",
+      "currentPassword": "Mot de passe actuel",
+      "newPassword": "Nouveau mot de passe",
+      "newPasswordDesc": "Au moins 8 caractères avec une majuscule, une minuscule et un chiffre",
+      "confirmPassword": "Confirmer le nouveau mot de passe",
+      "update": "Mettre à jour le mot de passe",
+      "toastChanged": "Mot de passe modifié avec succès",
+      "toastChangeFailed": "Échec du changement de mot de passe. Vérifiez votre mot de passe actuel."
+    },
+    "mfa": {
+      "title": "Authentification à deux facteurs",
+      "descEnabled": "Votre compte est protégé par une application d'authentification.",
+      "descDisabled": "Ajoutez une seconde étape à la connexion via une application d'authentification (TOTP).",
+      "recoveryNote": "Enregistrez ces codes de récupération maintenant — ils ne sont affichés qu'une seule fois. Chacun est utilisable une fois si vous perdez votre appareil.",
+      "copyCodes": "Copier les codes",
+      "setup": "Configurer l'authentification à deux facteurs",
+      "step1": "1. Ajoutez ce compte à votre application d'authentification",
+      "step1Desc": "Scannez l'URL otpauth sous forme de QR code, ou saisissez le secret manuellement :",
+      "step2": "2. Saisissez le code à 6 chiffres pour confirmer",
+      "codePlaceholder": "123456",
+      "enable": "Activer",
+      "disablePrompt": "Pour désactiver, confirmez votre mot de passe et un code actuel.",
+      "currentPasswordPlaceholder": "Mot de passe actuel",
+      "disableCodePlaceholder": "Code à 6 chiffres ou code de récupération",
+      "disable": "Désactiver l'authentification à deux facteurs",
+      "toastEnabled": "Authentification à deux facteurs activée",
+      "toastDisabled": "Authentification à deux facteurs désactivée",
+      "toastCopied": "Codes de récupération copiés"
+    }
   }
 }


### PR DESCRIPTION
i18n batch 13a — settings: **profile page** (account, email-verification states, notifications toggles, team/security/billing section links), **security page** (account activity, change-password form), and the **MFA section** (enrollment, recovery codes, disable flow). Adds the `settings` namespace. Full suite 513/513, build green, parity 672/672. Branch via Git Data API. Batch 13b (billing + team) next.