### PR TITLE
fix(security): key auth rate limits on ipv6 subnet, not exact address (#381)

### DIFF
--- a/backend/middleware/authRateLimiter.js
+++ b/backend/middleware/authRateLimiter.js
@@ -14,10 +14,19 @@
  * without inflating counters or hitting limits.
  */
 
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import logger from '../config/logger.js';
 
 const DISABLED = process.env.AUTH_RATE_LIMIT_DISABLED === 'true';
+
+/**
+ * Build the per-IP rate-limit key. ipKeyGenerator normalizes IPv6 to its subnet
+ * so a single /64 allocation can't rotate through addresses to bypass the cap
+ * (issue #381). Exported for testing.
+ */
+export function buildRateLimitKey(name, ip) {
+  return `auth:${name}:${ipKeyGenerator(ip || 'unknown')}`;
+}
 
 function makeLimiter({ name, windowMs, max, message }) {
   return rateLimit({
@@ -28,7 +37,7 @@ function makeLimiter({ name, windowMs, max, message }) {
     skip: () => DISABLED,
     // Key by IP. We deliberately do NOT key by user — the point is to
     // protect endpoints that establish identity, before a user is known.
-    keyGenerator: (req) => `auth:${name}:${req.ip || 'unknown'}`,
+    keyGenerator: (req) => buildRateLimitKey(name, req.ip),
     validate: { ip: false, trustProxy: false },
     message: { status: 'fail', message },
     handler: (req, res, _next, options) => {

--- a/backend/tests/unittest/authRateLimiter.test.js
+++ b/backend/tests/unittest/authRateLimiter.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { buildRateLimitKey } from '../../middleware/authRateLimiter.js';
+
+/**
+ * #381 — the auth limiters must key on the IPv6 *subnet*, not the exact address,
+ * so a single /64 allocation can't rotate through ~18 quintillion addresses to
+ * bypass the per-IP cap.
+ */
+describe('authRateLimiter — IPv6-safe key generation (#381)', () => {
+  it('two IPv6 addresses in the same allocation share one key', () => {
+    const a = buildRateLimitKey('login', '2001:db8:1234:5678:aaaa:bbbb:cccc:dddd');
+    const b = buildRateLimitKey('login', '2001:db8:1234:5678:1111:2222:3333:4444');
+    expect(a).toBe(b);
+  });
+
+  it('IPv6 addresses in different allocations get different keys', () => {
+    const a = buildRateLimitKey('login', '2001:db8:1234:5678::1');
+    const c = buildRateLimitKey('login', '2001:db8:9999:0000::1');
+    expect(a).not.toBe(c);
+  });
+
+  it('keeps IPv4 addresses distinct (per-address, as before)', () => {
+    expect(buildRateLimitKey('login', '203.0.113.7')).not.toBe(
+      buildRateLimitKey('login', '203.0.113.8')
+    );
+  });
+
+  it('namespaces by limiter name so endpoints have separate buckets', () => {
+    expect(buildRateLimitKey('login', '203.0.113.7')).not.toBe(
+      buildRateLimitKey('register', '203.0.113.7')
+    );
+  });
+
+  it('falls back to "unknown" without throwing when ip is missing', () => {
+    expect(() => buildRateLimitKey('login', undefined)).not.toThrow();
+    expect(buildRateLimitKey('login', undefined)).toContain('unknown');
+  });
+});


### PR DESCRIPTION
Closes #381.

## Problème (sécurité)
Les limiters auth (`authRateLimiter.js`) keyaient sur `req.ip` brut :
```js
keyGenerator: (req) => `auth:${name}:${req.ip || 'unknown'}`,
```
En **IPv6**, une allocation résidentielle = un **/64** (~18 quintillions d'adresses pour un seul abonné). Un attaquant change d'adresse IPv6 à chaque tentative dans son /64 → chaque requête a une clé différente → le plafond « 10 logins / 15 min par IP » est **contourné** (credential stuffing). `express-rate-limit` le signalait via `ERR_ERL_KEY_GEN_IPV6`.

## Fix
```js
import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
keyGenerator: (req) => buildRateLimitKey(name, req.ip), // → ipKeyGenerator(ip)
```
`ipKeyGenerator` **normalise l'IPv6 sur son sous-réseau** (collapse `/56`) → la limite s'applique par allocation, pas par adresse exacte. IPv4 inchangé.

**Bonus** : supprime la `ValidationError` levée au chargement du module — la fragilité qui avait fait planter 5 tests d'intégration quand l'import eager de `vectorStore` (#394) a décalé l'ordre de chargement.

## Validation
- ✅ 5 tests unitaires (`buildRateLimitKey`) : deux IPv6 du même /64 → **même clé** ; /64 différents → clés différentes ; IPv4 distinct ; namespacing par endpoint ; fallback `unknown` sans throw.
- ✅ Backend **1431 tests** (70 fichiers), aucune régression.
