### PR TITLE
fix(rag): add sse keepalive heartbeat to prevent nginx 60s timeout

### DIFF
--- a/backend/controllers/ragController.js
+++ b/backend/controllers/ragController.js
@@ -84,6 +84,13 @@ export const askQuestionStream = catchAsync(async (req, res) => {
     closed = true;
   });
 
+  // Keep the SSE connection alive through nginx's proxy_read_timeout (default 60s).
+  // The embedding phase can take minutes on CPU-only ollama — without this, nginx
+  // kills the idle connection before the first event is ever flushed.
+  const heartbeat = setInterval(() => {
+    if (!closed && !res.writableEnded) res.write(': keepalive\n\n');
+  }, 20000);
+
   try {
     await executeRAG({
       question,
@@ -104,6 +111,7 @@ export const askQuestionStream = catchAsync(async (req, res) => {
       send('error', { message: 'Stream failed', code: 'STREAM_ERROR' });
     }
   } finally {
+    clearInterval(heartbeat);
     if (!res.writableEnded) res.end();
   }
 });


### PR DESCRIPTION
## Root cause

The RAG `/stream` endpoint uses SSE. The embedding phase (multi-query expansion via CPU-only ollama) takes 3–5 minutes on the current prod infra. Nginx's default `proxy_read_timeout` is **60 seconds** — it kills any SSE connection where no body bytes are written within that window.

Result: the SSE stream was dropped silently 60s after opening. The frontend stayed on "Retrieving context…" indefinitely, then reset to 0 messages. The backend actually completed the pipeline successfully (confirmed in logs: `totalTime: 323330ms`, messages saved to DB) but no client was connected anymore to receive the events.

## Fix

Send an SSE comment (`: keepalive\n\n`) every 20 seconds from the moment the stream opens. SSE comments are valid per spec, ignored by browsers, and count as body bytes — so nginx resets its idle timer on each one, keeping the connection alive for the full pipeline duration.

```js
const heartbeat = setInterval(() => {
  if (!closed && !res.writableEnded) res.write(': keepalive\n\n');
}, 20000);
// cleared in finally block
```

## Test plan

- [x] All 1449 backend unit + integration tests pass
- [x] All 521 frontend tests pass
- [ ] E2E: send a question via the Ask AI UI → response appears within 5–6 minutes (not stuck at "Retrieving context…")

## Notes

The underlying performance issue (CPU-only ollama at ~5 min/query) is a separate infra concern. This fix makes the feature functional while that is addressed.