### PR TITLE
release: promote dev → main — security (#381) + report caveat (#395)

### DIFF
--- a/backend/middleware/authRateLimiter.js
+++ b/backend/middleware/authRateLimiter.js
@@ -14,10 +14,19 @@
  * without inflating counters or hitting limits.
  */
 
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import logger from '../config/logger.js';
 
 const DISABLED = process.env.AUTH_RATE_LIMIT_DISABLED === 'true';
+
+/**
+ * Build the per-IP rate-limit key. ipKeyGenerator normalizes IPv6 to its subnet
+ * so a single /64 allocation can't rotate through addresses to bypass the cap
+ * (issue #381). Exported for testing.
+ */
+export function buildRateLimitKey(name, ip) {
+  return `auth:${name}:${ipKeyGenerator(ip || 'unknown')}`;
+}
 
 function makeLimiter({ name, windowMs, max, message }) {
   return rateLimit({
@@ -28,7 +37,7 @@ function makeLimiter({ name, windowMs, max, message }) {
     skip: () => DISABLED,
     // Key by IP. We deliberately do NOT key by user — the point is to
     // protect endpoints that establish identity, before a user is known.
-    keyGenerator: (req) => `auth:${name}:${req.ip || 'unknown'}`,
+    keyGenerator: (req) => buildRateLimitKey(name, req.ip),
     validate: { ip: false, trustProxy: false },
     message: { status: 'fail', message },
     handler: (req, res, _next, options) => {

--- a/backend/services/reportGenerator.js
+++ b/backend/services/reportGenerator.js
@@ -234,10 +234,58 @@ function buildCoverPage(assessment) {
   ];
 }
 
+// Recommended document types per framework — surfaced in the report when the
+// assessment was run on a thin evidence base (issue #395). English labels, as
+// the report is generated in English.
+const RECOMMENDED_REPORT_DOCS = {
+  DORA: [
+    'an ISO 27001 certificate',
+    'a SOC 2 / SOC 3 report',
+    'a security policy',
+    'a business continuity / DR plan',
+    'a data processing agreement (GDPR)',
+  ],
+  CONTRACT_A30: [
+    'the ICT services contract / MSA',
+    'an SLA annex',
+    'a subcontractor list',
+    'an exit / termination annex',
+    'a security annex',
+  ],
+};
+
+// Below this many documents the evidence base is considered partial.
+const MIN_THOROUGH_DOCS = 2;
+
+/**
+ * Returns a "reduced confidence" caveat string when an assessment was run on a
+ * partial document set, or null otherwise. Pure + exported for testing.
+ * (Phase 2c of #395 — count-based; upgrades to precise missing-category listing
+ * once per-file tagging lands.)
+ */
+export function partialEvidenceCaveat(assessment) {
+  const docCount = assessment?.documents?.length || 0;
+  if (docCount === 0 || docCount >= MIN_THOROUGH_DOCS) return null;
+
+  const isContract = assessment.framework === 'CONTRACT_A30';
+  const recommended = isContract
+    ? RECOMMENDED_REPORT_DOCS.CONTRACT_A30
+    : RECOMMENDED_REPORT_DOCS.DORA;
+  const reviewLabel = isContract ? 'Article 30 contract review' : 'DORA gap analysis';
+
+  return (
+    `This ${reviewLabel} is based on a single uploaded document. A thorough review typically ` +
+    `draws on several document types — e.g. ${recommended.join(', ')}. Conclusions may understate ` +
+    `gaps where supporting evidence was not provided; treat the coverage findings below as a floor, ` +
+    `not a ceiling.`
+  );
+}
+
 function buildExecutiveSummary(assessment) {
   const gaps = assessment.results?.gaps || [];
   const risk = assessment.results?.overallRisk || 'N/A';
   const summary = assessment.results?.summary || '';
+  const caveat = partialEvidenceCaveat(assessment);
 
   const covered = gaps.filter((g) => g.gapLevel === 'covered').length;
   const partial = gaps.filter((g) => g.gapLevel === 'partial').length;
@@ -250,6 +298,12 @@ function buildExecutiveSummary(assessment) {
       summary ||
         `This report presents the results of a DORA compliance gap analysis for ${assessment.vendorName}.`
     ),
+    ...(caveat
+      ? [
+          heading2('Confidence Note — Partial Document Set'),
+          para(caveat, { color: GAP_COLOUR.partial, italics: true }),
+        ]
+      : []),
     new Paragraph({ spacing: { before: 200, after: 100 } }),
     heading2('Assessment Statistics'),
     new Table({

--- a/backend/tests/unittest/authRateLimiter.test.js
+++ b/backend/tests/unittest/authRateLimiter.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { buildRateLimitKey } from '../../middleware/authRateLimiter.js';
+
+/**
+ * #381 — the auth limiters must key on the IPv6 *subnet*, not the exact address,
+ * so a single /64 allocation can't rotate through ~18 quintillion addresses to
+ * bypass the per-IP cap.
+ */
+describe('authRateLimiter — IPv6-safe key generation (#381)', () => {
+  it('two IPv6 addresses in the same allocation share one key', () => {
+    const a = buildRateLimitKey('login', '2001:db8:1234:5678:aaaa:bbbb:cccc:dddd');
+    const b = buildRateLimitKey('login', '2001:db8:1234:5678:1111:2222:3333:4444');
+    expect(a).toBe(b);
+  });
+
+  it('IPv6 addresses in different allocations get different keys', () => {
+    const a = buildRateLimitKey('login', '2001:db8:1234:5678::1');
+    const c = buildRateLimitKey('login', '2001:db8:9999:0000::1');
+    expect(a).not.toBe(c);
+  });
+
+  it('keeps IPv4 addresses distinct (per-address, as before)', () => {
+    expect(buildRateLimitKey('login', '203.0.113.7')).not.toBe(
+      buildRateLimitKey('login', '203.0.113.8')
+    );
+  });
+
+  it('namespaces by limiter name so endpoints have separate buckets', () => {
+    expect(buildRateLimitKey('login', '203.0.113.7')).not.toBe(
+      buildRateLimitKey('register', '203.0.113.7')
+    );
+  });
+
+  it('falls back to "unknown" without throwing when ip is missing', () => {
+    expect(() => buildRateLimitKey('login', undefined)).not.toThrow();
+    expect(buildRateLimitKey('login', undefined)).toContain('unknown');
+  });
+});

--- a/backend/tests/unittest/reportCaveat.test.js
+++ b/backend/tests/unittest/reportCaveat.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { partialEvidenceCaveat } from '../../services/reportGenerator.js';
+
+/**
+ * #395 phase 2c — the generated report must flag a "reduced confidence" caveat
+ * when an assessment was run on a partial document set, so a shallow analysis
+ * isn't read as complete.
+ */
+describe('reportGenerator — partial-evidence caveat (#395)', () => {
+  it('returns a DORA caveat listing recommended docs for a single-document assessment', () => {
+    const caveat = partialEvidenceCaveat({ framework: 'DORA', documents: [{ fileName: 'a.pdf' }] });
+    expect(caveat).toContain('DORA gap analysis');
+    expect(caveat).toContain('single uploaded document');
+    expect(caveat).toContain('ISO 27001');
+    expect(caveat).toContain('SOC 2');
+  });
+
+  it('returns a contract-review caveat with Art.30 annexes', () => {
+    const caveat = partialEvidenceCaveat({
+      framework: 'CONTRACT_A30',
+      documents: [{ fileName: 'msa.pdf' }],
+    });
+    expect(caveat).toContain('Article 30 contract review');
+    expect(caveat).toContain('SLA annex');
+    expect(caveat).toContain('subcontractor list');
+  });
+
+  it('returns null when the evidence base is adequate (>= 2 documents)', () => {
+    expect(partialEvidenceCaveat({ framework: 'DORA', documents: [{}, {}] })).toBeNull();
+    expect(partialEvidenceCaveat({ framework: 'DORA', documents: [{}, {}, {}] })).toBeNull();
+  });
+
+  it('returns null for an empty assessment (no documents) — a different problem', () => {
+    expect(partialEvidenceCaveat({ framework: 'DORA', documents: [] })).toBeNull();
+    expect(partialEvidenceCaveat({ framework: 'DORA' })).toBeNull();
+    expect(partialEvidenceCaveat({})).toBeNull();
+  });
+});


### PR DESCRIPTION
Promote `dev` → `main` : 2 correctifs de suivi (auto-deploy prod au merge).

| # | Correctif | Type | Tests |
|---|---|---|---|
| **#381** | Rate-limiter auth keyé sur le **sous-réseau IPv6** (`ipKeyGenerator`) — ferme un contournement par rotation d'adresses IPv6 dans un /64. Supprime aussi la `ValidationError` levée au chargement. | **sécurité** | 5 unit |
| **#395 (2c)** | Note **« confiance réduite »** dans le rapport DOCX quand l'évaluation s'appuie sur < 2 documents (par framework). | qualité produit | 4 unit |

## Statut
- Les deux mergés dans `dev` avec CI verte (back, front, E2E, docker, audit).
- Backend 1430 tests, aucune régression. Chaque fix = fonction pure exportée + testée.

## Reste (non bloquant)
- #395 phase 2 a/b : tagging par catégorie + complétude % (le caveat passera alors à « manquants : X, Y » précis).
