### PR TITLE
feat(web): translate workspaces list + overview cards — EN/FR (i18n batch 14a)

### DIFF
--- a/frontend/src/features/workspaces/components/compliance-score-card.tsx
+++ b/frontend/src/features/workspaces/components/compliance-score-card.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTranslation } from 'react-i18next';
 import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import type { ComplianceScore } from '@/features/workspaces/api/workspaces';
@@ -14,13 +15,14 @@ const STATUS_STYLES = {
   red: 'text-red-700 bg-red-50 border-red-200',
 } as const;
 
-const STATUS_LABEL = {
-  green: 'Good',
-  amber: 'Needs attention',
-  red: 'At risk',
+const STATUS_LABEL_KEY = {
+  green: 'workspaces.score.good',
+  amber: 'workspaces.score.needsAttention',
+  red: 'workspaces.score.atRisk',
 } as const;
 
 export function ComplianceScoreCard({ score }: ComplianceScoreCardProps) {
+  const { t } = useTranslation();
   if (!score) return null;
 
   const TrendIcon = score.trend > 0 ? TrendingUp : score.trend < 0 ? TrendingDown : Minus;
@@ -32,16 +34,16 @@ export function ComplianceScoreCard({ score }: ComplianceScoreCardProps) {
         : 'text-muted-foreground';
   const trendLabel =
     score.trend > 0
-      ? `+${score.trend} pts`
+      ? t('workspaces.score.trendUp', { pts: score.trend })
       : score.trend < 0
-        ? `${score.trend} pts`
-        : 'No change';
+        ? t('workspaces.score.trendDown', { pts: score.trend })
+        : t('workspaces.score.noChange');
 
   return (
     <Card className="mb-4">
       <CardHeader className="pb-2">
         <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
-          Portfolio Compliance Score
+          {t('workspaces.score.title')}
         </CardTitle>
       </CardHeader>
       <CardContent>
@@ -55,15 +57,14 @@ export function ComplianceScoreCard({ score }: ComplianceScoreCardProps) {
             <span
               className={`text-xs font-semibold px-2 py-0.5 rounded-full border ${STATUS_STYLES[score.status]}`}
             >
-              {STATUS_LABEL[score.status]}
+              {t(STATUS_LABEL_KEY[score.status])}
             </span>
             <div className={`flex items-center gap-1 text-sm font-medium ${trendColor}`}>
               <TrendIcon className="h-3.5 w-3.5" />
-              {trendLabel} vs 30 days ago
+              {trendLabel} {t('workspaces.score.vs30')}
             </div>
             <p className="text-xs text-muted-foreground">
-              {score.assessmentCount} completed assessment
-              {score.assessmentCount !== 1 ? 's' : ''}
+              {t('workspaces.score.assessmentCount', { count: score.assessmentCount })}
             </p>
           </div>
         </div>

--- a/frontend/src/features/workspaces/components/workspace-assessments-card.tsx
+++ b/frontend/src/features/workspaces/components/workspace-assessments-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
 import { AlertCircle, Loader2, Plus, ShieldCheck } from 'lucide-react';
 
@@ -46,17 +47,18 @@ export function WorkspaceAssessmentsCard({
   isLoading,
   isError,
 }: WorkspaceAssessmentsCardProps) {
+  const { t } = useTranslation();
   const router = useRouter();
 
   return (
     <Card>
       <CardHeader className="pb-3 flex flex-row items-center justify-between">
         <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
-          DORA Gap Assessments
+          {t('workspaces.assessmentsCard.title')}
         </CardTitle>
         <Button size="sm" onClick={() => router.push('/assessments/new')}>
           <Plus className="h-3.5 w-3.5 mr-1.5" />
-          New Assessment
+          {t('assessments.newButton')}
         </Button>
       </CardHeader>
       <CardContent className="pt-0">
@@ -69,18 +71,18 @@ export function WorkspaceAssessmentsCard({
         ) : isError ? (
           <div className="flex items-center gap-2 text-destructive text-sm p-3 rounded-md border border-destructive/30 bg-destructive/10">
             <AlertCircle className="h-4 w-4 shrink-0" />
-            Failed to load assessments.
+            {t('assessments.loadError')}
           </div>
         ) : assessments.length > 0 ? (
           <div className="rounded-md border overflow-hidden">
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Vendor</TableHead>
-                  <TableHead>Assessment</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Risk</TableHead>
-                  <TableHead>Date</TableHead>
+                  <TableHead>{t('assessments.cols.vendor')}</TableHead>
+                  <TableHead>{t('assessments.cols.assessment')}</TableHead>
+                  <TableHead>{t('assessments.cols.status')}</TableHead>
+                  <TableHead>{t('assessments.cols.risk')}</TableHead>
+                  <TableHead>{t('workspaces.assessmentsCard.date')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -97,13 +99,13 @@ export function WorkspaceAssessmentsCard({
                         {(assessment.status === 'indexing' || assessment.status === 'analyzing') && (
                           <Loader2 className="h-3 w-3 mr-1 animate-spin" />
                         )}
-                        {assessment.status}
+                        {t(`assessments.status.${assessment.status}`)}
                       </Badge>
                     </TableCell>
                     <TableCell>
                       {assessment.results?.overallRisk ? (
                         <Badge variant={RISK_VARIANT[assessment.results.overallRisk]}>
-                          {assessment.results.overallRisk}
+                          {t(`assessments.risk.${assessment.results.overallRisk}`)}
                         </Badge>
                       ) : (
                         <span className="text-muted-foreground text-sm">—</span>
@@ -120,10 +122,10 @@ export function WorkspaceAssessmentsCard({
         ) : (
           <div className="flex flex-col items-center justify-center gap-3 py-10 text-center">
             <ShieldCheck className="h-10 w-10 text-muted-foreground/40" />
-            <p className="text-sm text-muted-foreground">No assessments yet for this vendor</p>
+            <p className="text-sm text-muted-foreground">{t('workspaces.assessmentsCard.noneYet')}</p>
             <Button size="sm" variant="outline" onClick={() => router.push('/assessments/new')}>
               <Plus className="h-3.5 w-3.5 mr-1.5" />
-              New Assessment
+              {t('assessments.newButton')}
             </Button>
           </div>
         )}

--- a/frontend/src/features/workspaces/components/workspace-header.tsx
+++ b/frontend/src/features/workspaces/components/workspace-header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
 import { Building2, Settings } from 'lucide-react';
 
 import { Button } from '@/shared/ui/button';
@@ -8,21 +9,23 @@ import { Badge } from '@/shared/ui/badge';
 import type { VendorTier, VendorStatus, WorkspaceWithMembership } from '@/types';
 
 function TierBadge({ tier }: { tier: VendorTier }) {
-  if (tier === 'critical') return <Badge variant="destructive">Critical</Badge>;
+  const { t } = useTranslation();
+  if (tier === 'critical') return <Badge variant="destructive">{t('workspaces.tier.critical')}</Badge>;
   if (tier === 'important') {
     return (
       <Badge className="bg-warning-muted text-warning border-warning-muted hover:bg-warning-muted">
-        Important
+        {t('workspaces.tier.important')}
       </Badge>
     );
   }
-  return <Badge variant="outline">Standard</Badge>;
+  return <Badge variant="outline">{t('workspaces.tier.standard')}</Badge>;
 }
 
 function VendorStatusBadge({ status }: { status: VendorStatus }) {
-  if (status === 'active') return <Badge variant="default">Active</Badge>;
-  if (status === 'under-review') return <Badge variant="secondary">Under Review</Badge>;
-  return <Badge variant="outline">Exited</Badge>;
+  const { t } = useTranslation();
+  if (status === 'active') return <Badge variant="default">{t('workspaces.status.active')}</Badge>;
+  if (status === 'under-review') return <Badge variant="secondary">{t('workspaces.status.underReview')}</Badge>;
+  return <Badge variant="outline">{t('workspaces.status.exited')}</Badge>;
 }
 
 interface WorkspaceHeaderProps {
@@ -36,6 +39,7 @@ export function WorkspaceHeader({
   workspaceId,
   isOwner,
 }: WorkspaceHeaderProps) {
+  const { t } = useTranslation();
   return (
     <div className="flex items-start justify-between mb-6">
       <div className="flex items-center gap-4">
@@ -57,7 +61,7 @@ export function WorkspaceHeader({
         <Link href={`/workspaces/${workspaceId}/settings`}>
           <Button variant="outline">
             <Settings className="h-4 w-4 mr-2" />
-            Settings
+            {t('workspaces.header.settings')}
           </Button>
         </Link>
       )}

--- a/frontend/src/features/workspaces/components/workspace-overview-page.tsx
+++ b/frontend/src/features/workspaces/components/workspace-overview-page.tsx
@@ -2,6 +2,7 @@
 
 import { use } from 'react';
 import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
 import { AlertTriangle, ArrowLeft, Building2, Calendar, Globe, Loader2 } from 'lucide-react';
 
@@ -16,11 +17,12 @@ import { WorkspaceHeader } from '@/features/workspaces/components/workspace-head
 import { useWorkspaceOverview } from '@/features/workspaces/hooks/use-workspace-overview';
 
 function ContractDaysChip({ contractEnd }: { contractEnd: string }) {
+  const { t } = useTranslation();
   const days = Math.ceil((new Date(contractEnd).getTime() - new Date().getTime()) / 86_400_000);
   const color = days < 30 ? 'text-destructive' : days < 90 ? 'text-warning' : 'text-success';
   return (
     <span className={`text-xs font-medium ${color}`}>
-      ({days < 0 ? `${Math.abs(days)}d overdue` : `+${days}d`})
+      {days < 0 ? t('workspaces.overview.daysOverdue', { days: Math.abs(days) }) : t('workspaces.overview.daysLeft', { days })}
     </span>
   );
 }
@@ -30,6 +32,7 @@ interface WorkspaceOverviewPageProps {
 }
 
 export function WorkspaceOverviewPage({ params }: WorkspaceOverviewPageProps) {
+  const { t } = useTranslation();
   const { id } = use(params);
   const {
     workspace,
@@ -56,7 +59,7 @@ export function WorkspaceOverviewPage({ params }: WorkspaceOverviewPageProps) {
       <div className="flex h-full items-center justify-center">
         <div className="text-center">
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mx-auto mb-4" />
-          <p className="text-muted-foreground">Loading workspace...</p>
+          <p className="text-muted-foreground">{t('workspaces.overview.loading')}</p>
         </div>
       </div>
     );
@@ -75,7 +78,7 @@ export function WorkspaceOverviewPage({ params }: WorkspaceOverviewPageProps) {
       <Link href="/workspaces">
         <Button variant="ghost" size="sm" className="mb-4">
           <ArrowLeft className="h-4 w-4 mr-2" />
-          Vendors
+          {t('workspaces.overview.back')}
         </Button>
       </Link>
 
@@ -95,7 +98,7 @@ export function WorkspaceOverviewPage({ params }: WorkspaceOverviewPageProps) {
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
-              Profile
+              {t('workspaces.overview.profile')}
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-2 text-sm">
@@ -113,13 +116,13 @@ export function WorkspaceOverviewPage({ params }: WorkspaceOverviewPageProps) {
             )}
             {!hasVendorProfile && (
               <p className="text-muted-foreground text-sm">
-                No vendor profile data —{' '}
+                {t('workspaces.overview.noProfile1')}
                 {isOwner ? (
                   <Link href={`/workspaces/${id}/settings`} className="underline underline-offset-2">
-                    add details in Settings
+                    {t('workspaces.overview.addInSettings')}
                   </Link>
                 ) : (
-                  'contact the workspace owner'
+                  t('workspaces.overview.contactOwner')
                 )}
               </p>
             )}
@@ -129,31 +132,31 @@ export function WorkspaceOverviewPage({ params }: WorkspaceOverviewPageProps) {
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
-              Contract
+              {t('workspaces.overview.contract')}
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-2 text-sm">
             {workspace.contractStart && (
               <div className="flex items-center gap-2">
                 <Calendar className="h-4 w-4 text-muted-foreground" />
-                <span>Start: {format(new Date(workspace.contractStart), 'dd MMM yyyy')}</span>
+                <span>{t('workspaces.overview.start', { date: format(new Date(workspace.contractStart), 'dd MMM yyyy') })}</span>
               </div>
             )}
             {workspace.contractEnd && (
               <div className="flex items-center gap-2">
                 <Calendar className="h-4 w-4 text-muted-foreground" />
-                <span>End: {format(new Date(workspace.contractEnd), 'dd MMM yyyy')}</span>
+                <span>{t('workspaces.overview.end', { date: format(new Date(workspace.contractEnd), 'dd MMM yyyy') })}</span>
                 <ContractDaysChip contractEnd={workspace.contractEnd} />
               </div>
             )}
             {workspace.nextReviewDate && (
               <div className="flex items-center gap-2">
                 <AlertTriangle className="h-4 w-4 text-warning" />
-                <span>Next review: {format(new Date(workspace.nextReviewDate), 'dd MMM yyyy')}</span>
+                <span>{t('workspaces.overview.nextReview', { date: format(new Date(workspace.nextReviewDate), 'dd MMM yyyy') })}</span>
               </div>
             )}
             {!workspace.contractStart && !workspace.contractEnd && !workspace.nextReviewDate && (
-              <p className="text-muted-foreground">No contract dates set</p>
+              <p className="text-muted-foreground">{t('workspaces.overview.noDates')}</p>
             )}
           </CardContent>
         </Card>

--- a/frontend/src/features/workspaces/components/workspaces-page.tsx
+++ b/frontend/src/features/workspaces/components/workspaces-page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { Plus, Building2, Users, ChevronRight, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
@@ -18,26 +19,29 @@ import { getRoleDisplayName, getRoleBadgeColor } from '@/lib/utils/permissions';
 import type { VendorTier, VendorStatus } from '@/types';
 
 function TierBadge({ tier }: { tier: VendorTier }) {
+  const { t } = useTranslation();
   if (tier === 'critical') {
-    return <Badge variant="destructive" className="text-xs h-5">Critical</Badge>;
+    return <Badge variant="destructive" className="text-xs h-5">{t('workspaces.tier.critical')}</Badge>;
   }
   if (tier === 'important') {
-    return <Badge className="text-xs h-5 bg-warning-muted text-warning border-warning-muted hover:bg-warning-muted">Important</Badge>;
+    return <Badge className="text-xs h-5 bg-warning-muted text-warning border-warning-muted hover:bg-warning-muted">{t('workspaces.tier.important')}</Badge>;
   }
-  return <Badge variant="outline" className="text-xs h-5">Standard</Badge>;
+  return <Badge variant="outline" className="text-xs h-5">{t('workspaces.tier.standard')}</Badge>;
 }
 
 function VendorStatusChip({ status }: { status: VendorStatus }) {
+  const { t } = useTranslation();
   if (status === 'active') {
     return null;
   }
   if (status === 'under-review') {
-    return <Badge variant="secondary" className="text-xs h-5">Under Review</Badge>;
+    return <Badge variant="secondary" className="text-xs h-5">{t('workspaces.status.underReview')}</Badge>;
   }
-  return <Badge variant="outline" className="text-xs h-5">Exited</Badge>;
+  return <Badge variant="outline" className="text-xs h-5">{t('workspaces.status.exited')}</Badge>;
 }
 
 function ContractExpiryBar({ contractEnd }: { contractEnd: string }) {
+  const { t } = useTranslation();
   const nowMs = new Date().getTime();
   const days = Math.ceil((new Date(contractEnd).getTime() - nowMs) / 86_400_000);
   if (days > 60) {
@@ -48,8 +52,8 @@ function ContractExpiryBar({ contractEnd }: { contractEnd: string }) {
     ? 'bg-destructive/10 border-destructive/30 text-destructive'
     : 'bg-warning-muted border-warning-muted text-warning';
   const label = days <= 0
-    ? `Contract expired ${Math.abs(days)}d ago`
-    : `Contract expires in ${days} days`;
+    ? t('workspaces.contractBar.expiredAgo', { days: Math.abs(days) })
+    : t('workspaces.contractBar.expiresIn', { days });
 
   return (
     <div className={`flex items-center gap-1.5 text-xs px-2 py-1 rounded border mt-2 ${colorClass}`}>
@@ -60,6 +64,7 @@ function ContractExpiryBar({ contractEnd }: { contractEnd: string }) {
 }
 
 export function WorkspacesPage() {
+  const { t } = useTranslation();
   const router = useRouter();
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
@@ -77,22 +82,22 @@ export function WorkspacesPage() {
 
     if (connected === 'true') {
       if (isNew === 'true') {
-        toast.success(`Workspace "${workspaceName}" connected successfully!`);
+        toast.success(t('workspaces.toast.connected', { name: workspaceName }));
       } else {
-        toast.success(`Workspace "${workspaceName}" reconnected`, {
-          description: 'Credentials have been updated.',
+        toast.success(t('workspaces.toast.reconnected', { name: workspaceName }), {
+          description: t('workspaces.toast.reconnectedDesc'),
         });
       }
 
       queryClient.invalidateQueries({ queryKey: ['workspaces'] });
       router.replace('/workspaces', { scroll: false });
     } else if (error) {
-      toast.error('Failed to connect workspace', {
+      toast.error(t('workspaces.toast.connectFailed'), {
         description: errorDescription || error,
       });
       router.replace('/workspaces', { scroll: false });
     }
-  }, [searchParams, router, queryClient]);
+  }, [searchParams, router, queryClient, t]);
 
   return (
     <div className="p-6 max-w-5xl mx-auto">
@@ -102,25 +107,25 @@ export function WorkspacesPage() {
 
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="page-title">Vendors</h1>
+          <h1 className="page-title">{t('workspaces.title')}</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Manage your third-party ICT vendors and DORA compliance
+            {t('workspaces.subtitle')}
           </p>
         </div>
         <Button onClick={() => openModal(MODAL_IDS.CREATE_WORKSPACE)}>
           <Plus className="h-4 w-4 mr-2" />
-          New Vendor
+          {t('workspaces.newVendor')}
         </Button>
       </div>
 
       {workspaces.length === 0 ? (
         <EmptyState
           icon={Building2}
-          heading="No vendors yet"
-          description="Add your first ICT vendor to begin the DORA Article 28 compliance workflow - classification, due diligence, gap analysis, and monitoring."
-          cta="Add your first vendor"
+          heading={t('workspaces.empty.heading')}
+          description={t('workspaces.empty.description')}
+          cta={t('workspaces.empty.cta')}
           onAction={() => openModal(MODAL_IDS.CREATE_WORKSPACE)}
-          hint="Each vendor gets its own workspace with a 5-step compliance checklist."
+          hint={t('workspaces.empty.hint')}
         />
       ) : (
         <div className="grid gap-4 md:grid-cols-2">
@@ -164,7 +169,7 @@ export function WorkspacesPage() {
                 <div className="flex items-center gap-4 text-xs text-muted-foreground">
                   <span className="flex items-center gap-1">
                     <Users className="h-3.5 w-3.5" />
-                    Team
+                    {t('workspaces.team')}
                   </span>
                   {workspace.syncStatus && (
                     <span className="flex items-center gap-1">
@@ -178,10 +183,10 @@ export function WorkspacesPage() {
                         }`}
                       />
                       {workspace.syncStatus === 'syncing'
-                        ? 'Syncing'
+                        ? t('workspaces.sync.syncing')
                         : workspace.syncStatus === 'error'
-                          ? 'Sync Error'
-                          : 'Synced'}
+                          ? t('workspaces.sync.error')
+                          : t('workspaces.sync.synced')}
                     </span>
                   )}
                 </div>

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -934,5 +934,77 @@
       "toastMemberRemoved": "Member removed",
       "toastRemoveFailed": "Failed to remove member"
     }
+  },
+  "workspaces": {
+    "title": "Vendors",
+    "subtitle": "Manage your third-party ICT vendors and DORA compliance",
+    "newVendor": "New Vendor",
+    "team": "Team",
+    "empty": {
+      "heading": "No vendors yet",
+      "description": "Add your first ICT vendor to begin the DORA Article 28 compliance workflow - classification, due diligence, gap analysis, and monitoring.",
+      "cta": "Add your first vendor",
+      "hint": "Each vendor gets its own workspace with a 5-step compliance checklist."
+    },
+    "tier": {
+      "critical": "Critical",
+      "important": "Important",
+      "standard": "Standard"
+    },
+    "status": {
+      "active": "Active",
+      "underReview": "Under Review",
+      "exited": "Exited"
+    },
+    "sync": {
+      "syncing": "Syncing",
+      "error": "Sync Error",
+      "synced": "Synced"
+    },
+    "toast": {
+      "connected": "Workspace \"{{name}}\" connected successfully!",
+      "reconnected": "Workspace \"{{name}}\" reconnected",
+      "reconnectedDesc": "Credentials have been updated.",
+      "connectFailed": "Failed to connect workspace"
+    },
+    "header": {
+      "settings": "Settings"
+    },
+    "overview": {
+      "back": "Vendors",
+      "loading": "Loading workspace...",
+      "profile": "Profile",
+      "noProfile1": "No vendor profile data — ",
+      "addInSettings": "add details in Settings",
+      "contactOwner": "contact the workspace owner",
+      "contract": "Contract",
+      "start": "Start: {{date}}",
+      "end": "End: {{date}}",
+      "nextReview": "Next review: {{date}}",
+      "noDates": "No contract dates set",
+      "daysOverdue": "({{days}}d overdue)",
+      "daysLeft": "(+{{days}}d)"
+    },
+    "contractBar": {
+      "expiredAgo": "Contract expired {{days}}d ago",
+      "expiresIn": "Contract expires in {{days}} days"
+    },
+    "score": {
+      "title": "Portfolio Compliance Score",
+      "good": "Good",
+      "needsAttention": "Needs attention",
+      "atRisk": "At risk",
+      "trendUp": "+{{pts}} pts",
+      "trendDown": "{{pts}} pts",
+      "noChange": "No change",
+      "vs30": "vs 30 days ago",
+      "assessmentCount_one": "{{count}} completed assessment",
+      "assessmentCount_other": "{{count}} completed assessments"
+    },
+    "assessmentsCard": {
+      "title": "DORA Gap Assessments",
+      "date": "Date",
+      "noneYet": "No assessments yet for this vendor"
+    }
   }
 }

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -934,5 +934,77 @@
       "toastMemberRemoved": "Membre retiré",
       "toastRemoveFailed": "Échec du retrait du membre"
     }
+  },
+  "workspaces": {
+    "title": "Fournisseurs",
+    "subtitle": "Gérez vos fournisseurs TIC tiers et la conformité DORA",
+    "newVendor": "Nouveau fournisseur",
+    "team": "Équipe",
+    "empty": {
+      "heading": "Aucun fournisseur pour le moment",
+      "description": "Ajoutez votre premier fournisseur TIC pour démarrer le flux de conformité à l'article 28 de DORA — classification, due diligence, analyse d'écart et surveillance.",
+      "cta": "Ajoutez votre premier fournisseur",
+      "hint": "Chaque fournisseur dispose de son propre espace de travail avec une checklist de conformité en 5 étapes."
+    },
+    "tier": {
+      "critical": "Critique",
+      "important": "Important",
+      "standard": "Standard"
+    },
+    "status": {
+      "active": "Actif",
+      "underReview": "En cours d'examen",
+      "exited": "Sorti"
+    },
+    "sync": {
+      "syncing": "Synchronisation",
+      "error": "Erreur de synchro",
+      "synced": "Synchronisé"
+    },
+    "toast": {
+      "connected": "Espace de travail « {{name}} » connecté avec succès !",
+      "reconnected": "Espace de travail « {{name}} » reconnecté",
+      "reconnectedDesc": "Les identifiants ont été mis à jour.",
+      "connectFailed": "Échec de la connexion de l'espace de travail"
+    },
+    "header": {
+      "settings": "Paramètres"
+    },
+    "overview": {
+      "back": "Fournisseurs",
+      "loading": "Chargement de l'espace de travail…",
+      "profile": "Profil",
+      "noProfile1": "Aucune donnée de profil fournisseur — ",
+      "addInSettings": "ajoutez des détails dans les paramètres",
+      "contactOwner": "contactez le propriétaire de l'espace de travail",
+      "contract": "Contrat",
+      "start": "Début : {{date}}",
+      "end": "Fin : {{date}}",
+      "nextReview": "Prochain examen : {{date}}",
+      "noDates": "Aucune date de contrat définie",
+      "daysOverdue": "({{days}} j de retard)",
+      "daysLeft": "(+{{days}} j)"
+    },
+    "contractBar": {
+      "expiredAgo": "Contrat expiré il y a {{days}} j",
+      "expiresIn": "Le contrat expire dans {{days}} jours"
+    },
+    "score": {
+      "title": "Score de conformité du portefeuille",
+      "good": "Bon",
+      "needsAttention": "À surveiller",
+      "atRisk": "À risque",
+      "trendUp": "+{{pts}} pts",
+      "trendDown": "{{pts}} pts",
+      "noChange": "Aucun changement",
+      "vs30": "vs il y a 30 jours",
+      "assessmentCount_one": "{{count}} évaluation terminée",
+      "assessmentCount_other": "{{count}} évaluations terminées"
+    },
+    "assessmentsCard": {
+      "title": "Analyses d'écart DORA",
+      "date": "Date",
+      "noneYet": "Aucune évaluation pour ce fournisseur"
+    }
   }
 }


### PR DESCRIPTION
i18n batch 14a — **vendors list** (tier/status/sync badges, contract-expiry bar, empty state, connect toasts), **workspace overview** (header, profile + contract cards), **compliance score card** and the **per-vendor assessments card**. Adds the `workspaces` namespace (reuses `assessments.*` for shared status/risk/column labels). Full suite 513/513, build green, parity 782/782. Branch via Git Data API. Batches 14b (wizard + members) and 14c (checklist/monitoring/settings) follow.