### PR TITLE
release: promote dev → main — remove false LLM claims from report + scorer

### DIFF
--- a/backend/services/questionnaireScorer.js
+++ b/backend/services/questionnaireScorer.js
@@ -1,8 +1,10 @@
 /**
  * Questionnaire Scorer Service
  *
- * Uses gpt-4o-mini (via createLLM) to score each vendor answer independently
- * in parallel, then generates an executive summary across all Q&A pairs.
+ * Scores each vendor answer independently in parallel via createLLM (the
+ * configured provider/model — see config/llmProvider.js; no purpose is set, so
+ * it uses the global default), then generates an executive summary across all
+ * Q&A pairs.
  */
 
 import { createLLM } from '../config/llmProvider.js';

--- a/backend/services/reportGenerator.js
+++ b/backend/services/reportGenerator.js
@@ -500,8 +500,8 @@ function buildMethodology(assessment) {
     heading2('Assessment Methodology'),
     para(
       assessment.framework === 'CONTRACT_A30'
-        ? 'The uploaded contract was parsed and semantically indexed. Relevant clauses were extracted using vector similarity search across 12 targeted Article 30 compliance queries. Gap assessment was performed using Azure OpenAI (gpt-4o-mini) to produce a structured, auditable clause-by-clause review.'
-        : 'Vendor documentation was parsed and semantically indexed. Relevant content was extracted using vector similarity search across multiple compliance-focused query prompts. DORA obligations were retrieved from a pre-loaded regulatory knowledge base containing verbatim article texts. Gap assessment was performed using Azure OpenAI (gpt-4o-mini) function calling to produce structured, auditable output.',
+        ? 'The uploaded contract was parsed and semantically indexed. Relevant clauses were extracted using vector similarity search across targeted Article 30 compliance queries. Gap assessment was performed by a large language model to produce a structured, auditable clause-by-clause review.'
+        : 'Vendor documentation was parsed and semantically indexed. Relevant content was extracted using vector similarity search across multiple compliance-focused query prompts. DORA obligations were retrieved from a pre-loaded regulatory knowledge base containing verbatim article texts. Gap assessment was performed by a large language model to produce structured, auditable output.',
       { color: COLOUR.text }
     ),
     heading2('Source Documents Analysed'),


### PR DESCRIPTION
Promote `dev` → `main` (auto-deploy prod).

## Inclus
- **docs(#421)** : retrait du claim faux « Azure OpenAI (gpt-4o-mini) » dans le **rapport DOCX client** (rendu agnostique) + correction du commentaire `questionnaireScorer.js`. Reflète la réalité (Ollama gemma3:12b / Groq, configurable).

## Statut
Mergé dans `dev`, CI verte. 1441 tests. Aucune logique modifiée (texte/commentaires).