### PR TITLE
fix(ux): render select dropdown above dialogs (z-index)

### DIFF
--- a/frontend/src/shared/ui/select.tsx
+++ b/frontend/src/shared/ui/select.tsx
@@ -62,7 +62,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-[70] max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className


### PR DESCRIPTION
## Bug (signalé)
À la création d'un vendor, le menu déroulant du champ **pays** s'affichait **derrière la modale**.

## Cause
`SelectContent` était en **`z-50`**, mais le `Dialog` (overlay + content) est en **`z-[60]`** (`dialog.tsx:42,64`). Les deux sont portalisés sur `body` → le menu du Select passait **sous** la modale. **Global** : concernait *tous* les `<Select>` ouverts dans un Dialog (pays, tier, service-type, membres, team settings).

## Fix
`SelectContent` → **`z-[70]`** (au-dessus du Dialog). Une ligne, dans le primitive partagé → corrige tous les cas d'un coup.

## Validation
- ✅ `next build` · 521 tests · lint clean (non-régression).
- La correction est **certaine par construction** (z-70 > z-60). Confirmation visuelle immédiate une fois déployé.