### PR TITLE
release: promote dev → main — vendor country dropdown

### DIFF
--- a/frontend/src/features/workspaces/components/create-workspace-wizard.tsx
+++ b/frontend/src/features/workspaces/components/create-workspace-wizard.tsx
@@ -22,6 +22,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Input } from '@/shared/ui/input';
 import { Label } from '@/shared/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
+import { COUNTRIES } from '@/shared/constants/countries';
 import { workspacesApi } from '@/features/workspaces/api/workspaces';
 import { MODAL_IDS, useUIStore } from '@/state/ui-store';
 import type { VendorFunction, VendorServiceType, VendorTier } from '@/types';
@@ -377,13 +378,18 @@ export function CreateWorkspaceWizard() {
 
             <div className="space-y-1.5">
               <Label htmlFor="ws-country">{t('workspaces.wizard.country')}</Label>
-              <Input
-                id="ws-country"
-                placeholder={t('workspaces.wizard.countryPlaceholder')}
-                value={country}
-                autoFocus
-                onChange={(event) => setCountry(event.target.value)}
-              />
+              <Select value={country} onValueChange={setCountry}>
+                <SelectTrigger id="ws-country">
+                  <SelectValue placeholder={t('workspaces.wizard.countryPlaceholder')} />
+                </SelectTrigger>
+                <SelectContent>
+                  {COUNTRIES.map((c) => (
+                    <SelectItem key={c} value={c}>
+                      {c}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">

--- a/frontend/src/features/workspaces/settings/workspace-settings-form.tsx
+++ b/frontend/src/features/workspaces/settings/workspace-settings-form.tsx
@@ -34,6 +34,7 @@ import { Input } from '@/shared/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
 import { Skeleton } from '@/shared/ui/skeleton';
 import { Textarea } from '@/shared/ui/textarea';
+import { COUNTRIES } from '@/shared/constants/countries';
 import { destructiveActionClasses } from '@/shared/styles/status-colors';
 import type { VendorQuestionnaire } from '@/features/questionnaires/api/questionnaires';
 import type { WorkspaceWithMembership } from '@/types';
@@ -194,9 +195,22 @@ export function WorkspaceSettingsForm({
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel>{t('workspaces.settingsForm.country')}</FormLabel>
-                      <FormControl>
-                        <Input placeholder={t('workspaces.settingsForm.countryPlaceholder')} {...field} />
-                      </FormControl>
+                      <Select onValueChange={field.onChange} value={field.value || ''}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue
+                              placeholder={t('workspaces.settingsForm.countryPlaceholder')}
+                            />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {COUNTRIES.map((c) => (
+                            <SelectItem key={c} value={c}>
+                              {c}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                       <FormMessage />
                     </FormItem>
                   )}

--- a/frontend/src/shared/constants/countries.ts
+++ b/frontend/src/shared/constants/countries.ts
@@ -1,0 +1,86 @@
+// ISO 3166 country names, used for the vendor-country selector (issue: country
+// field UX). The stored VALUE is the country name (string) — backward-compatible
+// with the previous free-text input and with existing workspace records.
+// DORA-relevant countries (EU/EEA + major ICT-provider hubs) are listed first for
+// quick access; the full list follows alphabetically. Radix Select typeahead lets
+// users jump by typing the first letters.
+
+const PRIORITY_COUNTRIES = [
+  // EU / EEA
+  'Austria',
+  'Belgium',
+  'Bulgaria',
+  'Croatia',
+  'Cyprus',
+  'Czech Republic',
+  'Denmark',
+  'Estonia',
+  'Finland',
+  'France',
+  'Germany',
+  'Greece',
+  'Hungary',
+  'Iceland',
+  'Ireland',
+  'Italy',
+  'Latvia',
+  'Liechtenstein',
+  'Lithuania',
+  'Luxembourg',
+  'Malta',
+  'Netherlands',
+  'Norway',
+  'Poland',
+  'Portugal',
+  'Romania',
+  'Slovakia',
+  'Slovenia',
+  'Spain',
+  'Sweden',
+  // Common non-EU ICT hubs
+  'United Kingdom',
+  'Switzerland',
+  'United States',
+  'Canada',
+  'India',
+  'Israel',
+  'Australia',
+  'Japan',
+  'Singapore',
+];
+
+const OTHER_COUNTRIES = [
+  'Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda',
+  'Argentina', 'Armenia', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh',
+  'Barbados', 'Belarus', 'Belize', 'Benin', 'Bhutan', 'Bolivia',
+  'Bosnia and Herzegovina', 'Botswana', 'Brazil', 'Brunei', 'Burkina Faso',
+  'Burundi', 'Cambodia', 'Cameroon', 'Cape Verde', 'Central African Republic',
+  'Chad', 'Chile', 'China', 'Colombia', 'Comoros', 'Congo', 'Costa Rica',
+  "Côte d'Ivoire", 'Cuba', 'Democratic Republic of the Congo', 'Djibouti',
+  'Dominica', 'Dominican Republic', 'Ecuador', 'Egypt', 'El Salvador',
+  'Equatorial Guinea', 'Eritrea', 'Eswatini', 'Ethiopia', 'Fiji', 'Gabon',
+  'Gambia', 'Georgia', 'Ghana', 'Grenada', 'Guatemala', 'Guinea', 'Guinea-Bissau',
+  'Guyana', 'Haiti', 'Honduras', 'Hong Kong', 'Indonesia', 'Iran', 'Iraq',
+  'Jamaica', 'Jordan', 'Kazakhstan', 'Kenya', 'Kiribati', 'Kosovo', 'Kuwait',
+  'Kyrgyzstan', 'Laos', 'Lebanon', 'Lesotho', 'Liberia', 'Libya', 'Madagascar',
+  'Malawi', 'Malaysia', 'Maldives', 'Mali', 'Marshall Islands', 'Mauritania',
+  'Mauritius', 'Mexico', 'Micronesia', 'Moldova', 'Monaco', 'Mongolia',
+  'Montenegro', 'Morocco', 'Mozambique', 'Myanmar', 'Namibia', 'Nauru', 'Nepal',
+  'New Zealand', 'Nicaragua', 'Niger', 'Nigeria', 'North Korea',
+  'North Macedonia', 'Oman', 'Pakistan', 'Palau', 'Palestine', 'Panama',
+  'Papua New Guinea', 'Paraguay', 'Peru', 'Philippines', 'Qatar', 'Russia',
+  'Rwanda', 'Saint Kitts and Nevis', 'Saint Lucia',
+  'Saint Vincent and the Grenadines', 'Samoa', 'San Marino',
+  'São Tomé and Príncipe', 'Saudi Arabia', 'Senegal', 'Serbia', 'Seychelles',
+  'Sierra Leone', 'Solomon Islands', 'Somalia', 'South Africa', 'South Korea',
+  'South Sudan', 'Sri Lanka', 'Sudan', 'Suriname', 'Syria', 'Taiwan',
+  'Tajikistan', 'Tanzania', 'Thailand', 'Timor-Leste', 'Togo', 'Tonga',
+  'Trinidad and Tobago', 'Tunisia', 'Turkey', 'Turkmenistan', 'Tuvalu', 'Uganda',
+  'Ukraine', 'United Arab Emirates', 'Uruguay', 'Uzbekistan', 'Vanuatu',
+  'Vatican City', 'Venezuela', 'Vietnam', 'Yemen', 'Zambia', 'Zimbabwe',
+];
+
+export const COUNTRIES: readonly string[] = [
+  ...PRIORITY_COUNTRIES,
+  ...OTHER_COUNTRIES.filter((c) => !PRIORITY_COUNTRIES.includes(c)),
+];


### PR DESCRIPTION
Promote `dev` → `main` (auto-deploy prod).

## Inclus
- **Champ pays = dropdown** (wizard + settings) : EU/EEA + hubs ICT en tête, liste ISO complète, recherche par frappe. Valeur = nom du pays → rétro-compatible.

## Statut
- Mergé dans `dev`, CI verte. Frontend 521 tests · `next build` ✓ · lint clean · aucun E2E impacté.