### PR TITLE
feat(report): flag reduced confidence on partial document sets (#395)

### DIFF
--- a/backend/services/reportGenerator.js
+++ b/backend/services/reportGenerator.js
@@ -234,10 +234,58 @@ function buildCoverPage(assessment) {
   ];
 }
 
+// Recommended document types per framework — surfaced in the report when the
+// assessment was run on a thin evidence base (issue #395). English labels, as
+// the report is generated in English.
+const RECOMMENDED_REPORT_DOCS = {
+  DORA: [
+    'an ISO 27001 certificate',
+    'a SOC 2 / SOC 3 report',
+    'a security policy',
+    'a business continuity / DR plan',
+    'a data processing agreement (GDPR)',
+  ],
+  CONTRACT_A30: [
+    'the ICT services contract / MSA',
+    'an SLA annex',
+    'a subcontractor list',
+    'an exit / termination annex',
+    'a security annex',
+  ],
+};
+
+// Below this many documents the evidence base is considered partial.
+const MIN_THOROUGH_DOCS = 2;
+
+/**
+ * Returns a "reduced confidence" caveat string when an assessment was run on a
+ * partial document set, or null otherwise. Pure + exported for testing.
+ * (Phase 2c of #395 — count-based; upgrades to precise missing-category listing
+ * once per-file tagging lands.)
+ */
+export function partialEvidenceCaveat(assessment) {
+  const docCount = assessment?.documents?.length || 0;
+  if (docCount === 0 || docCount >= MIN_THOROUGH_DOCS) return null;
+
+  const isContract = assessment.framework === 'CONTRACT_A30';
+  const recommended = isContract
+    ? RECOMMENDED_REPORT_DOCS.CONTRACT_A30
+    : RECOMMENDED_REPORT_DOCS.DORA;
+  const reviewLabel = isContract ? 'Article 30 contract review' : 'DORA gap analysis';
+
+  return (
+    `This ${reviewLabel} is based on a single uploaded document. A thorough review typically ` +
+    `draws on several document types — e.g. ${recommended.join(', ')}. Conclusions may understate ` +
+    `gaps where supporting evidence was not provided; treat the coverage findings below as a floor, ` +
+    `not a ceiling.`
+  );
+}
+
 function buildExecutiveSummary(assessment) {
   const gaps = assessment.results?.gaps || [];
   const risk = assessment.results?.overallRisk || 'N/A';
   const summary = assessment.results?.summary || '';
+  const caveat = partialEvidenceCaveat(assessment);
 
   const covered = gaps.filter((g) => g.gapLevel === 'covered').length;
   const partial = gaps.filter((g) => g.gapLevel === 'partial').length;
@@ -250,6 +298,12 @@ function buildExecutiveSummary(assessment) {
       summary ||
         `This report presents the results of a DORA compliance gap analysis for ${assessment.vendorName}.`
     ),
+    ...(caveat
+      ? [
+          heading2('Confidence Note — Partial Document Set'),
+          para(caveat, { color: GAP_COLOUR.partial, italics: true }),
+        ]
+      : []),
     new Paragraph({ spacing: { before: 200, after: 100 } }),
     heading2('Assessment Statistics'),
     new Table({

--- a/backend/tests/unittest/reportCaveat.test.js
+++ b/backend/tests/unittest/reportCaveat.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { partialEvidenceCaveat } from '../../services/reportGenerator.js';
+
+/**
+ * #395 phase 2c — the generated report must flag a "reduced confidence" caveat
+ * when an assessment was run on a partial document set, so a shallow analysis
+ * isn't read as complete.
+ */
+describe('reportGenerator — partial-evidence caveat (#395)', () => {
+  it('returns a DORA caveat listing recommended docs for a single-document assessment', () => {
+    const caveat = partialEvidenceCaveat({ framework: 'DORA', documents: [{ fileName: 'a.pdf' }] });
+    expect(caveat).toContain('DORA gap analysis');
+    expect(caveat).toContain('single uploaded document');
+    expect(caveat).toContain('ISO 27001');
+    expect(caveat).toContain('SOC 2');
+  });
+
+  it('returns a contract-review caveat with Art.30 annexes', () => {
+    const caveat = partialEvidenceCaveat({
+      framework: 'CONTRACT_A30',
+      documents: [{ fileName: 'msa.pdf' }],
+    });
+    expect(caveat).toContain('Article 30 contract review');
+    expect(caveat).toContain('SLA annex');
+    expect(caveat).toContain('subcontractor list');
+  });
+
+  it('returns null when the evidence base is adequate (>= 2 documents)', () => {
+    expect(partialEvidenceCaveat({ framework: 'DORA', documents: [{}, {}] })).toBeNull();
+    expect(partialEvidenceCaveat({ framework: 'DORA', documents: [{}, {}, {}] })).toBeNull();
+  });
+
+  it('returns null for an empty assessment (no documents) — a different problem', () => {
+    expect(partialEvidenceCaveat({ framework: 'DORA', documents: [] })).toBeNull();
+    expect(partialEvidenceCaveat({ framework: 'DORA' })).toBeNull();
+    expect(partialEvidenceCaveat({})).toBeNull();
+  });
+});


### PR DESCRIPTION
Addresses #395 (phase 2c — caveat rapport).

## Problème
Une gap analysis / contract review lancée avec **1 seul document** produisait un rapport présenté comme **complet**. Rien dans le **rapport généré** ne signalait l'incomplétude (la phase 1 ne couvrait que l'UI de création).

## Fix
Ajout d'une note **« Confidence Note — Partial Document Set »** dans le résumé exécutif du DOCX (`reportGenerator.js`) quand l'évaluation s'appuie sur < 2 documents :

> *This DORA gap analysis is based on a single uploaded document. A thorough review typically draws on several document types — e.g. an ISO 27001 certificate, a SOC 2 / SOC 3 report, a security policy, a business continuity / DR plan, a data processing agreement (GDPR). Conclusions may understate gaps where supporting evidence was not provided; treat the coverage findings below as a floor, not a ceiling.*

- `partialEvidenceCaveat(assessment)` : fonction **pure exportée** → renvoie le texte (par framework : DORA vs Art.30) ou `null`. Rendu en **ambre/italique** dans le résumé exécutif.
- Heuristique simple **basée sur le compte** (pas de tagging requis). Cohérent avec le seuil de la phase 1 (< 2 docs).

## Validation
- ✅ 4 tests unitaires (DORA, Art.30, ≥2 docs → null, 0 doc → null).
- ✅ Backend **1430 tests** (70 fichiers), aucune régression.

## Reste (phase 2 a/b)
Quand le **tagging par catégorie** des fichiers existera, ce caveat passera de « basé sur 1 document » à la **liste précise** « documents manquants : X, Y ».
