### PR TITLE
docs: remove false LLM claims (Azure OpenAI / gpt-4o-mini) from report + scorer

### DIFF
--- a/backend/services/questionnaireScorer.js
+++ b/backend/services/questionnaireScorer.js
@@ -1,8 +1,10 @@
 /**
  * Questionnaire Scorer Service
  *
- * Uses gpt-4o-mini (via createLLM) to score each vendor answer independently
- * in parallel, then generates an executive summary across all Q&A pairs.
+ * Scores each vendor answer independently in parallel via createLLM (the
+ * configured provider/model — see config/llmProvider.js; no purpose is set, so
+ * it uses the global default), then generates an executive summary across all
+ * Q&A pairs.
  */
 
 import { createLLM } from '../config/llmProvider.js';

--- a/backend/services/reportGenerator.js
+++ b/backend/services/reportGenerator.js
@@ -500,8 +500,8 @@ function buildMethodology(assessment) {
     heading2('Assessment Methodology'),
     para(
       assessment.framework === 'CONTRACT_A30'
-        ? 'The uploaded contract was parsed and semantically indexed. Relevant clauses were extracted using vector similarity search across 12 targeted Article 30 compliance queries. Gap assessment was performed using Azure OpenAI (gpt-4o-mini) to produce a structured, auditable clause-by-clause review.'
-        : 'Vendor documentation was parsed and semantically indexed. Relevant content was extracted using vector similarity search across multiple compliance-focused query prompts. DORA obligations were retrieved from a pre-loaded regulatory knowledge base containing verbatim article texts. Gap assessment was performed using Azure OpenAI (gpt-4o-mini) function calling to produce structured, auditable output.',
+        ? 'The uploaded contract was parsed and semantically indexed. Relevant clauses were extracted using vector similarity search across targeted Article 30 compliance queries. Gap assessment was performed by a large language model to produce a structured, auditable clause-by-clause review.'
+        : 'Vendor documentation was parsed and semantically indexed. Relevant content was extracted using vector similarity search across multiple compliance-focused query prompts. DORA obligations were retrieved from a pre-loaded regulatory knowledge base containing verbatim article texts. Gap assessment was performed by a large language model to produce structured, auditable output.',
       { color: COLOUR.text }
     ),
     heading2('Source Documents Analysed'),


### PR DESCRIPTION
Nettoyage de commentaires/docs **faux** sur le LLM, pour refléter la réalité (prod = Ollama `gemma3:12b` / Groq, configurable par usage — pas Azure OpenAI gpt-4o-mini).

## Corrigé
1. **Rapport DOCX client** (`reportGenerator.js:503-504`) — affirmait *« Gap assessment was performed using **Azure OpenAI (gpt-4o-mini)** »*. **Faux**, et c'est imprimé dans le **livrable remis au client/auditeur** → risque de crédibilité pour un doc de conformité. Rendu **agnostique** (« a large language model »). Retiré aussi le « 12 » hardcodé (nombre de requêtes/clauses configurable).
2. **questionnaireScorer.js** — l'en-tête disait *« Uses gpt-4o-mini »* alors que le code appelle `createLLM()` **sans model/purpose** → le défaut global configuré. Commentaire corrigé.

## Vérifié (pas touché)
- `crossEncoderRerank.js` mentionne Cohere/Azure/LLM → **exact** (réellement supportés via `RERANK_PROVIDER`). Laissé tel quel.
- CLAUDE.md (section LLM/embeddings) → déjà à jour.

## Validation
- ✅ Lint clean · reportGenerator se charge · 1441 tests (pre-push) verts · aucun test n'assertait l'ancien texte.

Connexe : note ajoutée dans **#385 (E1)** sur le routage modèle (`analysis` → modèle plus fort, à mesurer via éval).