### PR TITLE
fix(workspace): cascade-delete vendor data on workspace deletion (#417)

### DIFF
--- a/backend/config/vectorStore.js
+++ b/backend/config/vectorStore.js
@@ -441,3 +441,27 @@ export async function deleteAssessmentChunksFromWorkspace(assessmentId) {
     });
   }
 }
+
+/**
+ * Purge ALL chunks of a workspace from the shared collection — called when a
+ * vendor workspace is deleted so its indexed documents don't linger (#417,
+ * GDPR erasure / clean offboarding). Best-effort; never throws into the caller.
+ */
+export async function deleteWorkspaceChunks(workspaceId) {
+  if (!workspaceId) return;
+  try {
+    const client = getQdrantClient();
+    await client.delete(COLLECTION_NAME, {
+      wait: true,
+      filter: {
+        must: [{ key: 'metadata.workspaceId', match: { value: String(workspaceId) } }],
+      },
+    });
+  } catch (error) {
+    logger.warn('Failed to delete workspace chunks from collection', {
+      service: 'vector-store',
+      workspaceId,
+      error: error.message,
+    });
+  }
+}

--- a/backend/services/WorkspaceService.js
+++ b/backend/services/WorkspaceService.js
@@ -3,6 +3,12 @@ import { Workspace } from '../models/Workspace.js';
 import { WorkspaceMember } from '../models/WorkspaceMember.js';
 import { OrganizationMember } from '../models/OrganizationMember.js';
 import { User } from '../models/User.js';
+import { Assessment } from '../models/Assessment.js';
+import { Conversation } from '../models/Conversation.js';
+import { Message } from '../models/Message.js';
+import { VendorQuestionnaire } from '../models/VendorQuestionnaire.js';
+import { deleteAssessmentCollection } from './fileIngestionService.js';
+import * as storageModule from '../config/storage.js';
 import logger from '../config/logger.js';
 import { emailService } from './emailService.js';
 
@@ -34,6 +40,12 @@ class WorkspaceService {
     this.WorkspaceMember = deps.WorkspaceMember || WorkspaceMember;
     this.OrganizationMember = deps.OrganizationMember || OrganizationMember;
     this.User = deps.User || User;
+    this.Assessment = deps.Assessment || Assessment;
+    this.Conversation = deps.Conversation || Conversation;
+    this.Message = deps.Message || Message;
+    this.VendorQuestionnaire = deps.VendorQuestionnaire || VendorQuestionnaire;
+    this.deleteAssessmentCollection = deps.deleteAssessmentCollection || deleteAssessmentCollection;
+    this.storage = deps.storage || storageModule;
     this.logger = deps.logger || logger;
     this.emailService = deps.emailService || emailService;
   }
@@ -155,10 +167,93 @@ class WorkspaceService {
     });
     if (!membership) throw new AppError('Only workspace owners can delete a workspace', 403);
 
+    // Cascade-purge the vendor's data BEFORE removing the workspace (#417):
+    // indexed vectors, per-assessment collections, files, and Mongo records.
+    await this._purgeWorkspaceData(workspaceId);
+
     await this.WorkspaceMember.deleteMany({ workspaceId });
     await this.Workspace.findByIdAndDelete(workspaceId);
 
     this.logger.info('Workspace deleted', { service: 'workspace', workspaceId });
