### PR TITLE
feat(web): recommended-documents checklist on the assessment form (#395)

### DIFF
--- a/frontend/src/app/(dashboard)/assessments/new/page.tsx
+++ b/frontend/src/app/(dashboard)/assessments/new/page.tsx
@@ -7,7 +7,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, Loader2, RotateCcw } from 'lucide-react';
+import { ArrowLeft, Loader2, RotateCcw, FileText, AlertTriangle, Circle } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
@@ -36,6 +36,17 @@ type FormValues = z.infer<typeof schema>;
 interface FileWithId extends File {
   id: string;
 }
+
+// Document categories recommended per framework (i18n label keys live under
+// assessments.form.recommendedDocs.<dora|a30>.<key>). Guidance only — the gate
+// is soft: the user can proceed with fewer.
+const RECOMMENDED_DOC_KEYS: Record<'DORA' | 'CONTRACT_A30', string[]> = {
+  DORA: ['iso27001', 'soc2', 'securityPolicy', 'bcp', 'dpa'],
+  CONTRACT_A30: ['contract', 'sla', 'subprocessors', 'exit', 'security'],
+};
+
+// Below this many uploaded documents, the analysis is likely incomplete.
+const MIN_RECOMMENDED_DOCS = 2;
 
 function buildAssessmentName(
   vendor: string,
@@ -242,6 +253,38 @@ export default function NewAssessmentPage() {
               <p className="text-xs text-destructive">
                 {t('assessments.form.uploadAtLeastOne')}
               </p>
+            )}
+          </div>
+
+          {/* Recommended documents checklist (soft guidance — does not block) */}
+          <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <p className="flex items-center gap-2 text-sm font-medium">
+                <FileText className="h-4 w-4" />
+                {t('assessments.form.recommendedDocs.title')}
+              </p>
+              <span className="text-xs text-muted-foreground">
+                {t('assessments.form.recommendedDocs.uploaded', { count: files.length })}
+              </span>
+            </div>
+            <ul className="grid gap-1.5 text-sm text-muted-foreground sm:grid-cols-2">
+              {RECOMMENDED_DOC_KEYS[framework].map((key) => (
+                <li key={key} className="flex items-center gap-2">
+                  <Circle className="h-2.5 w-2.5 shrink-0" />
+                  {t(
+                    `assessments.form.recommendedDocs.${framework === 'CONTRACT_A30' ? 'a30' : 'dora'}.${key}`,
+                  )}
+                </li>
+              ))}
+            </ul>
+            <p className="text-xs text-muted-foreground">
+              {t('assessments.form.recommendedDocs.note')}
+            </p>
+            {files.length >= 1 && files.length < MIN_RECOMMENDED_DOCS && (
+              <div className="flex gap-2 rounded-md border border-warning/30 bg-warning/10 p-3 text-xs text-warning">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{t('assessments.form.recommendedDocs.warning')}</span>
+              </div>
             )}
           </div>
 

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -487,7 +487,27 @@
       "uploadAtLeastOne": "Please upload at least one document.",
       "start": "Start Assessment",
       "uploading": "Uploading…",
-      "toastCreated": "Assessment created — indexing documents…"
+      "toastCreated": "Assessment created — indexing documents…",
+      "recommendedDocs": {
+        "title": "Recommended documents",
+        "note": "Recommended for a thorough analysis. You can proceed with fewer — the analysis confidence will be lower.",
+        "uploaded": "{{count}} uploaded",
+        "warning": "You're starting with very few documents. A thorough analysis usually needs several — the result may be incomplete. Consider adding the recommended documents above.",
+        "dora": {
+          "iso27001": "ISO 27001 certificate",
+          "soc2": "SOC 2 / SOC 3 report",
+          "securityPolicy": "Security policy / whitepaper",
+          "bcp": "Business continuity / DR plan",
+          "dpa": "Data processing agreement (GDPR)"
+        },
+        "a30": {
+          "contract": "ICT services contract / MSA",
+          "sla": "SLA annex",
+          "subprocessors": "Subcontractor list",
+          "exit": "Exit / termination annex",
+          "security": "Security annex"
+        }
+      }
     },
     "detail": {
       "back": "Assessments",

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -487,7 +487,27 @@
       "uploadAtLeastOne": "Veuillez importer au moins un document.",
       "start": "Lancer l'évaluation",
       "uploading": "Téléversement…",
-      "toastCreated": "Évaluation créée — indexation des documents…"
+      "toastCreated": "Évaluation créée — indexation des documents…",
+      "recommendedDocs": {
+        "title": "Documents recommandés",
+        "note": "Recommandés pour une analyse complète. Vous pouvez continuer avec moins — la confiance de l'analyse sera réduite.",
+        "uploaded": "{{count}} téléversé(s)",
+        "warning": "Vous démarrez avec très peu de documents. Une analyse complète en nécessite généralement plusieurs — le résultat peut être incomplet. Pensez à ajouter les documents recommandés ci-dessus.",
+        "dora": {
+          "iso27001": "Certificat ISO 27001",
+          "soc2": "Rapport SOC 2 / SOC 3",
+          "securityPolicy": "Politique / livre blanc de sécurité",
+          "bcp": "Plan de continuité / reprise (PCA/PRA)",
+          "dpa": "Accord de traitement des données (RGPD)"
+        },
+        "a30": {
+          "contract": "Contrat de services ICT / MSA",
+          "sla": "Annexe SLA",
+          "subprocessors": "Liste des sous-traitants",
+          "exit": "Annexe sortie / résiliation",
+          "security": "Annexe sécurité"
+        }
+      }
     },
     "detail": {
       "back": "Évaluations",


### PR DESCRIPTION
Addresses #395 (phase 1).

## Problème
Lancer une gap analysis / contract review avec **1 seul document** produisait un résultat superficiel présenté comme complet. Rien n'indiquait à l'utilisateur ce qu'une analyse complète nécessite.

## Fix (phase 1 — guidance + avertissement soft)
Sur la page `assessments/new`, entre l'upload et le bouton « Start » :
- **Checklist de documents recommandés par framework** :
  - DORA (Art. 28/29) : ISO 27001, SOC 2/3, politique sécurité, PCA/PRA, DPA (RGPD)
  - CONTRACT_A30 (Art. 30) : contrat/MSA, annexe SLA, liste sous-traitants, annexe sortie/résiliation, annexe sécurité
- **Avertissement soft** quand < 2 documents sont téléversés (« le résultat peut être incomplet ») — **ne bloque pas** le Start (gate souple, assessments partiels légitimes).
- **i18n en/fr** (parité validée par `i18n.test.ts`).

## Validation
- ✅ Frontend 517 tests (dont parité i18n) · lint clean · JSON valide
- La page est exercée par la Frontend E2E de la CI.

## Phase 2 (issue laissée ouverte)
- Taguer chaque fichier par catégorie + vraie complétude %.
- Caveat dans le **rapport généré** : « confiance réduite — documents manquants : X, Y ».
