### PR TITLE
feat: per-file document tagging + precise missing-evidence caveat (#395)

### DIFF
--- a/backend/models/Assessment.js
+++ b/backend/models/Assessment.js
@@ -49,6 +49,9 @@ const documentSchema = new mongoose.Schema(
     fileName: { type: String, required: true },
     fileType: { type: String, enum: ['pdf', 'xlsx', 'docx', 'xls'], required: true },
     fileSize: { type: Number }, // bytes
+    // Document category the uploader tagged (issue #395): drives completeness +
+    // the "missing evidence" report caveat. Free-form; null when untagged.
+    category: { type: String, default: null },
     qdrantCollectionId: { type: String }, // per-assessment collection
     uploadedAt: { type: Date, default: Date.now },
     status: {

--- a/backend/services/AssessmentService.js
+++ b/backend/services/AssessmentService.js
@@ -34,10 +34,23 @@ class AssessmentService {
   async createAssessment(userId, organizationId, data, files) {
     const { name, vendorName, framework = 'DORA', workspaceId } = data;
 
-    const documents = files.map((f) => ({
+    // Categories the uploader tagged, one per file in order (#395). Best-effort:
+    // bad/absent JSON just leaves documents untagged.
+    let categories = [];
+    if (data.categories) {
+      try {
+        const parsed = JSON.parse(data.categories);
+        if (Array.isArray(parsed)) categories = parsed;
+      } catch {
+        categories = [];
+      }
+    }
+
+    const documents = files.map((f, i) => ({
       fileName: f.originalname,
       fileType: path.extname(f.originalname).replace('.', '').toLowerCase(),
       fileSize: f.size,
+      category: typeof categories[i] === 'string' ? categories[i] : null,
       status: 'uploading',
     }));
 

--- a/backend/services/reportGenerator.js
+++ b/backend/services/reportGenerator.js
@@ -234,48 +234,68 @@ function buildCoverPage(assessment) {
   ];
 }
 
-// Recommended document types per framework — surfaced in the report when the
-// assessment was run on a thin evidence base (issue #395). English labels, as
+// Recommended document categories per framework, and their human labels. The
+// category KEYS must match the frontend tagging (issue #395). English labels, as
 // the report is generated in English.
-const RECOMMENDED_REPORT_DOCS = {
-  DORA: [
-    'an ISO 27001 certificate',
-    'a SOC 2 / SOC 3 report',
-    'a security policy',
-    'a business continuity / DR plan',
-    'a data processing agreement (GDPR)',
-  ],
-  CONTRACT_A30: [
-    'the ICT services contract / MSA',
-    'an SLA annex',
-    'a subcontractor list',
-    'an exit / termination annex',
-    'a security annex',
-  ],
+const CATEGORY_LABELS = {
+  iso27001: 'an ISO 27001 certificate',
+  soc2: 'a SOC 2 / SOC 3 report',
+  securityPolicy: 'a security policy',
+  bcp: 'a business continuity / DR plan',
+  dpa: 'a data processing agreement (GDPR)',
+  contract: 'the ICT services contract / MSA',
+  sla: 'an SLA annex',
+  subprocessors: 'a subcontractor list',
+  exit: 'an exit / termination annex',
+  security: 'a security annex',
 };
 
-// Below this many documents the evidence base is considered partial.
+const RECOMMENDED_CATEGORY_KEYS = {
+  DORA: ['iso27001', 'soc2', 'securityPolicy', 'bcp', 'dpa'],
+  CONTRACT_A30: ['contract', 'sla', 'subprocessors', 'exit', 'security'],
+};
+
+// Below this many documents an untagged evidence base is considered partial.
 const MIN_THOROUGH_DOCS = 2;
 
 /**
  * Returns a "reduced confidence" caveat string when an assessment was run on a
- * partial document set, or null otherwise. Pure + exported for testing.
- * (Phase 2c of #395 — count-based; upgrades to precise missing-category listing
- * once per-file tagging lands.)
+ * partial document set, or null otherwise. Pure + exported for testing (#395).
+ *
+ * Precise mode (documents tagged with categories): lists the SPECIFIC recommended
+ * categories that are missing. Fallback (untagged / legacy uploads): count-based.
  */
 export function partialEvidenceCaveat(assessment) {
-  const docCount = assessment?.documents?.length || 0;
-  if (docCount === 0 || docCount >= MIN_THOROUGH_DOCS) return null;
+  const docs = assessment?.documents || [];
+  if (docs.length === 0) return null;
 
   const isContract = assessment.framework === 'CONTRACT_A30';
-  const recommended = isContract
-    ? RECOMMENDED_REPORT_DOCS.CONTRACT_A30
-    : RECOMMENDED_REPORT_DOCS.DORA;
   const reviewLabel = isContract ? 'Article 30 contract review' : 'DORA gap analysis';
+  const recommendedKeys = isContract
+    ? RECOMMENDED_CATEGORY_KEYS.CONTRACT_A30
+    : RECOMMENDED_CATEGORY_KEYS.DORA;
+  const tagged = new Set(docs.map((d) => d.category).filter((c) => c && c !== 'other'));
 
+  // Precise mode — at least one document is tagged → list the missing categories.
+  if (tagged.size > 0) {
+    const missingLabels = recommendedKeys
+      .filter((k) => !tagged.has(k))
+      .map((k) => CATEGORY_LABELS[k])
+      .filter(Boolean);
+    if (missingLabels.length === 0) return null; // full recommended coverage
+    return (
+      `This ${reviewLabel} is based on ${docs.length} document${docs.length === 1 ? '' : 's'} but is ` +
+      `missing recommended evidence: ${missingLabels.join(', ')}. Conclusions may understate gaps where ` +
+      `supporting evidence was not provided; treat the coverage findings below as a floor, not a ceiling.`
+    );
+  }
+
+  // Fallback — untagged uploads or legacy assessments: flag a thin evidence base.
+  if (docs.length >= MIN_THOROUGH_DOCS) return null;
+  const allLabels = recommendedKeys.map((k) => CATEGORY_LABELS[k]).filter(Boolean);
   return (
     `This ${reviewLabel} is based on a single uploaded document. A thorough review typically ` +
-    `draws on several document types — e.g. ${recommended.join(', ')}. Conclusions may understate ` +
+    `draws on several document types — e.g. ${allLabels.join(', ')}. Conclusions may understate ` +
     `gaps where supporting evidence was not provided; treat the coverage findings below as a floor, ` +
     `not a ceiling.`
   );

--- a/backend/tests/unittest/reportCaveat.test.js
+++ b/backend/tests/unittest/reportCaveat.test.js
@@ -2,37 +2,80 @@ import { describe, it, expect } from 'vitest';
 import { partialEvidenceCaveat } from '../../services/reportGenerator.js';
 
 /**
- * #395 phase 2c — the generated report must flag a "reduced confidence" caveat
- * when an assessment was run on a partial document set, so a shallow analysis
- * isn't read as complete.
+ * #395 — the generated report flags a "reduced confidence" caveat when an
+ * assessment was run on a partial document set. With per-file category tagging
+ * it lists the SPECIFIC missing categories; without tags it falls back to a
+ * count-based caveat.
  */
 describe('reportGenerator — partial-evidence caveat (#395)', () => {
-  it('returns a DORA caveat listing recommended docs for a single-document assessment', () => {
-    const caveat = partialEvidenceCaveat({ framework: 'DORA', documents: [{ fileName: 'a.pdf' }] });
-    expect(caveat).toContain('DORA gap analysis');
-    expect(caveat).toContain('single uploaded document');
-    expect(caveat).toContain('ISO 27001');
-    expect(caveat).toContain('SOC 2');
-  });
-
-  it('returns a contract-review caveat with Art.30 annexes', () => {
-    const caveat = partialEvidenceCaveat({
-      framework: 'CONTRACT_A30',
-      documents: [{ fileName: 'msa.pdf' }],
+  describe('precise mode (tagged documents)', () => {
+    it('lists the specific missing recommended categories (DORA)', () => {
+      const caveat = partialEvidenceCaveat({
+        framework: 'DORA',
+        documents: [{ category: 'iso27001' }, { category: 'soc2' }],
+      });
+      expect(caveat).toContain('missing recommended evidence');
+      // present categories are NOT listed
+      expect(caveat).not.toContain('ISO 27001');
+      expect(caveat).not.toContain('SOC 2');
+      // missing ones ARE listed
+      expect(caveat).toContain('a security policy');
+      expect(caveat).toContain('a business continuity / DR plan');
+      expect(caveat).toContain('a data processing agreement (GDPR)');
     });
-    expect(caveat).toContain('Article 30 contract review');
-    expect(caveat).toContain('SLA annex');
-    expect(caveat).toContain('subcontractor list');
+
+    it('lists missing Art.30 annexes when only the contract is tagged', () => {
+      const caveat = partialEvidenceCaveat({
+        framework: 'CONTRACT_A30',
+        documents: [{ category: 'contract' }],
+      });
+      expect(caveat).toContain('an SLA annex');
+      expect(caveat).toContain('a subcontractor list');
+      expect(caveat).not.toContain('the ICT services contract'); // present
+    });
+
+    it('returns null when every recommended category is covered', () => {
+      const caveat = partialEvidenceCaveat({
+        framework: 'DORA',
+        documents: [
+          { category: 'iso27001' },
+          { category: 'soc2' },
+          { category: 'securityPolicy' },
+          { category: 'bcp' },
+          { category: 'dpa' },
+        ],
+      });
+      expect(caveat).toBeNull();
+    });
+
+    it('treats "other"-tagged documents as not covering any recommended category', () => {
+      const caveat = partialEvidenceCaveat({
+        framework: 'DORA',
+        documents: [{ category: 'iso27001' }, { category: 'other' }],
+      });
+      // 'other' doesn't count → the remaining recommended categories are still missing
+      expect(caveat).toContain('missing recommended evidence');
+      expect(caveat).toContain('a security policy');
+    });
   });
 
-  it('returns null when the evidence base is adequate (>= 2 documents)', () => {
-    expect(partialEvidenceCaveat({ framework: 'DORA', documents: [{}, {}] })).toBeNull();
-    expect(partialEvidenceCaveat({ framework: 'DORA', documents: [{}, {}, {}] })).toBeNull();
+  describe('fallback mode (untagged / legacy uploads)', () => {
+    it('flags a single untagged document with the recommended types', () => {
+      const caveat = partialEvidenceCaveat({
+        framework: 'DORA',
+        documents: [{ fileName: 'a.pdf' }],
+      });
+      expect(caveat).toContain('single uploaded document');
+      expect(caveat).toContain('an ISO 27001 certificate');
+    });
+
+    it('returns null for >= 2 untagged documents', () => {
+      expect(partialEvidenceCaveat({ framework: 'DORA', documents: [{}, {}] })).toBeNull();
+    });
   });
 
-  it('returns null for an empty assessment (no documents) — a different problem', () => {
+  it('returns null for an empty assessment (no documents)', () => {
     expect(partialEvidenceCaveat({ framework: 'DORA', documents: [] })).toBeNull();
-    expect(partialEvidenceCaveat({ framework: 'DORA' })).toBeNull();
     expect(partialEvidenceCaveat({})).toBeNull();
   });
 });

--- a/backend/validators/schemas.js
+++ b/backend/validators/schemas.js
@@ -397,6 +397,8 @@ export const createAssessmentSchema = z
       .trim(),
     framework: z.enum(['DORA', 'CONTRACT_A30']).default('DORA'),
     workspaceId: mongoIdSchema,
+    // JSON-encoded array of category keys, one per uploaded file in order (#395).
+    categories: z.string().optional(),
   })
   .strict();
 

--- a/frontend/src/app/(dashboard)/assessments/new/page.tsx
+++ b/frontend/src/app/(dashboard)/assessments/new/page.tsx
@@ -7,7 +7,15 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, Loader2, RotateCcw, FileText, AlertTriangle, Circle } from 'lucide-react';
+import {
+  ArrowLeft,
+  Loader2,
+  RotateCcw,
+  FileText,
+  AlertTriangle,
+  Circle,
+  CheckCircle2,
+} from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
@@ -35,18 +43,16 @@ type FormValues = z.infer<typeof schema>;
 
 interface FileWithId extends File {
   id: string;
+  category?: string;
 }
 
 // Document categories recommended per framework (i18n label keys live under
-// assessments.form.recommendedDocs.<dora|a30>.<key>). Guidance only — the gate
-// is soft: the user can proceed with fewer.
+// assessments.form.recommendedDocs.<dora|a30>.<key>). Drives the coverage tracker
+// + the report's "missing evidence" caveat. Gate stays soft.
 const RECOMMENDED_DOC_KEYS: Record<'DORA' | 'CONTRACT_A30', string[]> = {
   DORA: ['iso27001', 'soc2', 'securityPolicy', 'bcp', 'dpa'],
   CONTRACT_A30: ['contract', 'sla', 'subprocessors', 'exit', 'security'],
 };
-
-// Below this many uploaded documents, the analysis is likely incomplete.
-const MIN_RECOMMENDED_DOCS = 2;
 
 function buildAssessmentName(
   vendor: string,
@@ -108,6 +114,8 @@ export default function NewAssessmentPage() {
       formData.append('framework', framework);
       if (activeWorkspace?.id) formData.append('workspaceId', activeWorkspace.id);
       files.forEach((file) => formData.append('files', file));
+      // Categories aligned to files by order (issue #395).
+      formData.append('categories', JSON.stringify(files.map((f) => f.category ?? 'other')));
       return assessmentsApi.create(formData);
     },
     onSuccess: (res) => {
@@ -127,6 +135,22 @@ export default function NewAssessmentPage() {
       </div>
     );
   }
+
+  // Category tagging + coverage (issue #395).
+  const fwKey = framework === 'CONTRACT_A30' ? 'a30' : 'dora';
+  const recommendedKeys = RECOMMENDED_DOC_KEYS[framework];
+  const categoryOptions = [
+    ...recommendedKeys.map((key) => ({
+      value: key,
+      label: t(`assessments.form.recommendedDocs.${fwKey}.${key}`),
+    })),
+    { value: 'other', label: t('assessments.form.recommendedDocs.other') },
+  ];
+  const taggedCategories = new Set(
+    files.map((f) => f.category).filter((c): c is string => !!c && c !== 'other')
+  );
+  const missingKeys = recommendedKeys.filter((k) => !taggedCategories.has(k));
+  const coveredCount = recommendedKeys.length - missingKeys.length;
 
   return (
     <div className="p-6 max-w-2xl mx-auto space-y-6">
@@ -248,7 +272,7 @@ export default function NewAssessmentPage() {
                 ? t('assessments.form.docsA30')
                 : t('assessments.form.docsDora')}
             </p>
-            <FileUploadZone files={files} onChange={setFiles} />
+            <FileUploadZone files={files} onChange={setFiles} categories={categoryOptions} />
             {files.length === 0 && createMutation.isError && (
               <p className="text-xs text-destructive">
                 {t('assessments.form.uploadAtLeastOne')}
@@ -256,7 +280,7 @@ export default function NewAssessmentPage() {
             )}
           </div>
 
-          {/* Recommended documents checklist (soft guidance — does not block) */}
+          {/* Recommended documents coverage (soft guidance — does not block) */}
           <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
             <div className="flex items-center justify-between">
               <p className="flex items-center gap-2 text-sm font-medium">
@@ -264,26 +288,43 @@ export default function NewAssessmentPage() {
                 {t('assessments.form.recommendedDocs.title')}
               </p>
               <span className="text-xs text-muted-foreground">
-                {t('assessments.form.recommendedDocs.uploaded', { count: files.length })}
+                {t('assessments.form.recommendedDocs.coverage', {
+                  covered: coveredCount,
+                  total: recommendedKeys.length,
+                })}
               </span>
             </div>
-            <ul className="grid gap-1.5 text-sm text-muted-foreground sm:grid-cols-2">
-              {RECOMMENDED_DOC_KEYS[framework].map((key) => (
-                <li key={key} className="flex items-center gap-2">
-                  <Circle className="h-2.5 w-2.5 shrink-0" />
-                  {t(
-                    `assessments.form.recommendedDocs.${framework === 'CONTRACT_A30' ? 'a30' : 'dora'}.${key}`,
-                  )}
-                </li>
-              ))}
+            <ul className="grid gap-1.5 text-sm sm:grid-cols-2">
+              {recommendedKeys.map((key) => {
+                const covered = taggedCategories.has(key);
+                return (
+                  <li
+                    key={key}
+                    className={`flex items-center gap-2 ${covered ? 'text-foreground' : 'text-muted-foreground'}`}
+                  >
+                    {covered ? (
+                      <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-success" />
+                    ) : (
+                      <Circle className="h-2.5 w-2.5 shrink-0" />
+                    )}
+                    {t(`assessments.form.recommendedDocs.${fwKey}.${key}`)}
+                  </li>
+                );
+              })}
             </ul>
             <p className="text-xs text-muted-foreground">
-              {t('assessments.form.recommendedDocs.note')}
+              {t('assessments.form.recommendedDocs.tagPrompt')}
             </p>
-            {files.length >= 1 && files.length < MIN_RECOMMENDED_DOCS && (
+            {files.length >= 1 && missingKeys.length > 0 && (
               <div className="flex gap-2 rounded-md border border-warning/30 bg-warning/10 p-3 text-xs text-warning">
                 <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-                <span>{t('assessments.form.recommendedDocs.warning')}</span>
+                <span>
+                  {t('assessments.form.recommendedDocs.missingWarning', {
+                    list: missingKeys
+                      .map((k) => t(`assessments.form.recommendedDocs.${fwKey}.${k}`))
+                      .join(', '),
+                  })}
+                </span>
               </div>
             )}
           </div>

--- a/frontend/src/components/assessment/FileUploadZone.tsx
+++ b/frontend/src/components/assessment/FileUploadZone.tsx
@@ -19,11 +19,19 @@ const MAX_FILES = 5;
 
 interface FileWithPreview extends File {
   id: string;
+  category?: string;
+}
+
+interface CategoryOption {
+  value: string;
+  label: string;
 }
 
 interface FileUploadZoneProps {
   files: FileWithPreview[];
   onChange: (files: FileWithPreview[]) => void;
+  // When provided, each file row shows a category dropdown (issue #395 tagging).
+  categories?: CategoryOption[];
 }
 
 function FileIcon({ name }: { name: string }) {
@@ -39,8 +47,12 @@ function formatSize(bytes: number) {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export function FileUploadZone({ files, onChange }: FileUploadZoneProps) {
+export function FileUploadZone({ files, onChange, categories }: FileUploadZoneProps) {
   const { t } = useTranslation();
+
+  const setCategory = (id: string, category: string) => {
+    onChange(files.map((f) => (f.id === id ? Object.assign(f, { category }) : f)));
+  };
   const onDrop = useCallback(
     (accepted: File[]) => {
       const withId = accepted.map((f) =>
@@ -115,6 +127,23 @@ export function FileUploadZone({ files, onChange }: FileUploadZoneProps) {
                 <p className="truncate font-medium">{file.name}</p>
                 <p className="text-xs text-muted-foreground">{formatSize(file.size)}</p>
               </div>
+              {categories && categories.length > 0 && (
+                <select
+                  value={file.category ?? ''}
+                  onChange={(e) => setCategory(file.id, e.target.value)}
+                  aria-label={t('assessments.form.recommendedDocs.categoryPlaceholder')}
+                  className="shrink-0 max-w-[45%] rounded-md border bg-background px-2 py-1 text-xs"
+                >
+                  <option value="">
+                    {t('assessments.form.recommendedDocs.categoryPlaceholder')}
+                  </option>
+                  {categories.map((c) => (
+                    <option key={c.value} value={c.value}>
+                      {c.label}
+                    </option>
+                  ))}
+                </select>
+              )}
               <Button
                 type="button"
                 variant="ghost"

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -493,6 +493,11 @@
         "note": "Recommended for a thorough analysis. You can proceed with fewer — the analysis confidence will be lower.",
         "uploaded": "{{count}} uploaded",
         "warning": "You're starting with very few documents. A thorough analysis usually needs several — the result may be incomplete. Consider adding the recommended documents above.",
+        "tagPrompt": "Tag each document so coverage can be tracked.",
+        "categoryPlaceholder": "Document type…",
+        "other": "Other / not listed",
+        "coverage": "{{covered}} of {{total}} recommended types tagged",
+        "missingWarning": "Not yet provided: {{list}}. You can still start — the report will flag reduced confidence.",
         "dora": {
           "iso27001": "ISO 27001 certificate",
           "soc2": "SOC 2 / SOC 3 report",

--- a/frontend/src/shared/i18n/locales/fr.json
+++ b/frontend/src/shared/i18n/locales/fr.json
@@ -493,6 +493,11 @@
         "note": "Recommandés pour une analyse complète. Vous pouvez continuer avec moins — la confiance de l'analyse sera réduite.",
         "uploaded": "{{count}} téléversé(s)",
         "warning": "Vous démarrez avec très peu de documents. Une analyse complète en nécessite généralement plusieurs — le résultat peut être incomplet. Pensez à ajouter les documents recommandés ci-dessus.",
+        "tagPrompt": "Taguez chaque document pour suivre la couverture.",
+        "categoryPlaceholder": "Type de document…",
+        "other": "Autre / non listé",
+        "coverage": "{{covered}} sur {{total}} types recommandés tagués",
+        "missingWarning": "Pas encore fournis : {{list}}. Vous pouvez quand même démarrer — le rapport signalera une confiance réduite.",
         "dora": {
           "iso27001": "Certificat ISO 27001",
           "soc2": "Rapport SOC 2 / SOC 3",


### PR DESCRIPTION
Closes #395 (phase 2 a/b — complète le tagging + la complétude + le caveat précis).

## Ce qui change
La phase 1 affichait une checklist statique + un avertissement par compte ; la phase 2c ajoutait un caveat « basé sur 1 document ». Cette PR rend le signal **précis de bout en bout**.

### Frontend
- **Dropdown de catégorie par fichier** dans la zone d'upload (`FileUploadZone`) — types recommandés du framework + « Autre / non listé ».
- **Suivi de couverture en direct** : « X sur 5 types recommandés tagués », chaque type coché (✓ vert) ou manquant (○), + avertissement listant les types **pas encore fournis**.
- Les **catégories** sont envoyées avec l'évaluation (JSON, alignées aux fichiers par ordre).

### Backend
- `documents[].category` stocké (`Assessment` model) ; parsing des catégories à la création (best-effort).
- **Le caveat du rapport passe de count-based à category-based** : il liste désormais les **catégories recommandées manquantes précises** (« missing recommended evidence: a security policy, a BCP/DR plan, … »). **Fallback** count-based conservé pour les uploads non taggués / assessments legacy.

## Validation
- ✅ Backend **1438 tests** (caveat : mode précis — liste les manquants, ignore « other », null si couverture complète ; mode fallback ; 0 doc).
- ✅ Frontend **521 tests** + parité i18n en/fr + **`next build` OK** (typecheck complet).
- ✅ Rétro-compatible : assessments existants (sans catégorie) → fallback count-based ; `categories` optionnel dans le schéma.

## Note
Tagging **manuel** (pas d'auto-détection par nom de fichier) — une amélioration possible plus tard si utile.
