### PR TITLE
fix(web): keep session alive on access-token expiry (#396)

### DIFF
--- a/frontend/e2e/assessments.spec.ts
+++ b/frontend/e2e/assessments.spec.ts
@@ -67,8 +67,10 @@ test.describe('New Assessment page — with workspace', () => {
 
   test('assessment name is auto-generated and contains vendor name', async ({ page }) => {
     const nameInput = page.getByLabel('Assessment name');
-    const value = await nameInput.inputValue();
-    expect(value).toContain('Acme Corp');
+    // Web-first assertion: the assessment name is generated reactively once the
+    // vendor name (loaded async from the active workspace) propagates, so wait
+    // for it instead of reading inputValue() once (which races the update).
+    await expect(nameInput).toHaveValue(/Acme Corp/);
   });
 
   test('changing vendor name updates auto-generated assessment name', async ({ page }) => {

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -33,8 +33,12 @@ function decodeJWTPayload(token: string): { role?: string; exp?: number } | null
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Get access token from cookie
+  // Get tokens from cookies. The access token cookie lives 15 min; the refresh
+  // token cookie lives 7 days. A present refresh token means the client can
+  // silently mint a new access token — so an expired access token must NOT bounce
+  // the user to login.
   const accessToken = request.cookies.get('accessToken')?.value;
+  const refreshToken = request.cookies.get('refreshToken')?.value;
 
   // Check if path is public (exact match for '/', startsWith for others)
   const isPublicPath = pathname === '/' || publicPaths.some((path) => pathname.startsWith(path));
@@ -55,8 +59,11 @@ export function proxy(request: NextRequest) {
     }
   }
 
-  // If protected path and user is not authenticated, redirect to login
-  if (!isPublicPath && !accessToken) {
+  // If protected path and the user has NO way to authenticate (neither a valid
+  // access token nor a refresh token), redirect to login. When only the access
+  // token is gone but a refresh token survives, let the request through — the
+  // client's AuthProvider / axios interceptor will refresh transparently.
+  if (!isPublicPath && !accessToken && !refreshToken) {
     const loginUrl = new URL('/login', request.url);
     // Store the original URL to redirect back after login
     loginUrl.searchParams.set('callbackUrl', pathname);

--- a/frontend/src/shared/providers/auth-provider.tsx
+++ b/frontend/src/shared/providers/auth-provider.tsx
@@ -17,6 +17,7 @@ export function AuthProvider({
   authResolved = false,
 }: AuthProviderProps) {
   const isInitialized = useAuthStore((state) => state.isInitialized);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const setUser = useAuthStore((state) => state.setUser);
   const clearSession = useAuthStore((state) => state.clearSession);
   const setLoading = useAuthStore((state) => state.setLoading);
@@ -71,6 +72,24 @@ export function AuthProvider({
     setLoading,
     setInitialized,
   ]);
+
+  // Proactive silent refresh: while authenticated, renew the 15-min access token
+  // a couple of minutes before it expires so the session never breaks mid-use.
+  // The httpOnly cookies are renewed server-side; on failure (e.g. refresh token
+  // expired) the next request's 401 handler clears the session.
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    const REFRESH_INTERVAL_MS = 13 * 60 * 1000; // < 15-min access-token TTL
+
+    const intervalId = setInterval(() => {
+      void authApi.refreshToken().catch(() => {
+        // Swallow: the axios 401 interceptor / AuthProvider handles real expiry.
+      });
+    }, REFRESH_INTERVAL_MS);
+
+    return () => clearInterval(intervalId);
+  }, [isAuthenticated]);
 
   return <>{children}</>;
 }

--- a/frontend/src/tests/proxy.test.ts
+++ b/frontend/src/tests/proxy.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { proxy } from '@/proxy';
+import type { NextRequest } from 'next/server';
+
+/**
+ * Minimal NextRequest stand-in: proxy() only reads `nextUrl.pathname`,
+ * `url`, and `cookies.get(name)?.value`.
+ */
+function makeReq(pathname: string, cookies: Record<string, string> = {}): NextRequest {
+  return {
+    nextUrl: { pathname },
+    url: `https://app.test${pathname}`,
+    cookies: {
+      get: (name: string) =>
+        cookies[name] !== undefined ? { value: cookies[name] } : undefined,
+    },
+  } as unknown as NextRequest;
+}
+
+const location = (res: Response) => res.headers.get('location');
+
+describe('proxy middleware — refresh-aware route guard', () => {
+  it('redirects to login on a protected path with no tokens', () => {
+    const res = proxy(makeReq('/chat'));
+    expect(location(res)).toContain('/login');
+    expect(location(res)).toContain('callbackUrl=%2Fchat');
+  });
+
+  it('allows a protected path when only a refresh token survives (access expired)', () => {
+    // This is the core fix: a missing access token must NOT bounce the user to
+    // login while a 7-day refresh token is still present.
+    const res = proxy(makeReq('/chat', { refreshToken: 'r' }));
+    expect(location(res)).toBeNull();
+  });
+
+  it('allows a protected path with an access token', () => {
+    const res = proxy(makeReq('/chat', { accessToken: 'a' }));
+    expect(location(res)).toBeNull();
+  });
+
+  it('allows public paths without any token', () => {
+    expect(location(proxy(makeReq('/login')))).toBeNull();
+    expect(location(proxy(makeReq('/')))).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #396.

## Problème
Toutes les ~15 min, l'access-token expirait et l'utilisateur était **déconnecté** (redirigé vers `/login`), même avec un refresh-token (7 jours) valide. Repéré pendant le test E2E du 07/06.

## Cause racine
- Le cookie `accessToken` a `maxAge: 15 min` (`backend/utils/security/cookieConfig.js:29`) → le navigateur le supprime → `frontend/src/proxy.ts` voit `!accessToken` → redirect login, **sans regarder le `refreshToken`**.

## Fix
- **`proxy.ts` (refresh-aware)** : on ne redirige vers login que si **ni** access **ni** refresh token n'est présent. Si seul l'access token a expiré, on laisse passer → le client rafraîchit de façon transparente (AuthProvider/`getMe` → 401 → interceptor `/auth/refresh`).
- **`auth-provider.tsx` (silent refresh)** : pendant que l'utilisateur est authentifié, refresh proactif toutes les **13 min** (< TTL 15 min) → l'access token est renouvelé avant d'expirer, la session ne casse jamais en usage actif.
- **Test** : `proxy.test.ts` couvre le cas-clé (refresh token seul → pas de redirect) + les cas no-token / access-token / public.

## Validation
- ✅ Frontend : 517 tests (dont 4 nouveaux pour le proxy)
- ✅ Lint clean (warning React Compiler pré-existant, non lié)
- ✅ Pre-push hook vert (back + front)
- Sécurité préservée : le guard devient seulement *plus permissif quand un refresh token valide existe* — aucun accès ouvert qui ne l'était pas avant ; le backend reste l'autorité d'autorisation.

## Note
Validation E2E finale (attendre l'expiration réelle + naviguer) à faire sur `dev`/staging une fois mergé — la logique est couverte par le test unitaire du middleware.
