### PR TITLE
fix(web): send the first message of a new conversation (#397)

### DIFF
--- a/frontend/e2e/chat.spec.ts
+++ b/frontend/e2e/chat.spec.ts
@@ -93,6 +93,57 @@ test.describe('Chat page — with workspace', () => {
     // After conversation creation, should redirect to /conversations/<id>
     await expect(page).toHaveURL(/\/conversations\//);
   });
+
+  test('sends the first message after creating the conversation (#397)', async ({ page }) => {
+    await page.route('**/api/v1/conversations', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'success', data: { conversation: MOCK_CONVERSATION } }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    // The destination conversation page loads the (empty) new conversation.
+    await page.route(`**/api/v1/conversations/${MOCK_CONVERSATION.id}`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'success',
+          data: { conversation: MOCK_CONVERSATION, messages: [] },
+        }),
+      })
+    );
+
+    // Capture the question + the page that fired the stream request.
+    let streamedBody: string | null = null;
+    let streamedFromUrl: string | null = null;
+    await page.route('**/api/v1/rag/stream', async (route) => {
+      streamedBody = route.request().postData();
+      streamedFromUrl = route.request().frame().url();
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: 'data: {"type":"done"}\n\n',
+      });
+    });
+
+    await page.goto('/chat');
+    const chatInput = page.getByRole('textbox').first();
+    await chatInput.fill('What are the DORA requirements?');
+    await chatInput.press('Enter');
+
+    await expect(page).toHaveURL(/\/conversations\//);
+    // The bug (#397): the first message was sent from the blank /chat page, which
+    // then unmounted on navigation and aborted the stream — so it was lost. With
+    // the fix the message is sent from the mounted /conversations/<id> page.
+    await expect.poll(() => streamedBody).toContain('DORA requirements');
+    await expect.poll(() => streamedFromUrl).toContain('/conversations/');
+  });
 });
 
 test.describe('Conversations list page', () => {

--- a/frontend/src/features/chat/hooks/use-chat-session.ts
+++ b/frontend/src/features/chat/hooks/use-chat-session.ts
@@ -8,6 +8,10 @@ import { conversationsApi } from '@/features/chat/api/conversations';
 import { useActiveWorkspace } from '@/features/workspaces/queries/use-workspace-queries';
 import { usePermissions } from '@/shared/hooks/use-permissions';
 import { useStreaming } from '@/features/chat/hooks/use-streaming';
+import {
+  setPendingFirstMessage,
+  takePendingFirstMessage,
+} from '@/features/chat/lib/pending-first-message';
 import type { Conversation, Message } from '@/types';
 
 const EMPTY_MESSAGES: Message[] = [];
@@ -112,6 +116,19 @@ export function useChatSession({
     [startStreaming]
   );
 
+  // First-message handoff (issue #397): when this conversation page mounts right
+  // after being created on /chat, send the stashed question once. takePending…
+  // clears it, so StrictMode's double-invoke can't double-send.
+  useEffect(() => {
+    if (!conversation?.id) return;
+    const handoff = takePendingFirstMessage(conversation.id);
+    if (handoff) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      handleSendWithConversation(handoff.question, conversation.id, handoff.workspaceId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conversation?.id]);
+
   const createConversationMutation = useMutation({
     mutationFn: async (question: string) => {
       if (!activeWorkspace) {
@@ -127,11 +144,18 @@ export function useChatSession({
     onSuccess: (newConversation) => {
       if (!newConversation) return;
 
-      onConversationCreated?.(newConversation);
+      // Stash the question BEFORE navigating: onConversationCreated unmounts this
+      // page, so sending here would abort the stream. The destination conversation
+      // page picks it up on mount and sends it (issue #397).
       if (pendingQuestion) {
-        handleSendWithConversation(pendingQuestion, newConversation.id, activeWorkspace?.id ?? null);
+        setPendingFirstMessage({
+          conversationId: newConversation.id,
+          question: pendingQuestion,
+          workspaceId: activeWorkspace?.id ?? null,
+        });
         setPendingQuestion(null);
       }
+      onConversationCreated?.(newConversation);
     },
     onError: () => {
       toast.error('Failed to create conversation');

--- a/frontend/src/features/chat/lib/pending-first-message.ts
+++ b/frontend/src/features/chat/lib/pending-first-message.ts
@@ -1,0 +1,30 @@
+/**
+ * Hands the first message off from the blank `/chat` page to the freshly-created
+ * `/conversations/<id>` page across the route change (issue #397).
+ *
+ * Why: on first send the blank page creates the conversation then navigates, which
+ * unmounts it and aborts the in-flight SSE stream — so the message was lost. We
+ * instead stash the question here, navigate, and let the (stable) destination page
+ * send it on mount. Keyed by conversationId and taken exactly once.
+ */
+export interface PendingFirstMessage {
+  conversationId: string;
+  question: string;
+  workspaceId: string | null;
+}
+
+let pending: PendingFirstMessage | null = null;
+
+export function setPendingFirstMessage(value: PendingFirstMessage): void {
+  pending = value;
+}
+
+/** Returns and clears the pending message iff it matches this conversation. */
+export function takePendingFirstMessage(conversationId: string): PendingFirstMessage | null {
+  if (pending && pending.conversationId === conversationId) {
+    const value = pending;
+    pending = null;
+    return value;
+  }
+  return null;
+}

--- a/frontend/src/tests/pending-first-message.test.ts
+++ b/frontend/src/tests/pending-first-message.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import {
+  setPendingFirstMessage,
+  takePendingFirstMessage,
+} from '@/features/chat/lib/pending-first-message';
+
+describe('pending-first-message handoff (#397)', () => {
+  it('returns the stashed message for the matching conversation', () => {
+    setPendingFirstMessage({ conversationId: 'c1', question: 'hello', workspaceId: 'ws1' });
+    const taken = takePendingFirstMessage('c1');
+    expect(taken).toEqual({ conversationId: 'c1', question: 'hello', workspaceId: 'ws1' });
+  });
+
+  it('is taken exactly once (guards StrictMode double-invoke)', () => {
+    setPendingFirstMessage({ conversationId: 'c2', question: 'q', workspaceId: null });
+    expect(takePendingFirstMessage('c2')).not.toBeNull();
+    expect(takePendingFirstMessage('c2')).toBeNull();
+  });
+
+  it('does not return (nor clear) a message for a different conversation', () => {
+    setPendingFirstMessage({ conversationId: 'c3', question: 'q', workspaceId: null });
+    expect(takePendingFirstMessage('other')).toBeNull();
+    // still available for the right id
+    expect(takePendingFirstMessage('c3')).not.toBeNull();
+  });
+
+  it('returns null when nothing is pending', () => {
+    // c3 was consumed above; no pending message remains
+    expect(takePendingFirstMessage('anything')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #397.

## Problème
Sur `/chat`, le **tout premier message** d'une nouvelle conversation ne s'envoyait pas : la conversation était créée, l'URL passait à `/conversations/<id>`, mais l'utilisateur arrivait sur une conversation **vide** (message + réponse perdus). Repéré au test E2E du 07/06.

## Cause racine
`useChatSession.createConversationMutation.onSuccess` :
1. `onConversationCreated()` → `router.replace('/conversations/<id>')` → **démonte** la page `/chat`
2. *puis* `handleSendWithConversation()` → `startStreaming()` sur le composant **en cours de démontage** → le fetch SSE est avorté → message perdu. La page conversation se monte « fraîche » sans connaître la question.

## Fix
- **Handoff** (`pending-first-message.ts`) : la question est stockée **avant** la navigation, puis envoyée par la page conversation **montée/stable** au montage (via le même `handleSendWithConversation` que les envois normaux). `take` keyed + once → pas de double-envoi (StrictMode safe).

## Validation
- ✅ **Test E2E de régression** (`chat.spec.ts`) : vérifie que le stream part de `/conversations/<id>`.
  - **Avec le fix** → passe.
  - **Sans le fix** → échoue (`Received: ".../chat"`) — prouve le bug ET le fix, exécuté en vrai navigateur localement.
- ✅ Test unitaire du handoff (keyed, take-once).
- ✅ Frontend 521 tests · lint clean.
