### PR TITLE
release: promote dev → main — e2e bugfixes (#394, #395, #396, #397)

### DIFF
--- a/backend/config/vectorStore.js
+++ b/backend/config/vectorStore.js
@@ -1,6 +1,6 @@
 import { QdrantVectorStore } from '@langchain/qdrant';
 import { QdrantClient } from '@qdrant/js-client-rest';
-import { randomUUID } from 'crypto';
+import { randomUUID, createHash } from 'crypto';
 import {
   embeddings,
   BATCH_CONFIG,
@@ -341,5 +341,103 @@ export async function getIndexStats() {
   } catch (error) {
     logger.error('Failed to get index stats', { error: error.message });
     return null;
+  }
+}
+
+// Remove lone Unicode surrogates that break JSON encoding (shared by upserts).
+function sanitizeText(text) {
+  if (typeof text !== 'string') return text;
+  return text.replace(
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
+    '�'
+  );
+}
+
+// Deterministic UUID from a stable key → re-indexing the same chunk overwrites
+// instead of duplicating.
+function deterministicPointId(key) {
+  const h = createHash('sha256').update(key).digest('hex');
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20, 32)}`;
+}
+
+/**
+ * Dual-write (issue #394): upsert already-embedded assessment chunks into the
+ * SHARED workspace collection so the chat — which is tenant-filtered on
+ * `metadata.workspaceId` — can retrieve documents indexed during an assessment.
+ * Reuses the vectors (no re-embedding); deterministic IDs make it idempotent.
+ *
+ * @param {object} params
+ * @param {string[]} params.chunks  - Chunk texts (same order as vectors)
+ * @param {number[][]} params.vectors - Embeddings for each chunk
+ * @param {object} params.metadata - Must include workspaceId, assessmentId, fileName
+ * @returns {Promise<{ upserted: number }>}
+ */
+/**
+ * Pure helper: build the Qdrant points for the workspace collection. Exported so
+ * the payload shape + deterministic ids can be unit-tested without a live client.
+ * Returns [] when nothing should be written (missing chunks/vectors/workspaceId).
+ */
+export function buildWorkspacePoints({ chunks, vectors, metadata }) {
+  if (!chunks?.length || !vectors?.length || !metadata?.workspaceId) return [];
+  return chunks.map((chunk, i) => ({
+    id: deterministicPointId(
+      `${metadata.workspaceId}:${metadata.assessmentId}:${metadata.fileName}:${i}`
+    ),
+    vector: vectors[i],
+    payload: {
+      pageContent: sanitizeText(chunk),
+      metadata: { ...metadata, chunkIndex: i },
+    },
+  }));
+}
+
+export async function upsertChunksToWorkspaceCollection({ chunks, vectors, metadata }) {
+  const points = buildWorkspacePoints({ chunks, vectors, metadata });
+  if (points.length === 0) {
+    return { upserted: 0 };
+  }
+
+  const client = getQdrantClient();
+  await ensureCollection(client, points[0].vector.length);
+
+  const BATCH_SIZE = 100;
+  for (let i = 0; i < points.length; i += BATCH_SIZE) {
+    await client.upsert(COLLECTION_NAME, {
+      wait: true,
+      points: points.slice(i, i + BATCH_SIZE),
+    });
+  }
+
+  logger.info('Dual-write to workspace collection complete', {
+    service: 'vector-store',
+    workspaceId: metadata.workspaceId,
+    assessmentId: metadata.assessmentId,
+    upserted: points.length,
+  });
+
+  return { upserted: points.length };
+}
+
+/**
+ * Remove an assessment's chunks from the shared workspace collection — called on
+ * assessment deletion so the chat doesn't keep retrieving deleted documents.
+ * Best-effort; never throws into the delete flow.
+ */
+export async function deleteAssessmentChunksFromWorkspace(assessmentId) {
+  if (!assessmentId) return;
+  try {
+    const client = getQdrantClient();
+    await client.delete(COLLECTION_NAME, {
+      wait: true,
+      filter: {
+        must: [{ key: 'metadata.assessmentId', match: { value: assessmentId } }],
+      },
+    });
+  } catch (error) {
+    logger.warn('Failed to delete assessment chunks from workspace collection', {
+      service: 'vector-store',
+      assessmentId,
+      error: error.message,
+    });
   }
 }

--- a/backend/services/AssessmentService.js
+++ b/backend/services/AssessmentService.js
@@ -20,6 +20,14 @@ class AssessmentService {
     this.storage = deps.storage || storageModule;
     this.generateReport = deps.generateReport || generateReport;
     this.deleteAssessmentCollection = deps.deleteAssessmentCollection || deleteAssessmentCollection;
+    // Lazy default: only pull in the heavy vectorStore module when actually
+    // deleting (keeps it out of the app's eager import graph).
+    this.deleteAssessmentChunksFromWorkspace =
+      deps.deleteAssessmentChunksFromWorkspace ||
+      (async (assessmentId) => {
+        const { deleteAssessmentChunksFromWorkspace } = await import('../config/vectorStore.js');
+        return deleteAssessmentChunksFromWorkspace(assessmentId);
+      });
     this.logger = deps.logger || logger;
   }
 
@@ -335,6 +343,15 @@ class AssessmentService {
 
     Promise.resolve(this.deleteAssessmentCollection(id)).catch((err) =>
       this.logger.warn('Failed to delete assessment Qdrant collection', {
+        assessmentId: id,
+        error: err?.message,
+      })
+    );
+
+    // Also purge this assessment's chunks from the shared workspace collection
+    // (issue #394 dual-write) so the chat no longer retrieves deleted documents.
+    Promise.resolve(this.deleteAssessmentChunksFromWorkspace(id)).catch((err) =>
+      this.logger.warn('Failed to delete assessment chunks from workspace collection', {
         assessmentId: id,
         error: err?.message,
       })

--- a/backend/services/fileIngestionService.js
+++ b/backend/services/fileIngestionService.js
@@ -212,6 +212,7 @@ export async function ingestFile({
   fileType,
   fileName,
   assessmentId,
+  workspaceId,
   vendorName,
   onProgress,
 }) {
@@ -294,6 +295,39 @@ export async function ingestFile({
     upserted += batchChunks.length;
 
     if (onProgress) onProgress({ indexed: upserted, total: chunks.length, phase: 'indexing' });
+  }
+
+  // 5. Dual-write (issue #394): also index the same chunks into the shared
+  // workspace collection so the chat (tenant-filtered on metadata.workspaceId)
+  // can retrieve this vendor's documents. Reuses the vectors — no re-embedding.
+  // Best-effort: a failure here must not fail the assessment (gap analysis uses
+  // the per-assessment collection regardless).
+  if (workspaceId) {
+    try {
+      // Lazy import: keep the heavy vectorStore (and its module-load side effects)
+      // out of the app's eager import graph; only needed when actually ingesting.
+      const { upsertChunksToWorkspaceCollection } = await import('../config/vectorStore.js');
+      await upsertChunksToWorkspaceCollection({
+        chunks,
+        vectors,
+        metadata: {
+          workspaceId,
+          assessmentId,
+          vendorName,
+          fileName,
+          fileType,
+          source: 'assessment',
+        },
+      });
+    } catch (err) {
+      logger.warn('Dual-write to workspace collection failed (chat may miss this doc)', {
+        service: 'file-ingestion',
+        assessmentId,
+        workspaceId,
+        fileName,
+        error: err.message,
+      });
+    }
   }
 
   logger.info('File ingestion complete', {

--- a/backend/tests/unittest/vectorStoreDualWrite.test.js
+++ b/backend/tests/unittest/vectorStoreDualWrite.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildWorkspacePoints,
+  deleteAssessmentChunksFromWorkspace,
+} from '../../config/vectorStore.js';
+
+/**
+ * #394 — dual-write of assessment documents into the shared workspace collection
+ * so the chat (tenant-filtered on metadata.workspaceId) can retrieve them.
+ *
+ * The Qdrant-calling code is validated end-to-end on the local stack (the repo
+ * does not unit-test live Qdrant calls). Here we cover the pure point-building
+ * logic + the best-effort delete contract.
+ */
+describe('vectorStore dual-write (#394)', () => {
+  it('builds points carrying workspaceId metadata + pageContent', () => {
+    const points = buildWorkspacePoints({
+      chunks: ['hello world chunk'],
+      vectors: [[0.1, 0.2, 0.3]],
+      metadata: {
+        workspaceId: 'ws1',
+        assessmentId: 'a1',
+        fileName: 'f.pdf',
+        vendorName: 'AWS',
+        source: 'assessment',
+      },
+    });
+
+    expect(points).toHaveLength(1);
+    expect(points[0].vector).toEqual([0.1, 0.2, 0.3]);
+    expect(points[0].payload.pageContent).toContain('hello world');
+    expect(points[0].payload.metadata.workspaceId).toBe('ws1'); // tenant filter key
+    expect(points[0].payload.metadata.assessmentId).toBe('a1');
+    expect(points[0].payload.metadata.source).toBe('assessment');
+    expect(points[0].payload.metadata.chunkIndex).toBe(0);
+  });
+
+  it('produces deterministic, well-formed point ids (re-index overwrites)', () => {
+    const args = {
+      chunks: ['c'],
+      vectors: [[0.1]],
+      metadata: { workspaceId: 'ws1', assessmentId: 'a1', fileName: 'f.pdf' },
+    };
+    const id1 = buildWorkspacePoints(args)[0].id;
+    const id2 = buildWorkspacePoints(args)[0].id;
+    expect(id1).toBe(id2);
+    expect(id1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it('ids are unique per chunk and per assessment', () => {
+    const base = {
+      chunks: ['a', 'b'],
+      vectors: [[0.1], [0.2]],
+      metadata: { workspaceId: 'ws1', assessmentId: 'a1', fileName: 'f.pdf' },
+    };
+    const points = buildWorkspacePoints(base);
+    expect(points[0].id).not.toBe(points[1].id);
+
+    const otherAssessment = buildWorkspacePoints({
+      ...base,
+      metadata: { ...base.metadata, assessmentId: 'a2' },
+    });
+    expect(otherAssessment[0].id).not.toBe(points[0].id);
+  });
+
+  it('returns [] (no dual-write) when workspaceId or chunks are missing', () => {
+    expect(
+      buildWorkspacePoints({ chunks: ['x'], vectors: [[0.1]], metadata: { assessmentId: 'a1' } })
+    ).toEqual([]);
+    expect(
+      buildWorkspacePoints({ chunks: [], vectors: [], metadata: { workspaceId: 'ws1' } })
+    ).toEqual([]);
+  });
+
+  it('deleteAssessmentChunksFromWorkspace is best-effort (never throws)', async () => {
+    // No Qdrant in unit tests → the internal client call fails and is swallowed.
+    await expect(deleteAssessmentChunksFromWorkspace('a1')).resolves.toBeUndefined();
+  });
+});

--- a/backend/workers/assessmentWorker.js
+++ b/backend/workers/assessmentWorker.js
@@ -73,6 +73,7 @@ async function processFileIndex(job) {
       fileType,
       fileName,
       assessmentId,
+      workspaceId: existing?.workspaceId?.toString(),
       vendorName,
       onProgress: async ({ indexed, total }) => {
         const pct = Math.round(10 + (indexed / total) * 70);

--- a/frontend/e2e/assessments.spec.ts
+++ b/frontend/e2e/assessments.spec.ts
@@ -67,8 +67,10 @@ test.describe('New Assessment page — with workspace', () => {
 
   test('assessment name is auto-generated and contains vendor name', async ({ page }) => {
     const nameInput = page.getByLabel('Assessment name');
-    const value = await nameInput.inputValue();
-    expect(value).toContain('Acme Corp');
+    // Web-first assertion: the assessment name is generated reactively once the
+    // vendor name (loaded async from the active workspace) propagates, so wait
+    // for it instead of reading inputValue() once (which races the update).
+    await expect(nameInput).toHaveValue(/Acme Corp/);
   });
 
   test('changing vendor name updates auto-generated assessment name', async ({ page }) => {

--- a/frontend/e2e/chat.spec.ts
+++ b/frontend/e2e/chat.spec.ts
@@ -93,6 +93,57 @@ test.describe('Chat page — with workspace', () => {
     // After conversation creation, should redirect to /conversations/<id>
     await expect(page).toHaveURL(/\/conversations\//);
   });
+
+  test('sends the first message after creating the conversation (#397)', async ({ page }) => {
+    await page.route('**/api/v1/conversations', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'success', data: { conversation: MOCK_CONVERSATION } }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    // The destination conversation page loads the (empty) new conversation.
+    await page.route(`**/api/v1/conversations/${MOCK_CONVERSATION.id}`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'success',
+          data: { conversation: MOCK_CONVERSATION, messages: [] },
+        }),
+      })
+    );
+
+    // Capture the question + the page that fired the stream request.
+    let streamedBody: string | null = null;
+    let streamedFromUrl: string | null = null;
+    await page.route('**/api/v1/rag/stream', async (route) => {
+      streamedBody = route.request().postData();
+      streamedFromUrl = route.request().frame().url();
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: 'data: {"type":"done"}\n\n',
+      });
+    });
+
+    await page.goto('/chat');
+    const chatInput = page.getByRole('textbox').first();
+    await chatInput.fill('What are the DORA requirements?');
+    await chatInput.press('Enter');
+
+    await expect(page).toHaveURL(/\/conversations\//);
+    // The bug (#397): the first message was sent from the blank /chat page, which
+    // then unmounted on navigation and aborted the stream — so it was lost. With
+    // the fix the message is sent from the mounted /conversations/<id> page.
+    await expect.poll(() => streamedBody).toContain('DORA requirements');
+    await expect.poll(() => streamedFromUrl).toContain('/conversations/');
+  });
 });
 
 test.describe('Conversations list page', () => {

--- a/frontend/src/app/(dashboard)/assessments/new/page.tsx
+++ b/frontend/src/app/(dashboard)/assessments/new/page.tsx
@@ -7,7 +7,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, Loader2, RotateCcw } from 'lucide-react';
+import { ArrowLeft, Loader2, RotateCcw, FileText, AlertTriangle, Circle } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
@@ -36,6 +36,17 @@ type FormValues = z.infer<typeof schema>;
 interface FileWithId extends File {
   id: string;
 }
+
+// Document categories recommended per framework (i18n label keys live under
+// assessments.form.recommendedDocs.<dora|a30>.<key>). Guidance only — the gate
+// is soft: the user can proceed with fewer.
+const RECOMMENDED_DOC_KEYS: Record<'DORA' | 'CONTRACT_A30', string[]> = {
+  DORA: ['iso27001', 'soc2', 'securityPolicy', 'bcp', 'dpa'],
+  CONTRACT_A30: ['contract', 'sla', 'subprocessors', 'exit', 'security'],
+};
+
+// Below this many uploaded documents, the analysis is likely incomplete.
+const MIN_RECOMMENDED_DOCS = 2;
 
 function buildAssessmentName(
   vendor: string,
@@ -242,6 +253,38 @@ export default function NewAssessmentPage() {
               <p className="text-xs text-destructive">
                 {t('assessments.form.uploadAtLeastOne')}
               </p>
+            )}
+          </div>
+
+          {/* Recommended documents checklist (soft guidance — does not block) */}
+          <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <p className="flex items-center gap-2 text-sm font-medium">
+                <FileText className="h-4 w-4" />
+                {t('assessments.form.recommendedDocs.title')}
+              </p>
+              <span className="text-xs text-muted-foreground">
+                {t('assessments.form.recommendedDocs.uploaded', { count: files.length })}
+              </span>
+            </div>
+            <ul className="grid gap-1.5 text-sm text-muted-foreground sm:grid-cols-2">
+              {RECOMMENDED_DOC_KEYS[framework].map((key) => (
+                <li key={key} className="flex items-center gap-2">
+                  <Circle className="h-2.5 w-2.5 shrink-0" />
+                  {t(
+                    `assessments.form.recommendedDocs.${framework === 'CONTRACT_A30' ? 'a30' : 'dora'}.${key}`,
+                  )}
+                </li>
+              ))}
+            </ul>
+            <p className="text-xs text-muted-foreground">
+              {t('assessments.form.recommendedDocs.note')}
+            </p>
+            {files.length >= 1 && files.length < MIN_RECOMMENDED_DOCS && (
+              <div className="flex gap-2 rounded-md border border-warning/30 bg-warning/10 p-3 text-xs text-warning">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{t('assessments.form.recommendedDocs.warning')}</span>
+              </div>
             )}
           </div>
 

--- a/frontend/src/features/chat/hooks/use-chat-session.ts
+++ b/frontend/src/features/chat/hooks/use-chat-session.ts
@@ -8,6 +8,10 @@ import { conversationsApi } from '@/features/chat/api/conversations';
 import { useActiveWorkspace } from '@/features/workspaces/queries/use-workspace-queries';
 import { usePermissions } from '@/shared/hooks/use-permissions';
 import { useStreaming } from '@/features/chat/hooks/use-streaming';
+import {
+  setPendingFirstMessage,
+  takePendingFirstMessage,
+} from '@/features/chat/lib/pending-first-message';
 import type { Conversation, Message } from '@/types';
 
 const EMPTY_MESSAGES: Message[] = [];
@@ -112,6 +116,19 @@ export function useChatSession({
     [startStreaming]
   );
 
+  // First-message handoff (issue #397): when this conversation page mounts right
+  // after being created on /chat, send the stashed question once. takePending…
+  // clears it, so StrictMode's double-invoke can't double-send.
+  useEffect(() => {
+    if (!conversation?.id) return;
+    const handoff = takePendingFirstMessage(conversation.id);
+    if (handoff) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      handleSendWithConversation(handoff.question, conversation.id, handoff.workspaceId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conversation?.id]);
+
   const createConversationMutation = useMutation({
     mutationFn: async (question: string) => {
       if (!activeWorkspace) {
@@ -127,11 +144,18 @@ export function useChatSession({
     onSuccess: (newConversation) => {
       if (!newConversation) return;
 
-      onConversationCreated?.(newConversation);
+      // Stash the question BEFORE navigating: onConversationCreated unmounts this
+      // page, so sending here would abort the stream. The destination conversation
+      // page picks it up on mount and sends it (issue #397).
       if (pendingQuestion) {
-        handleSendWithConversation(pendingQuestion, newConversation.id, activeWorkspace?.id ?? null);
+        setPendingFirstMessage({
+          conversationId: newConversation.id,
+          question: pendingQuestion,
+          workspaceId: activeWorkspace?.id ?? null,
+        });
         setPendingQuestion(null);
       }
+      onConversationCreated?.(newConversation);
     },
     onError: () => {
       toast.error('Failed to create conversation');

--- a/frontend/src/features/chat/lib/pending-first-message.ts
+++ b/frontend/src/features/chat/lib/pending-first-message.ts
@@ -1,0 +1,30 @@
+/**
+ * Hands the first message off from the blank `/chat` page to the freshly-created
+ * `/conversations/<id>` page across the route change (issue #397).
+ *
+ * Why: on first send the blank page creates the conversation then navigates, which
+ * unmounts it and aborts the in-flight SSE stream — so the message was lost. We
+ * instead stash the question here, navigate, and let the (stable) destination page
+ * send it on mount. Keyed by conversationId and taken exactly once.
+ */
+export interface PendingFirstMessage {
+  conversationId: string;
+  question: string;
+  workspaceId: string | null;
+}
+
+let pending: PendingFirstMessage | null = null;
+
+export function setPendingFirstMessage(value: PendingFirstMessage): void {
+  pending = value;
+}
+
+/** Returns and clears the pending message iff it matches this conversation. */
+export function takePendingFirstMessage(conversationId: string): PendingFirstMessage | null {
+  if (pending && pending.conversationId === conversationId) {
+    const value = pending;
+    pending = null;
+    return value;
+  }
+  return null;
+}

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -33,8 +33,12 @@ function decodeJWTPayload(token: string): { role?: string; exp?: number } | null
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Get access token from cookie
+  // Get tokens from cookies. The access token cookie lives 15 min; the refresh
+  // token cookie lives 7 days. A present refresh token means the client can
+  // silently mint a new access token — so an expired access token must NOT bounce
+  // the user to login.
   const accessToken = request.cookies.get('accessToken')?.value;
+  const refreshToken = request.cookies.get('refreshToken')?.value;
 
   // Check if path is public (exact match for '/', startsWith for others)
   const isPublicPath = pathname === '/' || publicPaths.some((path) => pathname.startsWith(path));
@@ -55,8 +59,11 @@ export function proxy(request: NextRequest) {
     }
   }
 
-  // If protected path and user is not authenticated, redirect to login
-  if (!isPublicPath && !accessToken) {
+  // If protected path and the user has NO way to authenticate (neither a valid
+  // access token nor a refresh token), redirect to login. When only the access
+  // token is gone but a refresh token survives, let the request through — the
+  // client's AuthProvider / axios interceptor will refresh transparently.
+  if (!isPublicPath && !accessToken && !refreshToken) {
     const loginUrl = new URL('/login', request.url);
     // Store the original URL to redirect back after login
     loginUrl.searchParams.set('callbackUrl', pathname);

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -487,7 +487,27 @@
       "uploadAtLeastOne": "Please upload at least one document.",
       "start": "Start Assessment",
       "uploading": "Uploading…",
-      "toastCreated": "Assessment created — indexing documents…"
+      "toastCreated": "Assessment created — indexing documents…",
+      "recommendedDocs": {
+        "title": "Recommended documents",
+        "note": "Recommended for a thorough analysis. You can proceed with fewer — the analysis confidence will be lower.",
+        "uploaded": "{{count}} uploaded",
+        "warning": "You're starting with very few documents. A thorough analysis usually needs several — the result may be incomplete. Consider adding the recommended documents above.",
+        "dora": {
+          "iso27001": "ISO 27001 certificate",
+          "soc2": "SOC 2 / SOC 3 report",
+          "securityPolicy": "Security policy / whitepaper",
+          "bcp": "Business continuity / DR plan",
+          "dpa": "Data processing agreement (GDPR)"
+        },
+        "a30": {
+          "contract": "ICT services contract / MSA",
+          "sla": "SLA annex",
+          "subprocessors": "Subcontractor list",
+          "exit": "Exit / termination annex",
+          "security": "Security annex"
+        }
+      }
     },
     "detail": {
       "back": "Assessments",

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -487,7 +487,27 @@
       "uploadAtLeastOne": "Veuillez importer au moins un document.",
       "start": "Lancer l'évaluation",
       "uploading": "Téléversement…",
-      "toastCreated": "Évaluation créée — indexation des documents…"
+      "toastCreated": "Évaluation créée — indexation des documents…",
+      "recommendedDocs": {
+        "title": "Documents recommandés",
+        "note": "Recommandés pour une analyse complète. Vous pouvez continuer avec moins — la confiance de l'analyse sera réduite.",
+        "uploaded": "{{count}} téléversé(s)",
+        "warning": "Vous démarrez avec très peu de documents. Une analyse complète en nécessite généralement plusieurs — le résultat peut être incomplet. Pensez à ajouter les documents recommandés ci-dessus.",
+        "dora": {
+          "iso27001": "Certificat ISO 27001",
+          "soc2": "Rapport SOC 2 / SOC 3",
+          "securityPolicy": "Politique / livre blanc de sécurité",
+          "bcp": "Plan de continuité / reprise (PCA/PRA)",
+          "dpa": "Accord de traitement des données (RGPD)"
+        },
+        "a30": {
+          "contract": "Contrat de services ICT / MSA",
+          "sla": "Annexe SLA",
+          "subprocessors": "Liste des sous-traitants",
+          "exit": "Annexe sortie / résiliation",
+          "security": "Annexe sécurité"
+        }
+      }
     },
     "detail": {
       "back": "Évaluations",

--- a/frontend/src/shared/providers/auth-provider.tsx
+++ b/frontend/src/shared/providers/auth-provider.tsx
@@ -17,6 +17,7 @@ export function AuthProvider({
   authResolved = false,
 }: AuthProviderProps) {
   const isInitialized = useAuthStore((state) => state.isInitialized);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const setUser = useAuthStore((state) => state.setUser);
   const clearSession = useAuthStore((state) => state.clearSession);
   const setLoading = useAuthStore((state) => state.setLoading);
@@ -71,6 +72,24 @@ export function AuthProvider({
     setLoading,
     setInitialized,
   ]);
+
+  // Proactive silent refresh: while authenticated, renew the 15-min access token
+  // a couple of minutes before it expires so the session never breaks mid-use.
+  // The httpOnly cookies are renewed server-side; on failure (e.g. refresh token
+  // expired) the next request's 401 handler clears the session.
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    const REFRESH_INTERVAL_MS = 13 * 60 * 1000; // < 15-min access-token TTL
+
+    const intervalId = setInterval(() => {
+      void authApi.refreshToken().catch(() => {
+        // Swallow: the axios 401 interceptor / AuthProvider handles real expiry.
+      });
+    }, REFRESH_INTERVAL_MS);
+
+    return () => clearInterval(intervalId);
+  }, [isAuthenticated]);
 
   return <>{children}</>;
 }

--- a/frontend/src/tests/pending-first-message.test.ts
+++ b/frontend/src/tests/pending-first-message.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import {
+  setPendingFirstMessage,
+  takePendingFirstMessage,
+} from '@/features/chat/lib/pending-first-message';
+
+describe('pending-first-message handoff (#397)', () => {
+  it('returns the stashed message for the matching conversation', () => {
+    setPendingFirstMessage({ conversationId: 'c1', question: 'hello', workspaceId: 'ws1' });
+    const taken = takePendingFirstMessage('c1');
+    expect(taken).toEqual({ conversationId: 'c1', question: 'hello', workspaceId: 'ws1' });
+  });
+
+  it('is taken exactly once (guards StrictMode double-invoke)', () => {
+    setPendingFirstMessage({ conversationId: 'c2', question: 'q', workspaceId: null });
+    expect(takePendingFirstMessage('c2')).not.toBeNull();
+    expect(takePendingFirstMessage('c2')).toBeNull();
+  });
+
+  it('does not return (nor clear) a message for a different conversation', () => {
+    setPendingFirstMessage({ conversationId: 'c3', question: 'q', workspaceId: null });
+    expect(takePendingFirstMessage('other')).toBeNull();
+    // still available for the right id
+    expect(takePendingFirstMessage('c3')).not.toBeNull();
+  });
+
+  it('returns null when nothing is pending', () => {
+    // c3 was consumed above; no pending message remains
+    expect(takePendingFirstMessage('anything')).toBeNull();
+  });
+});

--- a/frontend/src/tests/proxy.test.ts
+++ b/frontend/src/tests/proxy.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { proxy } from '@/proxy';
+import type { NextRequest } from 'next/server';
+
+/**
+ * Minimal NextRequest stand-in: proxy() only reads `nextUrl.pathname`,
+ * `url`, and `cookies.get(name)?.value`.
+ */
+function makeReq(pathname: string, cookies: Record<string, string> = {}): NextRequest {
+  return {
+    nextUrl: { pathname },
+    url: `https://app.test${pathname}`,
+    cookies: {
+      get: (name: string) =>
+        cookies[name] !== undefined ? { value: cookies[name] } : undefined,
+    },
+  } as unknown as NextRequest;
+}
+
+const location = (res: Response) => res.headers.get('location');
+
+describe('proxy middleware — refresh-aware route guard', () => {
+  it('redirects to login on a protected path with no tokens', () => {
+    const res = proxy(makeReq('/chat'));
+    expect(location(res)).toContain('/login');
+    expect(location(res)).toContain('callbackUrl=%2Fchat');
+  });
+
+  it('allows a protected path when only a refresh token survives (access expired)', () => {
+    // This is the core fix: a missing access token must NOT bounce the user to
+    // login while a 7-day refresh token is still present.
+    const res = proxy(makeReq('/chat', { refreshToken: 'r' }));
+    expect(location(res)).toBeNull();
+  });
+
+  it('allows a protected path with an access token', () => {
+    const res = proxy(makeReq('/chat', { accessToken: 'a' }));
+    expect(location(res)).toBeNull();
+  });
+
+  it('allows public paths without any token', () => {
+    expect(location(proxy(makeReq('/login')))).toBeNull();
+    expect(location(proxy(makeReq('/')))).toBeNull();
+  });
+});


### PR DESCRIPTION
Promote `dev` → `main` : les **4 correctifs** issus du test end-to-end du 07/06 (auto-deploy prod au merge).

## Inclus
| # | Correctif | Validation |
|---|---|---|
| **#396** | Session refresh-aware : plus de logout toutes les 15 min (guard proxy + silent refresh) | unit + E2E |
| **#394** | Le chat voit les documents des fournisseurs (dual-write dans la collection workspace) | unit + **E2E vs vrai Qdrant** |
| **#395** | Checklist de documents recommandés à la création d'évaluation (phase 1) | unit + i18n + E2E |
| **#397** | Le 1er message d'une nouvelle conversation est bien envoyé (handoff) | unit + **E2E de régression** |

## Statut
- Chaque PR a été mergée dans `dev` avec CI verte (back, front, E2E, docker, audit).
- Aucune régression : backend 1426 tests, frontend 521 tests.

## Reste (non bloquant)
- Phase 2 de #395 : tagging par catégorie + caveat « confiance réduite » dans le rapport.