+  }
+
+  /**
+   * Erase all data tied to a workspace (#417 — GDPR erasure / clean offboarding).
+   * Best-effort: each step is isolated so a single store being unavailable never
+   * blocks the workspace deletion. Runs without tenant context (deleteMany is not
+   * tenant-hooked; explicit workspaceId filters are authoritative).
+   */
+  async _purgeWorkspaceData(workspaceId) {
+    const wid = String(workspaceId);
+
+    // Gather assessments first — we need their ids (per-assessment Qdrant
+    // collections) and file keys before deleting the Mongo records.
+    let assessments = [];
+    try {
+      assessments = await this.Assessment.find({ workspaceId })
+        .select('_id documents.storageKey')
+        .lean();
+    } catch (err) {
+      this.logger.warn('Purge: failed to list assessments', {
+        workspaceId: wid,
+        error: err.message,
+      });
+    }
+
+    // 1. Qdrant: purge all of the workspace's chunks from the shared collection.
+    try {
+      const { deleteWorkspaceChunks } = await import('../config/vectorStore.js');
+      await deleteWorkspaceChunks(wid);
+    } catch (err) {
+      this.logger.warn('Purge: failed to delete workspace vectors', {
+        workspaceId: wid,
+        error: err.message,
+      });
+    }
+
+    // 2. Qdrant per-assessment collections + 3. stored files.
+    for (const a of assessments) {
+      try {
+        await this.deleteAssessmentCollection(String(a._id));
+      } catch (err) {
+        this.logger.warn('Purge: failed to delete assessment collection', {
+          assessmentId: String(a._id),
+          error: err.message,
+        });
+      }
+      for (const doc of a.documents || []) {
+        if (!doc?.storageKey) continue;
+        try {
+          await this.storage.deleteFile(doc.storageKey);
+        } catch (err) {
+          this.logger.warn('Purge: failed to delete file', {
+            key: doc.storageKey,
+            error: err.message,
+          });
+        }
+      }
+    }
+
+    // 4. Mongo cascade: messages (by conversation), conversations, questionnaires,
+    // assessments.
+    try {
+      const convs = await this.Conversation.find({ workspaceId }).select('_id').lean();
+      const convIds = convs.map((c) => c._id);
+      if (convIds.length) {
+        await this.Message.deleteMany({ conversationId: { $in: convIds } });
+      }
+      await this.Conversation.deleteMany({ workspaceId });
+      await this.VendorQuestionnaire.deleteMany({ workspaceId });
+      await this.Assessment.deleteMany({ workspaceId });
+    } catch (err) {
+      this.logger.warn('Purge: Mongo cascade failed', { workspaceId: wid, error: err.message });
+    }
+
+    this.logger.info('Workspace data purged', {
+      service: 'workspace',
+      workspaceId: wid,
+      assessments: assessments.length,
+    });
   }
 
   async getMyWorkspaces(userId) {

--- a/backend/tests/unittest/vectorStoreDualWrite.test.js
+++ b/backend/tests/unittest/vectorStoreDualWrite.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildWorkspacePoints,
   deleteAssessmentChunksFromWorkspace,
+  deleteWorkspaceChunks,
 } from '../../config/vectorStore.js';
 
 /**
@@ -75,5 +76,10 @@ describe('vectorStore dual-write (#394)', () => {
   it('deleteAssessmentChunksFromWorkspace is best-effort (never throws)', async () => {
     // No Qdrant in unit tests → the internal client call fails and is swallowed.
     await expect(deleteAssessmentChunksFromWorkspace('a1')).resolves.toBeUndefined();
+  });
+
+  it('deleteWorkspaceChunks is best-effort (never throws) and no-ops without id (#417)', async () => {
+    await expect(deleteWorkspaceChunks('ws1')).resolves.toBeUndefined();
+    await expect(deleteWorkspaceChunks(undefined)).resolves.toBeUndefined();
   });
 });

--- a/backend/tests/unittest/workspaceService.unit.test.js
+++ b/backend/tests/unittest/workspaceService.unit.test.js
@@ -15,6 +15,10 @@ vi.mock('../../config/logger.js', () => ({
 vi.mock('../../services/emailService.js', () => ({
   emailService: { sendWorkspaceInvitation: vi.fn().mockResolvedValue(undefined) },
 }));
+// Lazy-imported inside _purgeWorkspaceData (#417) — mock so it doesn't hit Qdrant.
+vi.mock('../../config/vectorStore.js', () => ({
+  deleteWorkspaceChunks: vi.fn().mockResolvedValue(undefined),
+}));
 
 // ---------------------------------------------------------------------------
 // Shared fixtures
@@ -83,11 +87,37 @@ function makeDeps(overrides = {}) {
     updateOne: vi.fn().mockReturnValue({ catch: vi.fn() }),
   };
 
+  // Cascade-purge deps (#417). find() is chainable: .select().lean() → result.
+  const chain = (result) => ({
+    select: vi.fn(() => ({ lean: vi.fn().mockResolvedValue(result) })),
+  });
+  const Assessment = {
+    find: vi.fn(() => chain([])),
+    deleteMany: vi.fn().mockResolvedValue(undefined),
+  };
+  const Conversation = {
+    find: vi.fn(() => chain([])),
+    deleteMany: vi.fn().mockResolvedValue(undefined),
+  };
+  const Message = { deleteMany: vi.fn().mockResolvedValue(undefined) };
+  const VendorQuestionnaire = { deleteMany: vi.fn().mockResolvedValue(undefined) };
+  const deleteAssessmentCollection = vi.fn().mockResolvedValue(undefined);
+  const storage = {
+    deleteFile: vi.fn().mockResolvedValue(undefined),
+    isStorageConfigured: vi.fn(() => false),
+  };
+
   return {
     Workspace,
     WorkspaceMember,
     OrganizationMember,
     User,
+    Assessment,
+    Conversation,
+    Message,
+    VendorQuestionnaire,
+    deleteAssessmentCollection,
+    storage,
     logger,
     emailService,
     ...overrides,
@@ -257,6 +287,42 @@ describe('WorkspaceService.deleteWorkspace', () => {
     await svc.deleteWorkspace(WS_ID, USER_ID);
 
     expect(deps.WorkspaceMember.deleteMany).toHaveBeenCalledWith({ workspaceId: WS_ID });
+    expect(deps.Workspace.findByIdAndDelete).toHaveBeenCalledWith(WS_ID);
+  });
+
+  it('cascade-purges all vendor data before deleting the workspace (#417)', async () => {
+    deps.WorkspaceMember.findOne.mockResolvedValue(makeOwnerMembership());
+    deps.Assessment.find.mockReturnValue({
+      select: () => ({
+        lean: () => Promise.resolve([{ _id: 'a1', documents: [{ storageKey: 'k1' }] }]),
+      }),
+    });
+    deps.Conversation.find.mockReturnValue({
+      select: () => ({ lean: () => Promise.resolve([{ _id: 'c1' }]) }),
+    });
+
+    await svc.deleteWorkspace(WS_ID, USER_ID);
+
+    // per-assessment Qdrant collection + stored file
+    expect(deps.deleteAssessmentCollection).toHaveBeenCalledWith('a1');
+    expect(deps.storage.deleteFile).toHaveBeenCalledWith('k1');
+    // Mongo cascade
+    expect(deps.Message.deleteMany).toHaveBeenCalledWith({ conversationId: { $in: ['c1'] } });
+    expect(deps.Conversation.deleteMany).toHaveBeenCalledWith({ workspaceId: WS_ID });
+    expect(deps.VendorQuestionnaire.deleteMany).toHaveBeenCalledWith({ workspaceId: WS_ID });
+    expect(deps.Assessment.deleteMany).toHaveBeenCalledWith({ workspaceId: WS_ID });
+    // workspace removed last
+    expect(deps.Workspace.findByIdAndDelete).toHaveBeenCalledWith(WS_ID);
+  });
+
+  it('still deletes the workspace if a purge step fails (best-effort)', async () => {
+    deps.WorkspaceMember.findOne.mockResolvedValue(makeOwnerMembership());
+    deps.Assessment.find.mockReturnValue({
+      select: () => ({ lean: () => Promise.reject(new Error('db down')) }),
+    });
+
+    await svc.deleteWorkspace(WS_ID, USER_ID);
+
     expect(deps.Workspace.findByIdAndDelete).toHaveBeenCalledWith(WS_ID);
   });
 });


### PR DESCRIPTION
Closes #417.

## Bug
Supprimer un vendor workspace ne supprimait que **le workspace + les membres** → vecteurs indexés, collections par-assessment, fichiers, assessments, conversations et questionnaires laissés **orphelins** (gap d'effacement RGPD Art 17 / offboarding DORA pour un produit de conformité).

## Fix
`deleteWorkspace` **cascade-purge** maintenant, avant de supprimer le workspace :
- **Vecteurs workspace** (nouveau `deleteWorkspaceChunks` par `metadata.workspaceId`)
- **Collections Qdrant par-assessment** (`deleteAssessmentCollection` existant)
- **Fichiers** stockés (MinIO/Spaces, par `storageKey`)
- **Mongo** : assessments, conversations + messages, questionnaires
- **Best-effort + idempotent** : un store indisponible ne bloque pas la suppression (même garde-fou que la cascade assessment)
- **Lazy-import** de vectorStore (hors graphe eager — leçon #394)

## Validation
- ✅ Backend **1441 tests** (dont 3 nouveaux : cascade purge tous les stores · best-effort si un purge échoue · `deleteWorkspaceChunks`)
- ✅ Tests d'intégration (auth/conversation) verts → pas de régression d'ordre de chargement
- Le `deleteWorkspaceChunks` réutilise le **même pattern Qdrant** que `deleteAssessmentChunksFromWorkspace` (déjà validé sur vrai Qdrant en #394).

## Note
Sécurité préservée : ce n'était pas une fuite d'accès (isolation tenant intacte) mais un gap d'**effacement** — désormais comblé.